### PR TITLE
stm32l4-multi: Increase stack size

### DIFF
--- a/multi/stm32l4-multi/stm32l4-multi.c
+++ b/multi/stm32l4-multi/stm32l4-multi.c
@@ -36,7 +36,7 @@
 
 #define THREADS_NO 3
 #define THREADS_PRIORITY 1
-#define STACKSZ 512
+#define STACKSZ 640
 
 
 struct {

--- a/multi/stm32l4-multi/tty.c
+++ b/multi/stm32l4-multi/tty.c
@@ -39,12 +39,12 @@
 #define TTY_CNT (TTY1 + TTY2 + TTY3 + TTY4 + TTY5)
 
 #define THREAD_POOL 3
-#define THREAD_STACKSZ 512
+#define THREAD_STACKSZ 768
 #define THREAD_PRIO 1
 
 #if TTY_CNT != 0
 typedef struct {
-	char stack[256] __attribute__ ((aligned(8)));
+	char stack[512] __attribute__ ((aligned(8)));
 
 	volatile unsigned int *base;
 	volatile int enabled;


### PR DESCRIPTION
Due to recent changes, stm32l4-multi driver starts to overflow stack.
Values are chosen to reflect current stack size usage.

JIRA: ISM-53

<!--- Provide a general summary of your changes in the Title above -->

## Description
Stack size changes to avoid stack overflows. Probably caused by recent changes in libphoenix, but not sure.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I found that current worst case scenario for stack is:
| entry point | previous stack | current stack | stack usage |  
| --- | --- | --- | --- |
| tty_irqthread |  256 | 512 | 336 |
| tty_thread  |  512 | 768 | 608 |
| thread | 512 | 640 | 440 |

(stack usage is estimated without cost of interrupts and syscall call)

So this change increase memory usage by 256 + 256 * 3 +  128 * 2 = 1280 B
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7m4-stm32l4x6).
Compile and program with DEBUG kernel before and after the change.  It stops detects stack overflows.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
