### PR TITLE
imxrt-multi: fix errno check for already exist dir

### DIFF
--- a/multi/imxrt-multi/imxrt-multi.c
+++ b/multi/imxrt-multi/imxrt-multi.c
@@ -170,7 +170,7 @@ static int createDevFiles(void)
 
 	err = mkdir("/dev", 0);
 
-	if (err < 0 && err != -EEXIST)
+	if (err < 0 && errno != EEXIST)
 		return -1;
 
 	if (lookup("/dev", NULL, &dir) < 0)


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

JIRA: RTOS-68

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes behavior of `imxrt-multi` device registration when a directory `/dev` already exists.
`mkdir()` returns `-1` and sets `errno` value  respectively, checking returned value if it is -EEXIST or not is not correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
