### PR TITLE
imx6ull: change watchdog api

### DIFF
--- a/watchdog/imx6ull/watchdog.h
+++ b/watchdog/imx6ull/watchdog.h
@@ -4,7 +4,7 @@
 #include <sys/ioctl.h>
 
 #define WATCHDOG_IOCTL_BASE 'W'
-#define WDIOC_KEEPALIVE     _IOR(WATCHDOG_IOCTL_BASE, 5, int)
+#define WDIOC_KEEPALIVE     _IO(WATCHDOG_IOCTL_BASE, 5)
 #define WDIOC_SETTIMEOUT    _IOWR(WATCHDOG_IOCTL_BASE, 6, int)
 
 #endif /* IMX6ULL_WATCHDOG */


### PR DESCRIPTION
JIRA: DTR-122

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Calling `ioctl(fd, WDIOC_KEEPALIVE, 0)` causes an exception in [processing ioctl response](https://github.com/phoenix-rtos/phoenix-rtos-kernel/blob/4167188a695efba62e561f1f528a471be8db325a/posix/posix.c#L1421). The data is NULL but size is 4 bytes. Change IO operation to void.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
