### PR TITLE
ade7913: add CS pins ordering as arg, fix power enable

### DIFF
--- a/adc/ade7913/ade7913-test.c
+++ b/adc/ade7913/ade7913-test.c
@@ -14,26 +14,65 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 
 #include <sys/msg.h>
+#include <imxrt-multi.h>
 
 #include "ade7913.h"
 
 
+#define ADE7913_DEFAULT_LIST "1230"
+
+
+static int lpspi_config(oid_t *device, int spi)
+{
+	msg_t msg;
+	multi_i_t *imsg = (multi_i_t *)msg.i.raw;
+
+	msg.type = mtDevCtl;
+	msg.i.data = NULL;
+	msg.i.size = 0;
+	msg.o.data = NULL;
+	msg.o.size = 0;
+
+	imsg->id = id_spi1 + spi;
+	imsg->spi.type = spi_config;
+	imsg->spi.config.cs = 0;
+	imsg->spi.config.mode = spi_mode_0;
+	imsg->spi.config.endian = spi_msb;
+	imsg->spi.config.sckDiv = 4;
+	imsg->spi.config.prescaler = 3;
+
+	return msgSend(device->port, &msg);
+}
+
+
 int main(int argc, char **argv)
 {
-	int i;
+	int i, devnum, devcnt;
+	const char *order;
 	oid_t ade7913_spi;
 	ade7913_burst_reg_t sample;
 
-	int devcnt = 1;
+	if (argc != 2) {
+		printf("No device list given. Using default: %s\n", ADE7913_DEFAULT_LIST);
+		devcnt = strlen(ADE7913_DEFAULT_LIST);
+		order = ADE7913_DEFAULT_LIST;
+	}
+	else {
+		order = argv[1];
+		devcnt = strlen(argv[1]);
 
-	if (argc >= 2)
-		devcnt = atoi(argv[1]);
+		for (i = 0; i < devcnt; ++i) {
+			if ((int)(order[i] - '0') >= devcnt || (int)(order[i] - '0') < 0)
+				printf("Wrong order format provided\n");
+		}
 
-	printf("Starting ADE7913 test (%d devices)\n", devcnt);
+		printf("Device order: %s\n", order);
+	}
 
-	if (devcnt > 4 || devcnt <= 0) {
+	if (devcnt > 4) {
 		printf("Incorrect ADE7913 device count (4 max)\n");
 		return -1;
 	}
@@ -41,37 +80,49 @@ int main(int argc, char **argv)
 	while (lookup("/dev/spi1", NULL, &ade7913_spi) < 0)
 		usleep(5000);
 
+	if (lpspi_config(&ade7913_spi, 0) < 0) {
+		printf("Could not initialize SPI1\n");
+		return -1;
+	}
+
 	printf("SPI1 initialized\n");
 
+	/* Start init from device with xtal */
 	for (i = 0; i < devcnt; ++i) {
-		printf("Configuring ADE7913 device nr %d\n", i);
+		devnum = (int)(order[i] - '0');
 
-		while (ade7913_init(&ade7913_spi, i, i < devcnt - 1 ? 1 : 0) < 0) {
-			printf("Failed to initialize ade7913 nr %d\n", i);
+		usleep(500000);
+		printf("Configuring ADE7913 device nr %d\n", devnum);
+
+		while (ade7913_init(&ade7913_spi, devnum,
+				   devnum == order[devcnt - 1] - '0' ? 0 : 1) < 0) {
+			printf("Failed to initialize ADE7913 nr %d\n", devnum);
 			usleep(500000);
 		}
 
-		if (ade7913_lock(&ade7913_spi, i) < 0)
-			printf("Could not lock ADE7913 nr %d\n", i);
-		if (ade7913_enable(&ade7913_spi, i) < 0)
-			printf("Could not enable ADE7913 nr %d\n", i);
+		if (ade7913_enable(&ade7913_spi, devnum) < 0)
+			printf("Could not enable ADE7913 nr %d\n", devnum);
+		if (ade7913_lock(&ade7913_spi, devnum) < 0)
+			printf("Could not lock ADE7913 nr %d\n", devnum);
 	}
 
 	printf("Reading ADE7913 registers in burst mode:\n");
 
 	while (1) {
 		for (i = 0; i < devcnt; ++i) {
-			if (ade7913_sample_regs_read(&ade7913_spi, i, &sample) < 0) {
-				printf("Failed reading sample registers from device %d\n", i);
+			devnum = (int)(order[i] - '0');
+
+			if (ade7913_sample_regs_read(&ade7913_spi, devnum, &sample) < 0) {
+				printf("Failed reading sample registers from device %d\n", devnum);
 				continue;
 			}
 
-			printf("IWV[%d]: %x\n", i, sample.iwv);
-			printf("V1WV[%d]: %x\n", i, sample.v1wv);
-			printf("V2WV[%d]: %x\n", i, sample.v2wv);
-			printf("ADC_CRC[%d]: %x\n", i, sample.adc_crc);
-			printf("CNT_SNAPSHOT[%d]: %x\n", i, sample.cnt_snapshot);
-			printf("STATUS0[%d]: %x\n", i, sample.status0);
+			printf("IWV[%d]: 0x%x\n", devnum, sample.iwv);
+			printf("V1WV[%d]: 0x%x\n", devnum, sample.v1wv);
+			printf("V2WV[%d]: 0x%x\n", devnum, sample.v2wv);
+			printf("ADC_CRC[%d]: 0x%x\n", devnum, sample.adc_crc);
+			printf("CNT_SNAPSHOT[%d]: 0x%x\n", devnum, sample.cnt_snapshot);
+			printf("STATUS0[%d]: 0x%x\n", devnum, sample.status0);
 		}
 
 		printf("\n");


### PR DESCRIPTION
ADE7913 devices can be connected to SPI CS pins in many different
orders, thus giving CS pin orders as argument like:
ade7913-test;2301 - means main ADE7913 device (source of the clock)
is connected to CS pin 2, next in chain is connected to CS
pin 3, etc. This argument ensures correct initialization.

JIRA: NIL-117