### PR TITLE
imxrt: add optional baudrate defines

### DIFF
--- a/multi/imxrt-multi/config.h
+++ b/multi/imxrt-multi/config.h
@@ -36,12 +36,20 @@
 #define UART1_HW_FLOWCTRL 0
 #endif
 
+#ifndef UART1_BAUDRATE
+#define UART1_BAUDRATE B115200
+#endif
+
 #ifndef UART2
 #define UART2 0
 #endif
 
 #ifndef UART2_HW_FLOWCTRL
 #define UART2_HW_FLOWCTRL 0
+#endif
+
+#ifndef UART2_BAUDRATE
+#define UART2_BAUDRATE B115200
 #endif
 
 #ifndef UART3
@@ -52,12 +60,20 @@
 #define UART3_HW_FLOWCTRL 0
 #endif
 
+#ifndef UART3_BAUDRATE
+#define UART3_BAUDRATE B115200
+#endif
+
 #ifndef UART4
 #define UART4 0
 #endif
 
 #ifndef UART4_HW_FLOWCTRL
 #define UART4_HW_FLOWCTRL 0
+#endif
+
+#ifndef UART4_BAUDRATE
+#define UART4_BAUDRATE B115200
 #endif
 
 #ifndef UART5
@@ -68,12 +84,20 @@
 #define UART5_HW_FLOWCTRL 0
 #endif
 
+#ifndef UART5_BAUDRATE
+#define UART5_BAUDRATE B115200
+#endif
+
 #ifndef UART6
 #define UART6 0
 #endif
 
 #ifndef UART6_HW_FLOWCTRL
 #define UART6_HW_FLOWCTRL 0
+#endif
+
+#ifndef UART6_BAUDRATE
+#define UART6_BAUDRATE B115200
 #endif
 
 #ifndef UART7
@@ -84,12 +108,20 @@
 #define UART7_HW_FLOWCTRL 0
 #endif
 
+#ifndef UART7_BAUDRATE
+#define UART7_BAUDRATE B115200
+#endif
+
 #ifndef UART8
 #define UART8 0
 #endif
 
 #ifndef UART8_HW_FLOWCTRL
 #define UART8_HW_FLOWCTRL 0
+#endif
+
+#ifndef UART8_BAUDRATE
+#define UART8_BAUDRATE B115200
 #endif
 
 #ifdef TARGET_IMXRT1170
@@ -102,12 +134,20 @@
 #define UART9_HW_FLOWCTRL 0
 #endif
 
+#ifndef UART9_BAUDRATE
+#define UART9_BAUDRATE B115200
+#endif
+
 #ifndef UART10
 #define UART10 0
 #endif
 
 #ifndef UART10_HW_FLOWCTRL
 #define UART10_HW_FLOWCTRL 0
+#endif
+
+#ifndef UART10_BAUDRATE
+#define UART10_BAUDRATE B115200
 #endif
 
 #ifndef UART11
@@ -118,6 +158,10 @@
 #define UART11_HW_FLOWCTRL 0
 #endif
 
+#ifndef UART11_BAUDRATE
+#define UART11_BAUDRATE B115200
+#endif
+
 #ifndef UART12
 #define UART12 0
 #endif
@@ -126,16 +170,38 @@
 #define UART12_HW_FLOWCTRL 0
 #endif
 
+#ifndef UART12_BAUDRATE
+#define UART12_BAUDRATE B115200
+#endif
+
 #else
 #define UART9 0
 #define UART9_HW_FLOWCTRL 0
+#define UART9_BAUDRATE 0
 #define UART10 0
 #define UART10_HW_FLOWCTRL 0
+#define UART10_BAUDRATE 0
 #define UART11 0
 #define UART11_HW_FLOWCTRL 0
+#define UART11_BAUDRATE 0
 #define UART12 0
 #define UART12_HW_FLOWCTRL 0
+#define UART12_BAUDRATE 0
 #endif
+
+#define UART_BAUDRATES \
+	UART1_BAUDRATE, \
+	UART3_BAUDRATE, \
+	UART3_BAUDRATE, \
+	UART4_BAUDRATE, \
+	UART5_BAUDRATE, \
+	UART6_BAUDRATE, \
+	UART7_BAUDRATE, \
+	UART8_BAUDRATE, \
+	UART9_BAUDRATE, \
+	UART10_BAUDRATE, \
+	UART11_BAUDRATE, \
+	UART12_BAUDRATE
 
 #ifndef UART_CONSOLE
 #if defined(TARGET_IMXRT1050)

--- a/multi/imxrt-multi/uart.c
+++ b/multi/imxrt-multi/uart.c
@@ -680,6 +680,8 @@ int uart_init(void)
 
 	uart_initPins();
 
+	const speed_t default_baud[] = { UART_BAUDRATES };
+
 	for (i = 0, dev = 0; dev < sizeof(uartConfig) / sizeof(uartConfig[0]); ++dev) {
 		if (!uartConfig[dev])
 			continue;
@@ -721,7 +723,7 @@ int uart_init(void)
 
 		/* Set 115200 default baudrate */
 		t = *(uart->base + baudr) & ~((0x1f << 24) | (1 << 17) | 0x1fff);
-		*(uart->base + baudr) = t | calculate_baudrate(B115200);
+		*(uart->base + baudr) = t | calculate_baudrate(default_baud[dev]);
 
 		/* Set 8 bit and no parity mode */
 		*(uart->base + ctrlr) &= ~0x117;


### PR DESCRIPTION
The default baudrate equals 115200. Optional values set as UARTX_BAUDRATE.