### PR TITLE
stm32lx-multi: Add DMA support, make SPI use DMA

### DIFF
--- a/multi/stm32l1-multi/Makefile
+++ b/multi/stm32l1-multi/Makefile
@@ -4,7 +4,7 @@
 # Copyright 2018 Phoenix Systems
 #
 
-MULTIDRV_OBJS = stm32-multi.o uart.o rcc.o gpio.o adc.o i2c.o lcd.o rtc.o flash.o spi.o exti.o
+MULTIDRV_OBJS = stm32-multi.o uart.o rcc.o gpio.o adc.o i2c.o lcd.o rtc.o flash.o spi.o exti.o dma.o
 
 $(PREFIX_PROG)stm32-multi: $(addprefix $(PREFIX_O)multi/stm32l1-multi/, $(MULTIDRV_OBJS))
 	$(LINK)

--- a/multi/stm32l1-multi/README.md
+++ b/multi/stm32l1-multi/README.md
@@ -243,22 +243,25 @@ Structure of below format:
 
 	typedef struct {
 		int spi;
-		char cmd;
 		unsigned int addr;
 		unsigned int flags;
+		char cmd;
 	} spirw_t;
 
 Is used for read/write transactions with SPI device.
 
 - spi - from pool of enum { spi1 = 0, spi2, spi3 };
 - cmd - command to SPI device, first byte always written during transaction
-- addr - address, second and third byte written during transaction 
-- flags - bit mask of enum { spi_address = 0x1, spi_dummy = 0x2 };
+- addr - address to be written after cmd during transaction
+- flags - bit mask of enum { spi_cmd, spi_dummy, spi_addrlsb } and/or (addrsz << SPI_ADDRSHIFT)
+
 
 where
 
-- spi_address - if set address will be transmitted
+- addrsz - this many bytes of addr will be transmitted
+- spi_cmd - if set, cmd will be transmitted
 - spi_dummy - if set one dummy transaction will preceed read/write
+- spi_addrlsb - if set, addr will be sent least significant byte first
 
 ### spi_def
 
@@ -266,9 +269,9 @@ Structure of below format:
 
 	typedef struct {
 		int spi;
+		int enable;
 		char mode;
 		char bdiv;
-		int enable;
 	} spidef_t;
 
 Is used to configure paramters of transmission of SPI device.

--- a/multi/stm32l1-multi/dma.c
+++ b/multi/stm32l1-multi/dma.c
@@ -1,0 +1,245 @@
+/*
+ * Phoenix-RTOS
+ *
+ * STM32L1 DMA driver
+ *
+ * Copyright 2020 Phoenix Systems
+ * Author: Daniel Sawka
+ *
+ * %LICENSE%
+ */
+
+
+#include <errno.h>
+#include <sys/threads.h>
+#include <sys/interrupt.h>
+
+#include "common.h"
+#include "dma.h"
+#include "rcc.h"
+
+
+#define DMA1_CH1 0
+#define DMA1_CH2 (SPI1)
+#define DMA1_CH3 (SPI1)
+#define DMA1_CH4 (SPI2)
+#define DMA1_CH5 (SPI2)
+#define DMA1_CH6 0
+#define DMA1_CH7 0
+
+#define DMA2_CH1 (SPI3)
+#define DMA2_CH2 (SPI3)
+#define DMA2_CH3 0
+#define DMA2_CH4 0
+#define DMA2_CH5 0
+
+#define DMA1 (DMA1_CH1 || DMA1_CH2 || DMA1_CH3 || DMA1_CH4 || DMA1_CH5 || DMA1_CH6 || DMA1_CH7)
+#define DMA2 (DMA2_CH1 || DMA2_CH2 || DMA2_CH3 || DMA2_CH4 || DMA2_CH5)
+
+#define DMA1_POS 0
+#define DMA2_POS (DMA1_POS + DMA1)
+
+
+struct {
+	volatile unsigned int *base;
+	int irq_base;
+	handle_t irqLock;
+	handle_t cond;
+} dma_common[DMA1 + DMA2];
+
+
+enum { dma1 = 0, dma2 };
+
+
+static const int dma2pctl[] = { pctl_dma1, pctl_dma2 };
+
+
+static const unsigned char dmaConfig[] = { DMA1, DMA2 };
+
+
+static const unsigned char dmaChannelConfig[2][7] = {
+	{ DMA1_CH1, DMA1_CH2, DMA1_CH3, DMA1_CH4, DMA1_CH5, DMA1_CH6, DMA1_CH7 },
+	{ DMA2_CH1, DMA2_CH2, DMA2_CH3, DMA2_CH4, DMA2_CH5, 0, 0 }
+};
+
+
+static const int dmaPos[] = { DMA1_POS, DMA2_POS };
+
+
+static const struct dma_map {
+	char dma;
+	char channel[2];
+} spiChanMap[3] = {
+	{ dma1, { 1, 2 } },
+	{ dma1, { 3, 4 } },
+	{ dma2, { 0, 1 } },
+};
+
+
+enum { isr = 0, ifcr };
+
+
+enum { ccr = 0, cndtr, cpar, cmar };
+
+
+static int dma_irqHandler(unsigned int n, void *arg)
+{
+	int channel = n - dma_common[(int)arg].irq_base - 16;
+	volatile unsigned int *base = dma_common[(int)arg].base;
+
+	if (*(base + isr) & (0xF << channel * 4)) {
+		*(base + ifcr) = (0xF << channel * 4);
+		return 1;
+	} else {
+		return -1;
+	}
+}
+
+
+static void _configure_channel(int dma, int channel, int dir, int priority, void *paddr, int msize, int psize, int minc, int pinc)
+{
+	int pos = dmaPos[dma];
+	volatile unsigned int *channel_base = dma_common[pos].base + 2 + 5 * channel;
+
+	*(channel_base + ccr) = ((priority & 0x3) << 12) | ((msize & 0x3) << 10) | ((psize & 0x3) << 8) |
+		((minc & 0x1) << 7) | ((pinc & 0x1) << 6) | ((dir & 0x1) << 4);
+	*(channel_base + cpar) = (unsigned int) paddr;
+}
+
+
+int dma_configure_spi(int num, int dir, int priority, void *paddr, int msize, int psize, int minc, int pinc)
+{
+	int dma = spiChanMap[num].dma;
+	int channel = spiChanMap[num].channel[dir];
+
+	_configure_channel(dma, channel, dir, priority, paddr, msize, psize, minc, pinc);
+
+	return 0;
+}
+
+
+static void _prepare_transfer(volatile unsigned int *channel_base, void *maddr, size_t len, int tcie)
+{
+	*(channel_base + cmar) = (unsigned int) maddr;
+	*(channel_base + cndtr) = len;
+
+	if (tcie)
+		/* Enable Transfer Complete interrupt, enable channel */
+		*(channel_base + ccr) |= (1 << 1) | 0x1;
+	else
+		/* Enable channel */
+		*(channel_base + ccr) |= 0x1;
+}
+
+
+static void _unprepare_transfer(volatile unsigned int *channel_base)
+{
+	/* Disable Transfer Complete interrupt, disable channel */
+	*(channel_base + ccr) &= ~((1 << 1) | 0x1);
+}
+
+
+static int _has_channel_finished(void *maddr, volatile unsigned int *channel_base)
+{
+	return (maddr != NULL && *(channel_base + cndtr) > 0);
+}
+
+
+static int _transfer(int dma, int rx_channel, int tx_channel, void *rx_maddr, void *tx_maddr, size_t len)
+{
+	/* Empirically chosen value to avoid mutex+cond overhead for short transactions */
+	int use_interrupts = len > 24;
+	int pos = dmaPos[dma];
+
+	volatile unsigned int *rx_channel_base = dma_common[pos].base + 2 + 5 * rx_channel;
+	volatile unsigned int *tx_channel_base = dma_common[pos].base + 2 + 5 * tx_channel;
+
+	if (rx_maddr != NULL)
+		_prepare_transfer(rx_channel_base, rx_maddr, len, use_interrupts);
+
+	if (tx_maddr != NULL)
+		/* When doing rw transfer, avoid unnecessary interrupt handling and condSignal()
+		by waiting only for RX transfer completion, ignoring TX */
+		_prepare_transfer(tx_channel_base, tx_maddr, len, use_interrupts && rx_maddr == NULL);
+
+	if (use_interrupts) {
+		mutexLock(dma_common[pos].irqLock);
+		while (_has_channel_finished(rx_maddr, rx_channel_base) || _has_channel_finished(tx_maddr, tx_channel_base))
+			condWait(dma_common[pos].cond, dma_common[pos].irqLock, 1);
+		mutexUnlock(dma_common[pos].irqLock);
+	}
+	else {
+		while (_has_channel_finished(rx_maddr, rx_channel_base) || _has_channel_finished(tx_maddr, tx_channel_base))
+			;
+	}
+
+	if (rx_maddr != NULL)
+		_unprepare_transfer(rx_channel_base);
+
+	if (tx_maddr != NULL)
+		_unprepare_transfer(tx_channel_base);
+
+	return len;
+}
+
+
+int dma_transfer_spi(int num, void *rx_maddr, void *tx_maddr, size_t len)
+{
+	int pos;
+	int res;
+	volatile unsigned int *tx_channel_base;
+	int dma = spiChanMap[num].dma;
+	int rx_channel = spiChanMap[num].channel[dma_per2mem];
+	int tx_channel = spiChanMap[num].channel[dma_mem2per];
+	unsigned char txbuf = 0;
+
+	if (tx_maddr == NULL) {
+		/* In case no tx buffer is provided, use a 1-byte dummy
+		and configure DMA not to increment the memory address. */
+		pos = dmaPos[dma];
+		tx_channel_base = dma_common[pos].base + 2 + 5 * tx_channel;
+		*(tx_channel_base + ccr) &= ~(1 << 7);
+		res = _transfer(dma, rx_channel, tx_channel, rx_maddr, &txbuf, len);
+		*(tx_channel_base + ccr) |= (1 << 7);
+	}
+	else {
+		res = _transfer(dma, rx_channel, tx_channel, rx_maddr, tx_maddr, len);
+	}
+
+	return res;
+}
+
+
+int dma_init(void)
+{
+	int i, j, dma;
+
+	static const struct {
+		unsigned int base;
+		int irq_base;
+	} dmainfo[2] = { { 0x40026000, 11 }, { 0x40026400, 50 } };
+
+	for (i = 0, dma = 0; dma < 2; ++dma) {
+		if (!dmaConfig[dma])
+			continue;
+
+		dma_common[i].base = (void *)dmainfo[dma].base;
+		dma_common[i].irq_base = dmainfo[dma].irq_base;
+
+		mutexCreate(&dma_common[i].irqLock);
+		condCreate(&dma_common[i].cond);
+
+		for (j = 0; j < 7; j++) {
+			if (!dmaChannelConfig[dma][j])
+				continue;
+
+			interrupt(16 + dmainfo[dma].irq_base + j, dma_irqHandler, (void *)i, dma_common[i].cond, NULL);
+		}
+
+		rcc_devClk(dma2pctl[dma], 1);
+
+		++i;
+	}
+
+	return 0;
+}

--- a/multi/stm32l1-multi/dma.h
+++ b/multi/stm32l1-multi/dma.h
@@ -1,0 +1,30 @@
+/*
+ * Phoenix-RTOS
+ *
+ * STM32L1 DMA driver
+ *
+ * Copyright 2020 Phoenix Systems
+ * Author: Daniel Sawka
+ *
+ * %LICENSE%
+ */
+
+#ifndef _DMA_H_
+#define _DMA_H_
+
+#include <stddef.h>
+
+
+enum { dma_per2mem = 0, dma_mem2per };
+
+
+int dma_configure_spi(int num, int dir, int priority, void *paddr, int msize, int psize, int minc, int pinc);
+
+
+int dma_transfer_spi(int num, void *rx_maddr, void *tx_maddr, size_t len);
+
+
+int dma_init(void);
+
+
+#endif

--- a/multi/stm32l1-multi/stm32-multi.c
+++ b/multi/stm32l1-multi/stm32-multi.c
@@ -24,15 +24,16 @@
 #include "common.h"
 
 #include "adc.h"
+#include "dma.h"
+#include "exti.h"
 #include "flash.h"
 #include "gpio.h"
 #include "i2c.h"
 #include "lcd.h"
 #include "rcc.h"
 #include "rtc.h"
-#include "uart.h"
 #include "spi.h"
-#include "exti.h"
+#include "uart.h"
 
 #define THREADS_NO 4
 #define THREADS_PRIORITY 2
@@ -208,6 +209,7 @@ int main(void)
 	oid_t oid;
 
 	rcc_init();
+	dma_init();
 	uart_init();
 	gpio_init();
 	rtc_init();

--- a/multi/stm32l1-multi/stm32-multi.h
+++ b/multi/stm32l1-multi/stm32-multi.h
@@ -162,7 +162,11 @@ typedef struct {
 enum { spi1 = 0, spi2, spi3 };
 
 
-enum { spi_cmd = 0x1, spi_address = 0x2, spi_dummy = 0x4 };
+#define SPI_ADDRSHIFT 3
+#define SPI_ADDRMASK 0x3
+
+
+enum { spi_cmd = 0x1, spi_dummy = 0x2, /* 3-bits for SPI_ADDR* ,*/ spi_addrlsb = 0x20 };
 
 
 typedef struct {

--- a/multi/stm32l4-multi/Makefile
+++ b/multi/stm32l4-multi/Makefile
@@ -4,7 +4,7 @@
 # Copyright 2018, 2020 Phoenix Systems
 #
 
-MULTIDRV_OBJS = stm32-multi.o uart.o rcc.o gpio.o spi.o adc.o rtc.o flash.o exti.o #i2c.o
+MULTIDRV_OBJS = stm32-multi.o uart.o rcc.o gpio.o spi.o adc.o rtc.o flash.o exti.o dma.o #i2c.o
 
 $(PREFIX_PROG)stm32-multi: $(addprefix $(PREFIX_O)multi/stm32l4-multi/, $(MULTIDRV_OBJS))
 	$(LINK)

--- a/multi/stm32l4-multi/README.md
+++ b/multi/stm32l4-multi/README.md
@@ -243,22 +243,25 @@ Structure of below format:
 
 	typedef struct {
 		int spi;
-		char cmd;
 		unsigned int addr;
 		unsigned int flags;
+		char cmd;
 	} spirw_t;
 
 Is used for read/write transactions with SPI device.
 
 - spi - from pool of enum { spi1 = 0, spi2, spi3 };
 - cmd - command to SPI device, first byte always written during transaction
-- addr - address, second and third byte written during transaction 
-- flags - bit mask of enum { spi_address = 0x1, spi_dummy = 0x2 };
+- addr - address to be written after cmd during transaction
+- flags - bit mask of enum { spi_cmd, spi_dummy, spi_addrlsb } and/or (addrsz << SPI_ADDRSHIFT)
+
 
 where
 
-- spi_address - if set address will be transmitted
+- addrsz - this many bytes of addr will be transmitted
+- spi_cmd - if set, cmd will be transmitted
 - spi_dummy - if set one dummy transaction will preceed read/write
+- spi_addrlsb - if set, addr will be sent least significant byte first
 
 ### spi_def
 
@@ -266,9 +269,9 @@ Structure of below format:
 
 	typedef struct {
 		int spi;
+		int enable;
 		char mode;
 		char bdiv;
-		int enable;
 	} spidef_t;
 
 Is used to configure paramters of transmission of SPI device.

--- a/multi/stm32l4-multi/dma.c
+++ b/multi/stm32l4-multi/dma.c
@@ -1,0 +1,261 @@
+/*
+ * Phoenix-RTOS
+ *
+ * STM32L4 DMA driver
+ *
+ * Copyright 2020 Phoenix Systems
+ * Author: Daniel Sawka
+ *
+ * %LICENSE%
+ */
+
+
+#include <errno.h>
+#include <sys/threads.h>
+#include <sys/interrupt.h>
+
+#include "common.h"
+#include "dma.h"
+#include "rcc.h"
+
+
+#define DMA1_CH1 0
+#define DMA1_CH2 (SPI1)
+#define DMA1_CH3 (SPI1)
+#define DMA1_CH4 (SPI2)
+#define DMA1_CH5 (SPI2)
+#define DMA1_CH6 0
+#define DMA1_CH7 0
+
+#define DMA2_CH1 (SPI3)
+#define DMA2_CH2 (SPI3)
+#define DMA2_CH3 0
+#define DMA2_CH4 0
+#define DMA2_CH5 0
+#define DMA2_CH6 0
+#define DMA2_CH7 0
+
+#define DMA1 (DMA1_CH1 || DMA1_CH2 || DMA1_CH3 || DMA1_CH4 || DMA1_CH5 || DMA1_CH6 || DMA1_CH7)
+#define DMA2 (DMA2_CH1 || DMA2_CH2 || DMA2_CH3 || DMA2_CH4 || DMA2_CH5 || DMA2_CH6 || DMA2_CH7)
+
+#define DMA1_POS 0
+#define DMA2_POS (DMA1_POS + DMA1)
+
+
+struct {
+	volatile unsigned int *base;
+	int irq_base;
+	handle_t irqLock;
+	handle_t cond;
+} dma_common[DMA1 + DMA2];
+
+
+enum { dma1 = 0, dma2 };
+
+
+static const int dma2pctl[] = { pctl_dma1, pctl_dma2 };
+
+
+static const unsigned char dmaConfig[] = { DMA1, DMA2 };
+
+
+static const unsigned char dmaChannelConfig[2][7] = {
+	{ DMA1_CH1, DMA1_CH2, DMA1_CH3, DMA1_CH4, DMA1_CH5, DMA1_CH6, DMA1_CH7 },
+	{ DMA2_CH1, DMA2_CH2, DMA2_CH3, DMA2_CH4, DMA2_CH5, DMA2_CH6, DMA2_CH7 }
+};
+
+
+static const int dmaPos[] = { DMA1_POS, DMA2_POS };
+
+
+static const struct dma_map {
+	char dma;
+	char channel[2];
+	char reqmap;
+} spiChanMap[3] = {
+	{ dma1, { 1, 2 }, 0x1 },
+	{ dma1, { 3, 4 }, 0x1 },
+	{ dma2, { 0, 1 }, 0x3 },
+};
+
+
+enum { isr = 0, ifcr, cselr = 42 };
+
+
+enum { ccr = 0, cndtr, cpar, cmar };
+
+
+static int dma_irqHandler(unsigned int n, void *arg)
+{
+	int channel = n - dma_common[(int)arg].irq_base - 16;
+	volatile unsigned int *base = dma_common[(int)arg].base;
+
+	if (*(base + isr) & (0xF << channel * 4)) {
+		*(base + ifcr) = (0xF << channel * 4);
+		return 1;
+	} else {
+		return -1;
+	}
+}
+
+
+static void _configure_channel(int dma, int channel, int dir, int priority, void *paddr, int msize, int psize, int minc, int pinc, unsigned char reqmap)
+{
+	int pos = dmaPos[dma];
+	unsigned int tmp;
+	volatile unsigned int *channel_base = dma_common[pos].base + 2 + 5 * channel;
+
+	*(channel_base + ccr) = ((priority & 0x3) << 12) | ((msize & 0x3) << 10) | ((psize & 0x3) << 8) |
+		((minc & 0x1) << 7) | ((pinc & 0x1) << 6) | ((dir & 0x1) << 4);
+	*(channel_base + cpar) = (unsigned int) paddr;
+	tmp = *(dma_common[pos].base + cselr) & ~(0xF << channel * 4);
+	*(dma_common[pos].base + cselr) = tmp | ((unsigned int) reqmap << channel * 4);
+}
+
+
+int dma_configure_spi(int num, int dir, int priority, void *paddr, int msize, int psize, int minc, int pinc)
+{
+	int dma = spiChanMap[num].dma;
+	int channel = spiChanMap[num].channel[dir];
+	char reqmap = spiChanMap[num].reqmap;
+
+	_configure_channel(dma, channel, dir, priority, paddr, msize, psize, minc, pinc, reqmap);
+
+	return 0;
+}
+
+
+static void _prepare_transfer(volatile unsigned int *channel_base, void *maddr, size_t len, int tcie)
+{
+	*(channel_base + cmar) = (unsigned int) maddr;
+	*(channel_base + cndtr) = len;
+
+	if (tcie)
+		/* Enable Transfer Complete interrupt, enable channel */
+		*(channel_base + ccr) |= (1 << 1) | 0x1;
+	else
+		/* Enable channel */
+		*(channel_base + ccr) |= 0x1;
+}
+
+
+static void _unprepare_transfer(volatile unsigned int *channel_base)
+{
+	/* Disable Transfer Complete interrupt, disable channel */
+	*(channel_base + ccr) &= ~((1 << 1) | 0x1);
+}
+
+
+static int _has_channel_finished(void *maddr, volatile unsigned int *channel_base)
+{
+	return (maddr != NULL && *(channel_base + cndtr) > 0);
+}
+
+
+static int _transfer(int dma, int rx_channel, int tx_channel, void *rx_maddr, void *tx_maddr, size_t len)
+{
+	/* Empirically chosen value to avoid mutex+cond overhead for short transactions */
+	int use_interrupts = len > 24;
+	int pos = dmaPos[dma];
+
+	volatile unsigned int *rx_channel_base = dma_common[pos].base + 2 + 5 * rx_channel;
+	volatile unsigned int *tx_channel_base = dma_common[pos].base + 2 + 5 * tx_channel;
+
+	if (rx_maddr != NULL)
+		_prepare_transfer(rx_channel_base, rx_maddr, len, use_interrupts);
+
+	if (tx_maddr != NULL)
+		/* When doing rw transfer, avoid unnecessary interrupt handling and condSignal()
+		by waiting only for RX transfer completion, ignoring TX */
+		_prepare_transfer(tx_channel_base, tx_maddr, len, use_interrupts && rx_maddr == NULL);
+
+	if (use_interrupts) {
+		mutexLock(dma_common[pos].irqLock);
+		while (_has_channel_finished(rx_maddr, rx_channel_base) || _has_channel_finished(tx_maddr, tx_channel_base))
+			condWait(dma_common[pos].cond, dma_common[pos].irqLock, 1);
+		mutexUnlock(dma_common[pos].irqLock);
+	}
+	else {
+		while (_has_channel_finished(rx_maddr, rx_channel_base) || _has_channel_finished(tx_maddr, tx_channel_base))
+			;
+	}
+
+	if (rx_maddr != NULL)
+		_unprepare_transfer(rx_channel_base);
+
+	if (tx_maddr != NULL)
+		_unprepare_transfer(tx_channel_base);
+
+	return len;
+}
+
+
+int dma_transfer_spi(int num, void *rx_maddr, void *tx_maddr, size_t len)
+{
+	int pos;
+	int res;
+	volatile unsigned int *tx_channel_base;
+	int dma = spiChanMap[num].dma;
+	int rx_channel = spiChanMap[num].channel[dma_per2mem];
+	int tx_channel = spiChanMap[num].channel[dma_mem2per];
+	unsigned char txbuf = 0;
+
+	if (tx_maddr == NULL) {
+		/* In case no tx buffer is provided, use a 1-byte dummy
+		and configure DMA not to increment the memory address. */
+		pos = dmaPos[dma];
+		tx_channel_base = dma_common[pos].base + 2 + 5 * tx_channel;
+		*(tx_channel_base + ccr) &= ~(1 << 7);
+		res = _transfer(dma, rx_channel, tx_channel, rx_maddr, &txbuf, len);
+		*(tx_channel_base + ccr) |= (1 << 7);
+	}
+	else {
+		res = _transfer(dma, rx_channel, tx_channel, rx_maddr, tx_maddr, len);
+	}
+
+	return res;
+}
+
+
+int dma_init(void)
+{
+	int i, j, dma;
+	int irqnum;
+
+	static const struct {
+		unsigned int base;
+		int irq_base;
+	} dmainfo[2] = { { 0x40020000, 11 }, { 0x40020400, 56 } };
+
+	for (i = 0, dma = 0; dma < 2; ++dma) {
+		if (!dmaConfig[dma])
+			continue;
+
+		dma_common[i].base = (void *)dmainfo[dma].base;
+		dma_common[i].irq_base = dmainfo[dma].irq_base;
+
+		mutexCreate(&dma_common[i].irqLock);
+		condCreate(&dma_common[i].cond);
+
+		for (j = 0; j < 7; j++) {
+			if (!dmaChannelConfig[dma][j])
+				continue;
+
+			/* Channels of DMA2 are noncontiguous */
+			if (dma == dma2 && j >= 5) {
+				irqnum = 16 + 68 - 5 + j;
+			}
+			else {
+				irqnum = 16 + dmainfo[dma].irq_base + j;
+			}
+
+			interrupt(irqnum, dma_irqHandler, (void *)i, dma_common[i].cond, NULL);
+		}
+
+		rcc_devClk(dma2pctl[dma], 1);
+
+		++i;
+	}
+
+	return 0;
+}

--- a/multi/stm32l4-multi/dma.h
+++ b/multi/stm32l4-multi/dma.h
@@ -1,0 +1,30 @@
+/*
+ * Phoenix-RTOS
+ *
+ * STM32L4 DMA driver
+ *
+ * Copyright 2020 Phoenix Systems
+ * Author: Daniel Sawka
+ *
+ * %LICENSE%
+ */
+
+#ifndef _DMA_H_
+#define _DMA_H_
+
+#include <stddef.h>
+
+
+enum { dma_per2mem = 0, dma_mem2per };
+
+
+int dma_configure_spi(int num, int dir, int priority, void *paddr, int msize, int psize, int minc, int pinc);
+
+
+int dma_transfer_spi(int num, void *rx_maddr, void *tx_maddr, size_t len);
+
+
+int dma_init(void);
+
+
+#endif

--- a/multi/stm32l4-multi/stm32-multi.c
+++ b/multi/stm32l4-multi/stm32-multi.c
@@ -24,14 +24,15 @@
 #include "common.h"
 
 #include "adc.h"
+#include "dma.h"
+#include "exti.h"
 #include "flash.h"
 #include "gpio.h"
 #include "i2c.h"
 #include "rcc.h"
 #include "rtc.h"
-#include "uart.h"
 #include "spi.h"
-#include "exti.h"
+#include "uart.h"
 
 #define THREADS_NO 4
 #define THREADS_PRIORITY 1
@@ -204,6 +205,7 @@ int main(void)
 	oid_t oid;
 
 	rcc_init();
+	dma_init();
 	uart_init();
 	gpio_init();
 	spi_init();

--- a/multi/stm32l4-multi/stm32-multi.h
+++ b/multi/stm32l4-multi/stm32-multi.h
@@ -113,7 +113,11 @@ typedef struct {
 enum { spi1 = 0, spi2, spi3 };
 
 
-enum { spi_cmd = 0x1, spi_address = 0x2, spi_dummy = 0x4 };
+#define SPI_ADDRSHIFT 3
+#define SPI_ADDRMASK 0x3
+
+
+enum { spi_cmd = 0x1, spi_dummy = 0x2, /* 3-bits for SPI_ADDR* ,*/ spi_addrlsb = 0x20 };
 
 
 typedef struct {


### PR DESCRIPTION
This change introduces DMA to stm32lx-multi driver (both STM32L1 and STM32L4 are supported). Currently only SPI peripheral is handled, avoiding the overhead of sharing DMA channels between multiple peripherals. DMA transfers are used implicitly by the driver when a certain transfer length threshold is exceeded - processes using multi driver have no notion of DMA at all.

Hardware NSS output is now enabled, eliminating the need of managing NSS GPIO in software. The pin still needs to be explicitly mapped as alternate function, so the change is backward compatible. NSS is always asserted when SPI peripheral is enabled, so the enable/disable part has to be done directly before and after the transaction.

The following enhancements, which may be added to this request, are to be discussed:

- Replace active-wait for the interrupt-set flag `ready` in `_spi_readwrite()` with waiting for `SPIx_SR.RXNE==1` directly. Active-wait is already employed, and this enhancement will remove interrupt overhead completely.
- For time-critical operations, allow multiple transactions to be scheduled in one multi driver message (by e.g. an array of buffer pointers in `multi_i_t`'s union). This would significantly reduce the time required to complete small consecutive transactions without having to bypass the driver's message IPC.
- The `spi_address16msb` flag was added to allow using 2-byte addresses before transactions and to not break compatibility with existing software using `spi_address` alone. If this compatibility is not needed, `spirw_t.flags` could have a `addrlen` subfield instead of `spi_address*` to make the addressing feature more flexible.