### PR TITLE
multi: added the static keyword

### DIFF
--- a/multi/stm32l1-multi/uart.c
+++ b/multi/stm32l1-multi/uart.c
@@ -282,7 +282,7 @@ int uart_read(int uart, void* buff, unsigned int count, char mode, unsigned int 
 int uart_init(void)
 {
 	int i, uart;
-	const struct {
+	static const struct {
 		volatile uint32_t *base;
 		int dev;
 		unsigned irq;

--- a/multi/stm32l4-multi/libmulti/libuart.c
+++ b/multi/stm32l4-multi/libmulti/libuart.c
@@ -260,7 +260,7 @@ int libuart_read(libuart_ctx *ctx, void* buff, unsigned int count, char mode, un
 int libuart_init(libuart_ctx *ctx, unsigned int uart)
 {
 
-	const struct {
+	static const struct {
 		volatile uint32_t *base;
 		int dev;
 		unsigned irq;
@@ -296,5 +296,3 @@ int libuart_init(libuart_ctx *ctx, unsigned int uart)
 
 	return 0;
 }
-
-

--- a/multi/stm32l4-multi/tty.c
+++ b/multi/stm32l4-multi/tty.c
@@ -375,7 +375,7 @@ int tty_init(void)
 	oid_t oid;
 	libtty_callbacks_t callbacks;
 	tty_ctx_t *ctx;
-	const struct {
+	static const struct {
 		volatile uint32_t *base;
 		int dev;
 		unsigned irq;


### PR DESCRIPTION
Added the static keyword to eliminate copying the structure to the stack.
