### PR TITLE
imxrt1170: quickfix of SPI and eDMA clock performance

### DIFF
--- a/dma/imxrt-edma/imxrt-edma.c
+++ b/dma/imxrt-edma/imxrt-edma.c
@@ -135,9 +135,15 @@ int edma_init(int (*error_isr)(unsigned int n, void *arg))
 	int res;
 	platformctl_t pctl;
 
-	pctl.action = pctl_set;
+	pctl.action = pctl_get;
 	pctl.type = pctl_devclock;
 	pctl.devclock.dev = EDMA_CLK;
+
+	if ((res = platformctl(&pctl)) != 0)
+		return res;
+
+	pctl.action = pctl_set;
+
 #if defined(TARGET_IMXRT1060)
 	pctl.devclock.state = clk_state_run;
 #elif defined(TARGET_IMXRT1170)

--- a/multi/imxrt-multi/imxrt1170.h
+++ b/multi/imxrt-multi/imxrt1170.h
@@ -308,16 +308,32 @@
 
 static inline int common_setClock(int clock, int div, int mux, int mfd, int mfn, int state)
 {
+	int res;
 	platformctl_t pctl;
 
-	pctl.action = pctl_set;
+	pctl.action = pctl_get;
 	pctl.type = pctl_devclock;
 	pctl.devclock.dev = clock;
-	pctl.devclock.div = div;
-	pctl.devclock.mfd = mfd;
-	pctl.devclock.mfn = mfn;
-	pctl.devclock.mux = mux;
-	pctl.devclock.state = state;
+
+	if ((res = platformctl(&pctl)) != 0)
+		return res;
+
+	pctl.action = pctl_set;
+
+	if (div >= 0)
+		pctl.devclock.div = div;
+
+	if (mux >= 0)
+		pctl.devclock.mux = mux;
+
+	if (mfd >= 0)
+		pctl.devclock.mfd = mfd;
+
+	if (mfn >= 0)
+		pctl.devclock.mfn = mfn;
+
+	if (state >= 0)
+		pctl.devclock.state = state;
 
 	return platformctl(&pctl);
 }
@@ -340,6 +356,10 @@ static inline int common_setMux(int mux, char sion, char mode)
 static inline int common_setPad(int pad, char hys, char pus, char pue, char pke, char ode, char speed, char dse, char sre)
 {
 	platformctl_t pctl;
+
+	(void)hys;
+	(void)pke;
+	(void)speed;
 
 	pctl.action = pctl_set;
 	pctl.type = pctl_iopad;

--- a/multi/imxrt-multi/spi.c
+++ b/multi/imxrt-multi/spi.c
@@ -799,7 +799,7 @@ int spi_init(void)
 			continue;
 
 #ifdef TARGET_IMXRT1170
-		if (common_setClock(spiInfo[spi].clk, 0, 0, 0, 0, 1) < 0)
+		if (common_setClock(spiInfo[spi].clk, -1, -1, -1, -1, 1) < 0)
 #else
 		if (common_setClock(spiInfo[spi].clk, clk_state_run) < 0)
 #endif


### PR DESCRIPTION
This change is intended to make the `imxrt1176` SPI driver behave similar to SPI driver on `imxrt1064` target (clock setup).

Additionally this PR fixes poor eDMA performance on `imxrt1176`.

JIRA: NIL-139, NIL-140

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

The imxrt-multi implementation on imxrt117x resets the default SPI clocks settings while turning on, this is different from the imxrt1064 implementation, where the clocks when turned on do not affect the rest of the configuration, i.e. dividers, multipliers, PLL's, etc.

A similar bug has also occurres in eDMA library and this PR fixes it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (nil-imxrt1176).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
