### PR TITLE
imx6ull-flashsrv: fix flashsrv_write() overwriting metadata

### DIFF
--- a/storage/imx6ull-flash/flashsrv.c
+++ b/storage/imx6ull-flash/flashsrv.c
@@ -302,7 +302,6 @@ static int flashsrv_write(id_t id, size_t start, char *data, size_t size)
 	flashdrv_dma_t *dma;
 	int i, err;
 	char *databuf;
-	void *metabuf;
 	size_t partoff = 0;
 	size_t writesz = size;
 
@@ -324,15 +323,11 @@ static int flashsrv_write(id_t id, size_t start, char *data, size_t size)
 
 	dma = flashsrv_common.dma;
 	databuf = flashsrv_common.databuf;
-	metabuf = flashsrv_common.metabuf;
-
-	/* FIXME: this breaks meta parity bits, we need to read meta before writing data? */
-	memset(metabuf, 0xff, sizeof(flashdrv_meta_t));
 
 	for (i = 0; size; i++) {
 		/* TODO: should we skip badblocks ? */
 		memcpy(databuf, data + flashsrv_common.info.writesz * i, flashsrv_common.info.writesz);
-		err = flashdrv_write(dma, start / flashsrv_common.info.writesz + i, databuf, metabuf);
+		err = flashdrv_write(dma, start / flashsrv_common.info.writesz + i, databuf, NULL);
 
 		if (err) {
 			LOG_ERROR("write error %d", err);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Passing `aux == NULL` to `flashdrv_write()` means that we're going to perform partial page programming (data only). Therefore not programmed area (metadata and its ECC) should be set to `0xff`.
We trick BCH controller into thinking that this area contains metdata only without ECC (so that BCH won't calculate new ECC for the metadata).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-109](https://jira.phoenix-rtos.com/browse/DTR-109)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull + extended `test_meta()` in `imx6ull-flash-test.c`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
