### PR TITLE
imx6ull-flash: fix erase size in flashsrv_devErase()

### DIFF
--- a/storage/imx6ull-flash/flashsrv.c
+++ b/storage/imx6ull-flash/flashsrv.c
@@ -441,9 +441,9 @@ static int flashsrv_devErase(const flash_i_devctl_t *idevctl)
 	if ((err = flashsrv_partoff(idevctl->erase.oid.id, 0, start, size, &partoff, &partsize)) < 0)
 		return err;
 
-	start += partoff;
 	if (size == 0)
-		size = partsize;
+		size = partsize - start;
+	start += partoff;
 
 	return flashsrv_erase(start, start + size);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixed erasing blocks outside of partition range for `start > 0` and `size = 0`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: RTOS-96](https://jira.phoenix-rtos.com/browse/RTOS-96)
The problem showed up while testing blocks erasure with `nandtool`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
