### PR TITLE
stm32lX-multi: Fix setting time on RTC

### DIFF
--- a/multi/stm32l1-multi/rtc.c
+++ b/multi/stm32l1-multi/rtc.c
@@ -132,7 +132,7 @@ int rtc_setTime(rtctimestamp_t *timestamp)
 	time = 0;
 	time |= (rtc_binToBcd(timestamp->hours) & 0x3f) << 16;
 	time |= (rtc_binToBcd(timestamp->minutes) & 0x7f) << 8;
-	time |= (rtc_binToBcd(timestamp->seconds) & 0x3f);
+	time |= (rtc_binToBcd(timestamp->seconds) & 0x7f);
 
 	date = 0;
 	date |= (rtc_binToBcd(timestamp->day) & 0x3f);

--- a/multi/stm32l4-multi/rtc.c
+++ b/multi/stm32l4-multi/rtc.c
@@ -139,7 +139,7 @@ int rtc_setTime(rtctimestamp_t *timestamp)
 	time = 0;
 	time |= (rtc_binToBcd(timestamp->hours) & 0x3f) << 16;
 	time |= (rtc_binToBcd(timestamp->minutes) & 0x7f) << 8;
-	time |= (rtc_binToBcd(timestamp->seconds) & 0x3f);
+	time |= (rtc_binToBcd(timestamp->seconds) & 0x7f);
 
 	date = 0;
 	date |= (rtc_binToBcd(timestamp->day) & 0x3f);


### PR DESCRIPTION
Fix issue of cutting off high part of seconds in set.
This causing an issue where time was not properly set
Eg. ts 1601907525 
GMT: Monday, 5 October 2020 14:18:45
was set as
GMT: Monday, 5 October 2020 14:18:05

Tested on stm32l4, checked in documentation that it should be apply also to l1