### PR TITLE
Unify use of the rid parameter of msgRecv, msgRespond functions

### DIFF
--- a/adc/ad7779/ad7779-driver.c
+++ b/adc/ad7779/ad7779-driver.c
@@ -606,7 +606,7 @@ static int dev_ctl(msg_t *msg)
 static void msg_loop(void)
 {
 	msg_t msg;
-	unsigned rid;
+	unsigned long rid;
 
 	while (1) {
 		if (msgRecv(common.port, &msg, &rid) < 0)

--- a/display/oled-128O064B0/oled-dev.c
+++ b/display/oled-128O064B0/oled-dev.c
@@ -102,7 +102,7 @@ static int dev_write(oled_write_t *cmd)
 void msg_loop(void)
 {
 	msg_t msg;
-	unsigned int rid;
+	unsigned long int rid;
 
 	while (1) {
 		if (msgRecv(dev_common.port, &msg, &rid) < 0)

--- a/dma/imx6ull-sdma/imx6ull-sdma.c
+++ b/dma/imx6ull-sdma/imx6ull-sdma.c
@@ -735,7 +735,7 @@ static int dev_ctl(msg_t *msg)
 static void worker_thread(void *arg)
 {
 	msg_t msg;
-	unsigned rid;
+	unsigned long rid;
 
 	(void)arg;
 

--- a/gpio/imx6ull-gpio/imx6ull-gpio.c
+++ b/gpio/imx6ull-gpio/imx6ull-gpio.c
@@ -177,7 +177,7 @@ int gpiosetdir(int d, uint32_t dir, uint32_t mask)
 void thread(void *arg)
 {
 	msg_t msg;
-	unsigned int rid;
+	unsigned long int rid;
 	int d;
 	uint32_t val, mask;
 

--- a/multi/imxrt-multi/imxrt-multi.c
+++ b/multi/imxrt-multi/imxrt-multi.c
@@ -276,7 +276,7 @@ static int createDevFiles(void)
 static void multi_thread(void *arg)
 {
 	msg_t msg;
-	unsigned int rid;
+	unsigned long int rid;
 
 	while (1) {
 		while (msgRecv(multi_port, &msg, &rid) < 0)
@@ -319,7 +319,7 @@ static void multi_thread(void *arg)
 static void uart_thread(void *arg)
 {
 	msg_t msg;
-	unsigned int rid;
+	unsigned long int rid;
 
 	while (1) {
 		while (msgRecv(common.uart_port, &msg, &rid) < 0)

--- a/multi/stm32l1-multi/stm32-multi.c
+++ b/multi/stm32l1-multi/stm32-multi.c
@@ -160,7 +160,7 @@ static void handleMsg(msg_t *msg)
 static void thread(void *arg)
 {
 	msg_t msg;
-	unsigned int rid;
+	unsigned long int rid;
 
 	while (1) {
 		while (msgRecv(common.port, &msg, &rid) < 0)

--- a/multi/stm32l4-multi/stm32-multi.c
+++ b/multi/stm32l4-multi/stm32-multi.c
@@ -152,7 +152,7 @@ static void handleMsg(msg_t *msg)
 static void thread(void *arg)
 {
 	msg_t msg;
-	unsigned int rid;
+	unsigned long int rid;
 
 	while (1) {
 		while (msgRecv(common.port, &msg, &rid) < 0)

--- a/storage/imx6ull-flash/flashsrv.c
+++ b/storage/imx6ull-flash/flashsrv.c
@@ -26,7 +26,7 @@ typedef struct {
 
 	int (*handler)(void *, msg_t *);
 	msg_t msg;
-	unsigned rid;
+	unsigned long rid;
 	unsigned port;
 	void *data;
 } flashsrv_request_t;
@@ -596,7 +596,7 @@ static int flashsrv_fileAttr(int type, id_t id)
 static void flashsrv_devThread(void *arg)
 {
 	msg_t msg;
-	unsigned rid, port = (unsigned)arg;
+	unsigned long rid, port = (unsigned)arg;
 
 	for (;;) {
 		if (msgRecv(port, &msg, &rid) < 0)

--- a/storage/imxrt-flash/flashsrv.c
+++ b/storage/imxrt-flash/flashsrv.c
@@ -345,7 +345,7 @@ static void flashsrv_rawCtl(flash_memory_t *memory, msg_t *msg)
 static void flashsrv_meterfsThread(void *arg)
 {
 	msg_t msg;
-	unsigned rid;
+	unsigned long rid;
 
 	flashsrv_partition_t *part = (flashsrv_partition_t *)arg;
 
@@ -437,7 +437,7 @@ static int flashsrv_verifyRawIO(const flash_memory_t *memory, msg_t *msg, size_t
 static void flashsrv_rawThread(void *arg)
 {
 	msg_t msg;
-	unsigned rid;
+	unsigned long rid;
 	uint32_t beginAddr;
 
 	flash_memory_t *memory = (flash_memory_t *)arg;
@@ -485,7 +485,7 @@ static void flashsrv_rawThread(void *arg)
 static void flashsrv_devThread(void *arg)
 {
 	msg_t msg;
-	unsigned rid;
+	unsigned long rid;
 
 	flash_memory_t *memory = (flash_memory_t *)arg;
 

--- a/tty/imx6ull-uart/imx6ull-uart.c
+++ b/tty/imx6ull-uart/imx6ull-uart.c
@@ -93,7 +93,7 @@ void uart_thr(void *arg)
 {
 	uint32_t port = (uint32_t)arg;
 	msg_t msg;
-	unsigned int rid;
+	unsigned long int rid;
 
 	for (;;) {
 


### PR DESCRIPTION
Accordingly to https://github.com/phoenix-rtos/libphoenix/issues/70#issuecomment-697253799