### PR TITLE
make: add option to build specific target without adding 'all' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,7 @@ T1 := $(filter-out clean all,$(MAKECMDGOALS))
 ifneq ($(T1),)
 	include $(T1)/Makefile
 .PHONY: $(T1)
-$(T1):
-	@echo >/dev/null
+$(T1): all
 else
 	include _targets/Makefile.$(TARGET_FAMILY)-$(TARGET_SUBFAMILY)
 endif


### PR DESCRIPTION
This PR makes it possible to call
```bash
make -C phoenix-rtos-devices adc/ad7779
```

instead of
```bash
make -C phoenix-rtos-devices all adc/ad7779
```

which is more semantic, as this invocation builds only `adc/ad7779` component anyway.