### PR TITLE
stml24-multi: corrected dependency

### DIFF
--- a/multi/stm32l4-multi/Makefile
+++ b/multi/stm32l4-multi/Makefile
@@ -12,12 +12,12 @@ MULTIDRV_OBJS := $(addprefix $(PREFIX_O)$(MULTI_PATH), $(MULTIDRV_OBJS))
 MULTIDRV_LIBOBJS := $(addprefix $(PREFIX_O)$(MULTI_PATH), $(MULTIDRV_LIBOBJS))
 SRCHEADERS := $(patsubst $(MULTI_PATH)%,$(PREFIX_H)%,$(wildcard $(MULTI_PATH)libmulti/*.h))
 
-$(MULTIDRV_OBJS): $(SRCHEADERS)
+$(MULTIDRV_OBJS): $(SRCHEADERS) $(PREFIX_H)libtty.h
 
 $(PREFIX_PROG)stm32-multi: $(MULTIDRV_OBJS) $(PREFIX_A)libstm32l4-multi.a $(PREFIX_A)libtty.a
 	$(LINK)
 
-$(PREFIX_A)libstm32l4-multi.a: $(MULTIDRV_LIBOBJS) $(PREFIX_H)libtty.h $(PREFIX_A)libtty.a
+$(PREFIX_A)libstm32l4-multi.a: $(MULTIDRV_LIBOBJS) $(PREFIX_A)libtty.a
 	$(ARCH)
 
 $(PREFIX_H)%.h: $(MULTI_PATH)%.h


### PR DESCRIPTION
`libstm32l4-multi.a` does not depend on `libtty.h`.
`tty.o`. depends on `libtty.h`.

Can be removed `$(SRCHEADERS)` in a line
```
$(MULTIDRV_OBJS): $(SRCHEADERS) $(PREFIX_H)libtty.h
```
