### PR TITLE
stm32l4_tty: send logs to tty only when UART_CONSOLE points to tty

### DIFF
--- a/multi/stm32l4-multi/config.h
+++ b/multi/stm32l4-multi/config.h
@@ -102,4 +102,6 @@
 #define I2C4 0
 #endif
 
+#define CONSOLE_IS_TTY ((UART_CONSOLE == 1 && TTY1) || (UART_CONSOLE == 2 && TTY2) || (UART_CONSOLE == 3 && TTY3) || (UART_CONSOLE == 4 && TTY4) || (UART_CONSOLE == 5 && TTY5))
+
 #endif

--- a/multi/stm32l4-multi/stm32-multi.c
+++ b/multi/stm32l4-multi/stm32-multi.c
@@ -163,7 +163,7 @@ static void handleMsg(msg_t *msg)
 
 static ssize_t console_write(const char *str, size_t len, int mode)
 {
-#if TTY1 || TTY2 || TTY3 || TTY4 || TTY5
+#if CONSOLE_IS_TTY
 	tty_log(str);
 	return (ssize_t)len;
 #else
@@ -174,7 +174,7 @@ static ssize_t console_write(const char *str, size_t len, int mode)
 
 static ssize_t console_read(char *str, size_t bufflen, int mode)
 {
-#if TTY1 || TTY2 || TTY3 || TTY4 || TTY5
+#if CONSOLE_IS_TTY
 	return -ENOSYS;
 #else
 	return uart_read(UART_CONSOLE - 1, str, bufflen, uart_mnormal, 0);
@@ -239,6 +239,11 @@ int main(void)
 
 	priority(THREADS_PRIORITY);
 
+#if !CONSOLE_IS_TTY
+	/* called before init functions to redirect logs here */
+	portCreate(&common.port);
+#endif
+
 	rcc_init();
 	exti_init();
 	tty_init();
@@ -250,7 +255,10 @@ int main(void)
 	i2c_init();
 	uart_init();
 
+#if CONSOLE_IS_TTY
 	portCreate(&common.port);
+#endif
+
 	portRegister(common.port, "/multi", &oid);
 
 	console_write(welcome, sizeof(welcome) - 1, 0);

--- a/multi/stm32l4-multi/tty.c
+++ b/multi/stm32l4-multi/tty.c
@@ -348,7 +348,7 @@ static void tty_thread(void *arg)
 
 void tty_log(const char *str)
 {
-#if TTY_CNT != 0
+#if CONSOLE_IS_TTY
 	libtty_write(&tty_getCtx(0)->tty_common, str, strlen(str), 0);
 #endif
 }
@@ -376,6 +376,11 @@ int tty_init(void)
 
 	portCreate(&uart_common.port);
 	oid.port = uart_common.port;
+
+#if CONSOLE_IS_TTY
+	oid.id = 0;
+	portRegister(uart_common.port, "/dev/tty", &oid);
+#endif
 
 	for (uart = usart1; uart <= uart5; ++uart) {
 		if (!uartConfig[uart])
@@ -416,9 +421,6 @@ int tty_init(void)
 		oid.id = uart - usart1 + 1;
 		portRegister(uart_common.port, fname, &oid);
 	}
-
-	oid.id = 0;
-	portRegister(uart_common.port, "/dev/tty", &oid);
 
 	for (i = 0; i < THREAD_POOL; ++i)
 		beginthread(tty_thread, THREAD_PRIO, uart_common.poolstack[i], sizeof(uart_common.poolstack[i]), (void *)i);


### PR DESCRIPTION
Currently logs are always sent to TTY when any TTY is enabled. After this change TTY can be used (ie. for optoport) without log redirection.

I've checked stm32l4 projects on gerrit and this would not change current behavior.