### PR TITLE
uart16550: fix device ports registration

### DIFF
--- a/tty/uart16550/uart16550.h
+++ b/tty/uart16550/uart16550.h
@@ -15,49 +15,41 @@
 #ifndef _DEV_SERIAL_H_
 #define _DEV_SERIAL_H_
 
-#define SIZE_SERIALS       2
-#define SIZE_SERIAL_CHUNK  256
+#define SIZE_SERIALS      2
+#define SIZE_SERIAL_CHUNK 256
 
 
 /* UART registers */
-#define REG_RBR     0
-#define REG_THR     0
-#define REG_IMR     1
-#define REG_IIR     2
-#define REG_LCR     3
-#define REG_MCR     4
-#define REG_LSR     5
-#define REG_MSR     6
-#define REG_ADR     7
-#define REG_LSB     0
-#define REG_MSB     1
+#define REG_RBR 0
+#define REG_THR 0
+#define REG_IMR 1
+#define REG_IIR 2
+#define REG_LCR 3
+#define REG_MCR 4
+#define REG_LSR 5
+#define REG_MSR 6
+#define REG_ADR 7
+#define REG_LSB 0
+#define REG_MSB 1
+#define REG_FCR 2
 
 
 /* Register bits */
-#define IMR_THRE      0x02
-#define IMR_DR        0x01
+#define IMR_THRE 0x02
+#define IMR_DR   0x01
 
-#define IIR_IRQPEND   0x01
-#define IIR_THRE      0x02
-#define IIR_DR        0x04
+#define IIR_IRQPEND 0x01
+#define IIR_THRE    0x02
+#define IIR_DR      0x04
 
-#define LCR_DLAB      0x80
-#define LCR_D8N1      0x03
-#define LCR_D8N2      0x07
+#define LCR_DLAB 0x80
+#define LCR_D8N1 0x03
+#define LCR_D8N2 0x07
 
-#define MCR_OUT2      0x08
+#define MCR_OUT2 0x08
 
-#define LSR_DR        0x01
-#define LSR_THRE      0x20
-
-
-#define BPS_28800     4
-#define BPS_38400     3
-#define BPS_57600     2
-#define BPS_115200    1
-
-
-extern void _uart16550_init(unsigned int speed);
+#define LSR_DR   0x01
+#define LSR_THRE 0x20
 
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixed following issues:
- all UART devices used the same path ("/dev/ttyS0") for port registration,
- device oid passed to portRegister() wasn't initialized,

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The uart16550 didn't work on real PC hardware.
[JIRA: PD-86](https://jira.phoenix-rtos.com/browse/PD-86)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
