### PR TITLE
Disable UART1 and SPI1 by default. Having both UART1 and UART3 enable…

### DIFF
--- a/multi/imxrt-multi/config.h
+++ b/multi/imxrt-multi/config.h
@@ -29,7 +29,7 @@
 /* UART */
 
 #ifndef UART1
-#define UART1 1
+#define UART1 0
 #endif
 
 #ifndef UART2
@@ -67,7 +67,7 @@
 /* SPI */
 
 #ifndef SPI1
-#define SPI1 1
+#define SPI1 0
 #endif
 
 #ifndef SPI2


### PR DESCRIPTION
…d causes kernel not to print init info. Having both SPI1 and SPI3 enabled causes imxrt-flashsrv to not initialize correctly and return with ENXIO error.