### PR TITLE
uart16550: fixed uart_get()

### DIFF
--- a/tty/uart16550/uart16550.c
+++ b/tty/uart16550/uart16550.c
@@ -165,7 +165,7 @@ uint8_t uart_get(oid_t *oid)
 {
 	unsigned int i;
 
-	for (i = 0; i < sizeof(uarts) / sizeof(uart_t); i++) {
+	for (i = 0; i < sizeof(uarts) / sizeof(uart_t *); i++) {
 		if ((uarts[i]->oid.id == oid->id) && (uarts[i]->oid.port == oid->port))
 			return i;
 	}
@@ -315,7 +315,7 @@ int main(void)
 	for (n = 0; n < 4; n++) {
 		if (_uart_init(n, B115200, &uarts[n]) < 0)
 			continue;
-		
+
 		if (portRegister(port, "/dev/ttyS0", &uarts[n]->oid) < 0) {
 			fprintf(stderr, DRIVER ": Can't register port %d\n", port);
 			return -1;


### PR DESCRIPTION
Now:
- the function returns 0 instead of the size of the array if neither condition is true
- wrong calculation of the number of array elements

I suggest to use an expression 
`
sizeof(array) / sizeof(array[0])
`
to calculate the size of the array