### PR TITLE
imx6ull-flash/imx6ull-nandtool: allocate physically contiguous DMA buffers

### DIFF
--- a/storage/imx6ull-flash/flashdrv.c
+++ b/storage/imx6ull-flash/flashdrv.c
@@ -1015,7 +1015,7 @@ void flashdrv_init(void)
 	flashdrv_common.gpmi = mmap(NULL, 2 * _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_DEVICE, OID_PHYSMEM, 0x1806000);
 	flashdrv_common.bch  = mmap(NULL, 4 * _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_DEVICE, OID_PHYSMEM, 0x1808000);
 	flashdrv_common.mux  = mmap(NULL, 4 * _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_DEVICE, OID_PHYSMEM, 0x20e0000);
-	flashdrv_common.uncached_buf = mmap(NULL, 2 * _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0);
+	flashdrv_common.uncached_buf = mmap(NULL, 2 * _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
 
 	/* 16 bytes of user metadada + ECC16 * bits per parity level (13) / 8 = 26 bytes for ECC  */
 	flashdrv_common.rawmetasz = 16 + 26;

--- a/storage/imx6ull-flash/flashsrv.c
+++ b/storage/imx6ull-flash/flashsrv.c
@@ -797,8 +797,8 @@ int main(int argc, char **argv)
 	flashsrv_partition(0, flashsrv_common.info.size / flashsrv_common.info.erasesz);
 
 	flashsrv_common.dma = flashdrv_dmanew();
-	flashsrv_common.databuf = mmap(NULL, 2 * flashsrv_common.info.writesz, PROT_READ | PROT_WRITE, MAP_UNCACHED, NULL, -1);
-	flashsrv_common.metabuf = mmap(NULL, flashsrv_common.info.writesz, PROT_READ | PROT_WRITE, MAP_UNCACHED, NULL, -1);
+	flashsrv_common.databuf = mmap(NULL, 2 * flashsrv_common.info.writesz, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
+	flashsrv_common.metabuf = mmap(NULL, flashsrv_common.info.writesz, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
 
 	for (i = 0; i < sizeof(flashsrv_common.poolStacks) / sizeof(flashsrv_common.poolStacks[0]); ++i)
 		beginthread(flashsrv_poolThread, 4, flashsrv_common.poolStacks[i], sizeof(flashsrv_common.poolStacks[i]), NULL);

--- a/storage/imx6ull-flash/imx6ull-flash-test.c
+++ b/storage/imx6ull-flash/imx6ull-flash-test.c
@@ -119,7 +119,7 @@ void test_write_fcb(void)
 	uint8_t *data;
 	int err;
 
-	data = mmap(NULL, _PAGE_SIZE * 2, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0);
+	data = mmap(NULL, _PAGE_SIZE * 2, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
 	if (data == MAP_FAILED)
 		FAIL("failed to mmap data buffer\n");
 
@@ -155,7 +155,7 @@ void test_meta(void)
 	const unsigned int blockno = 0;
 	uint32_t paddr = blockno * 64;
 
-	data = mmap(NULL, _PAGE_SIZE * 2, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0);
+	data = mmap(NULL, _PAGE_SIZE * 2, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
 	meta = data + _PAGE_SIZE;
 	aux = (flashdrv_meta_t *)meta;
 
@@ -247,7 +247,7 @@ void test_badblocks(void)
 	int err;
 	int total_read_fails = 0, total_bad_blocks = 0;
 
-	data = mmap(NULL, _PAGE_SIZE * 2, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0);
+	data = mmap(NULL, _PAGE_SIZE * 2, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
 	if (data == MAP_FAILED)
 		FAIL("failed to mmap data buffer\n");
 
@@ -322,8 +322,8 @@ void test_stress_one_block(void)
 
 	dma = flashdrv_dmanew();
 
-	data = mmap(NULL, _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0);
-	m = meta = mmap(NULL, _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0);
+	data = mmap(NULL, _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
+	m = meta = mmap(NULL, _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
 
 	for (int i = 0; i < 0x1000; ++i) {
 		((char *)data)[i] = (char)i;
@@ -532,8 +532,8 @@ void test_write_read_erase(void)
 	uint8_t *data, *meta;
 	unsigned int blockno;
 
-	data = mmap(NULL, _PAGE_SIZE * 2, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0);
-	meta = mmap(NULL, _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0);
+	data = mmap(NULL, _PAGE_SIZE * 2, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
+	meta = mmap(NULL, _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
 	if (data == MAP_FAILED || meta == MAP_FAILED)
 		FAIL("failed to mmap data buffers\n");
 
@@ -626,6 +626,7 @@ void test_3(void)
 
 	printf("done\n");
 }
+
 
 int main(int argc, char **argv)
 {

--- a/storage/imx6ull-nandtool/bcb.c
+++ b/storage/imx6ull-nandtool/bcb.c
@@ -64,8 +64,8 @@ int dbbt_flash(flashdrv_dma_t *dma, dbbt_t *dbbt)
 {
 	int i, err;
 	uint32_t page_num = DBBT_START;
-	void *data = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0);
-	void *meta = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0);
+	void *data = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
+	void *meta = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
 
 	dbbt_fingerprint(dbbt);
 
@@ -88,7 +88,7 @@ int dbbt_flash(flashdrv_dma_t *dma, dbbt_t *dbbt)
 	}
 
 	munmap(data, PAGE_SIZE);
-	munmap(data, PAGE_SIZE);
+	munmap(meta, PAGE_SIZE);
 	return 0;
 }
 
@@ -138,6 +138,7 @@ void fcb_init(fcb_t *fcb)
 	fcb->checksum = bcb_checksum(((uint8_t *)fcb) + 4, sizeof(fcb_t) - 4);
 }
 
+
 int fcb_flash(flashdrv_dma_t *dma, fcb_t *fcb_ret)
 {
 	char *sbuf, *tbuf;
@@ -149,7 +150,7 @@ int fcb_flash(flashdrv_dma_t *dma, fcb_t *fcb_ret)
 	if ((sbuf = mmap(NULL, PAGE_SIZE * 2, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0)) == MAP_FAILED)
 		return 1;
 
-	if ((tbuf = mmap(NULL, PAGE_SIZE * 2, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0)) == MAP_FAILED)
+	if ((tbuf = mmap(NULL, PAGE_SIZE * 2, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0)) == MAP_FAILED)
 		return 1;
 
 	memset(sbuf, 0x0, PAGE_SIZE * 2);

--- a/storage/imx6ull-nandtool/nandtool.c
+++ b/storage/imx6ull-nandtool/nandtool.c
@@ -307,7 +307,7 @@ int flash_write_cleanmarkers(void *arg, int start, int end)
 	else
 		dma = (flashdrv_dma_t *)arg;
 
-	metabuf = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0);
+	metabuf = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0);
 	memset(metabuf, 0xff, PAGE_SIZE);
 	memcpy(metabuf, &oob_cleanmarker, 8);
 	for (i = start; i < end; i++) {
@@ -316,6 +316,7 @@ int flash_write_cleanmarkers(void *arg, int start, int end)
 
 	return ret;
 }
+
 
 void set_nandboot(char *primary, char *secondary, char *rootfs, size_t rootfssz, int rwfs_erase)
 {

--- a/storage/imx6ull-nandtool/test.c
+++ b/storage/imx6ull-nandtool/test.c
@@ -19,13 +19,13 @@ int do_test(void *arg)
 
 	unsigned fail_erase = 0, fail_write = 0, mismatch = 0, errors = 0, uncorrectable = 0, erased = 0;
 
-	if ((wbuf = mmap(NULL, SIZE_PAGE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0)) == MAP_FAILED)
+	if ((wbuf = mmap(NULL, SIZE_PAGE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0)) == MAP_FAILED)
 		return 1;
 
-	if ((rbuf = mmap(NULL, SIZE_PAGE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0)) == MAP_FAILED)
+	if ((rbuf = mmap(NULL, SIZE_PAGE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0)) == MAP_FAILED)
 		return 1;
 
-	if ((meta = mmap(NULL, SIZE_PAGE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_NULL, 0)) == MAP_FAILED)
+	if ((meta = mmap(NULL, SIZE_PAGE, PROT_READ | PROT_WRITE, MAP_UNCACHED, OID_CONTIGUOUS, 0)) == MAP_FAILED)
 		return 1;
 
 	for (i = 0; i < SIZE_PAGE; ++i)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changed DMA buffers allocation to OID_CONTIGUOUS allocator.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-123](https://jira.phoenix-rtos.com/browse/DTR-123)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
