### PR TITLE
pc-ata: Make mbr_t structure packed

### DIFF
--- a/storage/pc-ata/mbr.h
+++ b/storage/pc-ata/mbr.h
@@ -44,7 +44,7 @@ typedef struct {
 	char bca[446];    /* Bootstrap Code Area */
 	pentry_t pent[4]; /* Partition entries */
 	uint16_t magic;   /* MBR magic */
-} mbr_t;
+} __attribute__((packed)) mbr_t;
 
 
 /* Reads MBR */


### PR DESCRIPTION
JIRA: RTOS-21

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR make mbr_t structure packed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Making the `mbr_t` structure packed would simplify mbr parsing/writing by allowing to cast a data buffer to `mbr_t` pointer. The `pentry_t` structure defined above contains the `packed` attribute, so for consistency `mbr_t` should also be packed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
