### PR TITLE
stm32lx-multi: Support setting up precise RTC alarms

### DIFF
--- a/multi/stm32l1-multi/exti.c
+++ b/multi/stm32l1-multi/exti.c
@@ -36,35 +36,35 @@ enum { memrmp = 0, pmc, exticr1, exticr2, exticr3, exticr4 };
 
 static int exti0_handler(unsigned int n, void *arg)
 {
-	*(exti_common.base + pr) |= 0x1;
+	*(exti_common.base + pr) = 0x1;
 	return -1;
 }
 
 
 static int exti1_handler(unsigned int n, void *arg)
 {
-	*(exti_common.base + pr) |= 0x2;
+	*(exti_common.base + pr) = 0x2;
 	return -1;
 }
 
 
 static int exti2_handler(unsigned int n, void *arg)
 {
-	*(exti_common.base + pr) |= 0x4;
+	*(exti_common.base + pr) = 0x4;
 	return -1;
 }
 
 
 static int exti3_handler(unsigned int n, void *arg)
 {
-	*(exti_common.base + pr) |= 0x8;
+	*(exti_common.base + pr) = 0x8;
 	return -1;
 }
 
 
 static int exti4_handler(unsigned int n, void *arg)
 {
-	*(exti_common.base + pr) |= 0x10;
+	*(exti_common.base + pr) = 0x10;
 	return -1;
 }
 

--- a/multi/stm32l1-multi/stm32-multi.c
+++ b/multi/stm32l1-multi/stm32-multi.c
@@ -209,6 +209,7 @@ int main(void)
 	oid_t oid;
 
 	rcc_init();
+	exti_init();
 	dma_init();
 	uart_init();
 	gpio_init();
@@ -218,7 +219,6 @@ int main(void)
 	i2c_init();
 	flash_init();
 	spi_init();
-	exti_init();
 
 	portCreate(&common.port);
 	portRegister(common.port, "/multi", &oid);

--- a/multi/stm32l4-multi/exti.c
+++ b/multi/stm32l4-multi/exti.c
@@ -36,49 +36,49 @@ enum { memrmp = 0, cfgr1, exticr1, exticr2, exticr3, exticr4 };
 
 static int exti0_handler(unsigned int n, void *arg)
 {
-	*(exti_common.base + pr1) |= 0x1;
+	*(exti_common.base + pr1) = 0x1;
 	return -1;
 }
 
 
 static int exti1_handler(unsigned int n, void *arg)
 {
-	*(exti_common.base + pr1) |= 0x2;
+	*(exti_common.base + pr1) = 0x2;
 	return -1;
 }
 
 
 static int exti2_handler(unsigned int n, void *arg)
 {
-	*(exti_common.base + pr1) |= 0x4;
+	*(exti_common.base + pr1) = 0x4;
 	return -1;
 }
 
 
 static int exti3_handler(unsigned int n, void *arg)
 {
-	*(exti_common.base + pr1) |= 0x8;
+	*(exti_common.base + pr1) = 0x8;
 	return -1;
 }
 
 
 static int exti4_handler(unsigned int n, void *arg)
 {
-	*(exti_common.base + pr1) |= 0x10;
+	*(exti_common.base + pr1) = 0x10;
 	return -1;
 }
 
 
 static int exti9_5_handler(unsigned int n, void *arg)
 {
-	*(exti_common.base + pr1) |= 0x3e0;
+	*(exti_common.base + pr1) = 0x3e0;
 	return -1;
 }
 
 
 static int exti15_10_handler(unsigned int n, void *arg)
 {
-	*(exti_common.base + pr1) |= 0xfc00;
+	*(exti_common.base + pr1) = 0xfc00;
 	return -1;
 }
 
@@ -160,6 +160,19 @@ int syscfg_mapexti(unsigned int line, int port)
 	mutexUnlock(exti_common.lock);
 
 	return EOK;
+}
+
+
+int exti_clear_irq(unsigned int line)
+{
+	if (line <= 22 && line != 17)
+		*(exti_common.base + pr1) = 1 << line;
+	else if (line >= 35 && line <= 38)
+		*(exti_common.base + pr2) = 1 << (line - 32);
+	else
+		return -1;
+
+	return 0;
 }
 
 

--- a/multi/stm32l4-multi/exti.h
+++ b/multi/stm32l4-multi/exti.h
@@ -21,6 +21,9 @@ int exti_configure(unsigned int line, unsigned char mode, unsigned char edge);
 int syscfg_mapexti(unsigned int line, int port);
 
 
+int exti_clear_irq(unsigned int line);
+
+
 int exti_init(void);
 
 

--- a/multi/stm32l4-multi/rtc.c
+++ b/multi/stm32l4-multi/rtc.c
@@ -13,11 +13,13 @@
 
 
 #include <errno.h>
+#include <stdint.h>
 #include <sys/threads.h>
 #include <sys/platform.h>
 
 #include "common.h"
 #include "rcc.h"
+#include "exti.h"
 #include "rtc.h"
 
 
@@ -30,9 +32,17 @@ enum { tr = 0, dr, cr, isr, prer, wutr, alrmar = wutr + 2, alrmbr, wpr, ssr, shi
 
 struct {
 	volatile unsigned int *base;
+	unsigned int prediv_s;
 
 	handle_t lock;
 } rtc_common;
+
+
+static int rtc_alarm_handler(unsigned int n, void *arg)
+{
+	exti_clear_irq(18);
+	return -1;
+}
 
 
 static char rtc_bcdToBin(char bcd)
@@ -56,10 +66,10 @@ static char rtc_binToBcd(char bin)
 
 static void _rtc_lock(void)
 {
+	dataBarier();
+
 	*(rtc_common.base + wpr) = 0xff;
 	pwr_lock();
-
-	dataBarier();
 }
 
 
@@ -70,6 +80,27 @@ static void _rtc_unlock(void)
 	*(rtc_common.base + wpr) = 0x53;
 
 	dataBarier();
+}
+
+
+static unsigned int timestampToTime(const rtctimestamp_t *timestamp)
+{
+	unsigned int time = 0;
+	time |= (rtc_binToBcd(timestamp->hours) & 0x3f) << 16;
+	time |= (rtc_binToBcd(timestamp->minutes) & 0x7f) << 8;
+	time |= (rtc_binToBcd(timestamp->seconds) & 0x7f);
+	return time;
+}
+
+
+static unsigned int timestampToDate(const rtctimestamp_t *timestamp)
+{
+	unsigned int date = 0;
+	date |= (rtc_binToBcd(timestamp->day) & 0x3f);
+	date |= (rtc_binToBcd(timestamp->month) & 0x1f) << 8;
+	date |= (rtc_binToBcd(timestamp->year) & 0xff) << 16;
+	date |= (timestamp->wday & 0x7) << 13;
+	return date;
 }
 
 
@@ -110,15 +141,27 @@ void rtc_setCalib(int value)
 
 int rtc_getTime(rtctimestamp_t *timestamp)
 {
-	unsigned int time, date;
+	unsigned int ssec, time, date, ssec2, time2, date2;
 
 	mutexLock(rtc_common.lock);
 
+	ssec = *(rtc_common.base + ssr);
 	time = *(rtc_common.base + tr);
 	date = *(rtc_common.base + dr);
 
+	ssec2 = *(rtc_common.base + ssr);
+	time2 = *(rtc_common.base + tr);
+	date2 = *(rtc_common.base + dr);
+
 	mutexUnlock(rtc_common.lock);
 
+	if (ssec != ssec2 || time != time2) {
+		ssec = ssec2;
+		time = time2;
+		date = date2;
+	}
+
+	timestamp->usecs = ((uint64_t) (rtc_common.prediv_s - (ssec & 0xffff)) * 1000 * 1000) / (rtc_common.prediv_s + 1);
 	timestamp->hours = rtc_bcdToBin((time >> 16) & 0x3f);
 	timestamp->minutes = rtc_bcdToBin((time >> 8) & 0x7f);
 	timestamp->seconds = rtc_bcdToBin(time & 0x7f);
@@ -136,19 +179,10 @@ int rtc_setTime(rtctimestamp_t *timestamp)
 {
 	unsigned int time, date;
 
-	time = 0;
-	time |= (rtc_binToBcd(timestamp->hours) & 0x3f) << 16;
-	time |= (rtc_binToBcd(timestamp->minutes) & 0x7f) << 8;
-	time |= (rtc_binToBcd(timestamp->seconds) & 0x7f);
-
-	date = 0;
-	date |= (rtc_binToBcd(timestamp->day) & 0x3f);
-	date |= (rtc_binToBcd(timestamp->month) & 0x1f) << 8;
-	date |= (rtc_binToBcd(timestamp->year) & 0xff) << 16;
-	date |= (timestamp->wday & 0x7) << 13;
+	time = timestampToTime(timestamp);
+	date = timestampToDate(timestamp);
 
 	mutexLock(rtc_common.lock);
-
 	_rtc_unlock();
 
 	if (!(*(rtc_common.base + isr) & (1 << 6))) {
@@ -163,7 +197,35 @@ int rtc_setTime(rtctimestamp_t *timestamp)
 	*(rtc_common.base + isr) &= ~(1 << 7);
 
 	_rtc_lock();
+	mutexUnlock(rtc_common.lock);
 
+	return EOK;
+}
+
+
+int rtc_setAlarm(rtctimestamp_t *timestamp)
+{
+	unsigned int ssec, time;
+
+	time = timestampToTime(timestamp);
+	ssec = rtc_common.prediv_s - (((uint64_t) timestamp->usecs * (rtc_common.prediv_s + 1)) / (1000 * 1000));
+
+	mutexLock(rtc_common.lock);
+	_rtc_unlock();
+	/* Disable the alarm. This clears RTC_ISR.ALR*F flags as a side effect */
+	*(rtc_common.base + cr) &= ~(1 << 8);
+	dataBarier();
+	while (!(*(rtc_common.base + isr) & 0x1));
+
+	/* Only hours, seconds, and subseconds are compared */
+	*(rtc_common.base + alrmassr) = (0xf << 24) | (ssec & 0x7fff);
+	*(rtc_common.base + alrmar) = (1 << 31) | time;
+
+	dataBarier();
+	/* Enable the alarm and its interrupt */
+	*(rtc_common.base + cr) |= (1 << 12) | (1 << 8);
+
+	_rtc_lock();
 	mutexUnlock(rtc_common.lock);
 
 	return EOK;
@@ -179,6 +241,12 @@ int rtc_init(void)
 	pwr_unlock();
 	devClk(pctl_rtc, 1);
 	pwr_lock();
+
+	rtc_common.prediv_s = *(rtc_common.base + prer) & 0x7fff;
+
+	exti_configure(18, exti_irq, exti_rising);
+
+	interrupt(rtc_alarm_irq, rtc_alarm_handler, NULL, 0, NULL);
 
 	return EOK;
 }

--- a/multi/stm32l4-multi/rtc.h
+++ b/multi/stm32l4-multi/rtc.h
@@ -27,6 +27,9 @@ int rtc_getTime(rtctimestamp_t *timestamp);
 int rtc_setTime(rtctimestamp_t *timestamp);
 
 
+int rtc_setAlarm(rtctimestamp_t *timestamp);
+
+
 int rtc_init(void);
 
 #endif

--- a/multi/stm32l4-multi/stm32-multi.c
+++ b/multi/stm32l4-multi/stm32-multi.c
@@ -90,6 +90,10 @@ static void handleMsg(msg_t *msg)
 			rtc_setTime(&imsg->rtc_timestamp);
 			break;
 
+		case rtc_setalarm:
+			rtc_setAlarm(&imsg->rtc_timestamp);
+			break;
+
 		case adc_get:
 			omsg->adc_valmv = adc_conversion(imsg->adc_get.adcno, imsg->adc_get.channel);
 			break;
@@ -204,13 +208,13 @@ int main(void)
 	oid_t oid;
 
 	rcc_init();
+	exti_init();
 	uart_init();
 	gpio_init();
 	spi_init();
 	adc_init();
 	rtc_init();
 	flash_init();
-	exti_init();
 
 /*
 	i2c_init();

--- a/multi/stm32l4-multi/stm32-multi.h
+++ b/multi/stm32l4-multi/stm32-multi.h
@@ -19,14 +19,15 @@
 #include <stm32l4-multi/libspi.h>
 
 
-enum { adc_get = 0, rtc_setcal, rtc_get, rtc_set, i2c_get, i2c_set, gpio_def, gpio_get,
-	gpio_set, uart_def, uart_get, uart_set, flash_get, flash_set, spi_get, spi_set,
+enum { adc_get = 0, rtc_setcal, rtc_get, rtc_set, rtc_setalarm, i2c_get, i2c_set, gpio_def,
+	gpio_get, gpio_set, uart_def, uart_get, uart_set, flash_get, flash_set, spi_get, spi_set,
 	spi_rw, spi_def, exti_def, exti_map };
 
 /* RTC */
 
 
 typedef struct {
+	unsigned int usecs;
 	unsigned int year;
 	unsigned char month;
 	unsigned char day;


### PR DESCRIPTION
This change introduces settable alarms to multidrv. For now only alarm A is supported.

Accompanied by the resolution increase PR:
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/150