### PR TITLE
flashsrv: Fix typo introduced with commit #1bf9f02

### DIFF
--- a/storage/imx6ull-flash/flashsrv.c
+++ b/storage/imx6ull-flash/flashsrv.c
@@ -596,7 +596,8 @@ static int flashsrv_fileAttr(int type, id_t id)
 static void flashsrv_devThread(void *arg)
 {
 	msg_t msg;
-	unsigned long rid, port = (unsigned)arg;
+	unsigned long rid;
+	unsigned port = (unsigned)arg;
 
 	for (;;) {
 		if (msgRecv(port, &msg, &rid) < 0)


### PR DESCRIPTION
This commit fixes typo described in code review https://github.com/phoenix-rtos/phoenix-rtos-devices/commit/1bf9f02721989066452f254c0e0ea29ed3a6d99c#r42685130 and refer to https://github.com/phoenix-rtos/libphoenix/issues/70
