### PR TITLE
imx6ull-gpio: add text write mode

### DIFF
--- a/gpio/imx6ull-gpio/README.md
+++ b/gpio/imx6ull-gpio/README.md
@@ -66,3 +66,27 @@ read data:
 ## Note
 
 Input/output multiplexers and physical pad control is performed independently by kernel's platformctl interface and should be performed by user prior to usage of GPIO driver.
+
+
+## Text write mode
+
+The `dir` and `port` files support also text write mode for easier usage from shell scripts.
+
+The syntax is `[+/-][pin]`, eg `+28`, `-7`, where:
+ - `+` means _value high_ for `port` and _output_ for `dir`
+ - `-` means _value low_ for `port` and _input_ for `dir`
+ - `pin` is the numeric pin value in <0, 31> range
+
+This interface allows changing only one pin value / direction at a time (state of other pins won't be changed).
+
+Please note that the byte length of the text message can't be divisible by 4 to avoid confusing it with the binary interface.
+
+
+### Example
+
+```bash
+# set direction to output
+echo -n "+9" > /dev/gpio2/dir
+# set output value to LOW
+echo -n "-9" > /dev/gpio2/port
+```


### PR DESCRIPTION
## Description

We need easy way to toggle leds from shell scripts. This is a kind-of hackish approach (single file which understands `text` and `binary` write mode), but I can use other approach if preferable:
 - separate files for `text mode` (`textdir`, `textport`? :rofl:)
 - `export` file which would allow us to dynamically export specific pin from specific port as a dir with files for different options (the linux way)

For now went whit the easiest path without creating additional files at all.

## Functional description

The `dir` and `port` files support text write mode for easier usage from shell scripts.

The syntax is `[+/-][pin]`, eg `+28`, `-7`, where:
 - `+` means _value high_ for `port` and _output_ for `dir`
 - `-` means _value low_ for `port` and _input_ for `dir`
 - `pin` is the numeric pin value in <0, 31> range

This interface allows changing only one pin value / direction at a time (state of other pins won't be changed).


### Example

```bash
# set direction to output
echo -n "+9" > /dev/gpio2/dir
# set output value to LOW
echo -n "-9" > /dev/gpio2/port
```
## Motivation and Context
JIRA: DTR-11, DTR-47

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
