### PR TITLE
imxrt-multi: Add TRNG driver

### DIFF
--- a/multi/imxrt-multi/Makefile
+++ b/multi/imxrt-multi/Makefile
@@ -8,7 +8,7 @@ NAME := imxrt-multi
 
 LOCAL_SRCS = imxrt-multi.c common.c uart.c gpio.c spi.c
 ifneq ($(TARGET_SUBFAMILY), imxrt117x)
-  LOCAL_SRCS += i2c.c
+  LOCAL_SRCS += i2c.c trng.c
 endif
 DEP_LIBS := libtty
 LOCAL_HEADERS := imxrt-multi.h

--- a/multi/imxrt-multi/config.h
+++ b/multi/imxrt-multi/config.h
@@ -260,4 +260,9 @@
 #define I2C4 0
 #endif
 
+/* TRNG */
+#ifndef TRNG
+#define TRNG 0
+#endif
+
 #endif

--- a/multi/imxrt-multi/imxrt-multi.c
+++ b/multi/imxrt-multi/imxrt-multi.c
@@ -33,6 +33,7 @@
 #include "gpio.h"
 #include "spi.h"
 #include "i2c.h"
+#include "trng.h"
 
 #define MULTI_THREADS_NO 2
 #define UART_THREADS_NO 2
@@ -85,6 +86,9 @@ static void multi_dispatchMsg(msg_t *msg)
 		case id_i2c3:
 		case id_i2c4:
 			i2c_handleMsg(msg, id);
+			break;
+		case id_trng:
+			trng_handleMsg(msg);
 			break;
 #endif
 	}
@@ -305,6 +309,11 @@ static int createDevFiles(void)
 		return -1;
 #endif
 
+#if TRNG
+	if (mkFile(&dir, id_trng, "trng", multi_port) < 0)
+		return -1;
+#endif
+
 #endif
 
 	return 0;
@@ -407,6 +416,10 @@ int main(void)
 	uart_init();
 	gpio_init();
 	spi_init();
+
+#if TRNG
+	trng_init();
+#endif
 
 	for (i = 0; i < UART_THREADS_NO; ++i)
 		beginthread(uart_thread, THREADS_PRIORITY, common.stack[i], STACKSZ, (void *)i);

--- a/multi/imxrt-multi/imxrt-multi.h
+++ b/multi/imxrt-multi/imxrt-multi.h
@@ -24,7 +24,7 @@ enum { id_console = 0, id_uart1, id_uart2, id_uart3, id_uart4, id_uart5, id_uart
 #ifdef TARGET_IMXRT1170
 	id_spi5, id_spi6,
 #endif
-	id_i2c1, id_i2c2, id_i2c3, id_i2c4 };
+	id_i2c1, id_i2c2, id_i2c3, id_i2c4, id_trng };
 
 
 #pragma pack(push, 8)

--- a/multi/imxrt-multi/imxrt1060.h
+++ b/multi/imxrt-multi/imxrt1060.h
@@ -124,6 +124,8 @@
 #define I2C3_IRQ 30 + 16
 #define I2C4_IRQ 31 + 16
 
+#define TRNG_BASE ((void *)0x400cc000)
+
 #define UART1_TX_PIN ad_b0_12
 #define UART1_RX_PIN ad_b0_13
 #define UART1_RTS_PIN ad_b0_15

--- a/multi/imxrt-multi/trng.c
+++ b/multi/imxrt-multi/trng.c
@@ -1,0 +1,125 @@
+/*
+ * Phoenix-RTOS
+ *
+ * i.MX RT TRNG driver
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Maciej Purski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "trng.h"
+#include "common.h"
+
+
+enum { mctl = 0, scmisc, pkrrng, pkrmax, sdctl, sblim, frqmin, frqcnt, scmc, scr1c,
+	scr2c, scr3c, scr4c, scr5c, scr6c, status, ent, pkrcnt10 = 32, pkrcnt32,
+	pkrcnt54, pkrcnt76, pkrcnt98, pkrcntba, pkrcntdc, pkrcntfe, sec_cfg, int_ctrl,
+	int_mask, int_status, reserved_0, vid1 = 60, vid2 };
+
+
+#define TRNG_MCTL_RST  0x40
+#define TRNG_MCTL_VAL  0x400
+#define TRNG_MCTL_ERR  0x1000
+#define TRNG_MCTL_PRGM 0x10000
+
+#define TRNG_ENT_COUNT 16
+
+struct {
+	volatile uint32_t *base;
+} trng_common;
+
+
+static uint32_t trng_readEnt(int index)
+{
+	uint32_t data;
+
+	if (index > TRNG_ENT_COUNT)
+		return 0;
+
+	data = *(trng_common.base + ent + index);
+
+	/* Dummy read, error workaround */
+	if (index == TRNG_ENT_COUNT - 1)
+		(void)*(trng_common.base + ent);
+
+	return data;
+}
+
+
+static int trng_read(char *data, size_t size)
+{
+	uint32_t val;
+	uint32_t mctlVal;
+	size_t offs = 0;
+	int index = 0;
+
+	while (offs < size) {
+		/* Wait for valid entropy or error */
+		do {
+			mctlVal = *(trng_common.base + mctl);
+		} while ((mctlVal & (TRNG_MCTL_VAL | TRNG_MCTL_ERR)) == 0);
+
+		if (mctlVal & TRNG_MCTL_ERR)
+			return offs;
+
+		val = trng_readEnt(index);
+		memcpy(data + offs, &val, sizeof(val));
+
+		offs += sizeof(val);
+		index = (index + 1) % TRNG_ENT_COUNT;
+	}
+
+	/* Start new entropy generation */
+	(void)trng_readEnt(TRNG_ENT_COUNT - 1);
+
+	return offs;
+}
+
+
+int trng_handleMsg(msg_t *msg)
+{
+	switch (msg->type) {
+		case mtRead:
+			msg->o.io.err = trng_read(msg->o.data, msg->o.size);
+			break;
+		case mtGetAttr:
+			msg->o.attr.val = -EINVAL;
+			break;
+		default:
+			msg->o.io.err = -EINVAL;
+	}
+
+	return EOK;
+}
+
+
+int trng_init(void)
+{
+	trng_common.base = TRNG_BASE;
+
+	if (common_setClock(pctl_clk_trng, clk_state_run) < 0)
+		return -EFAULT;
+
+	/* Set to program mode */
+	*(trng_common.base + mctl) |= TRNG_MCTL_PRGM;
+
+	/* Reset to default state */
+	*(trng_common.base + mctl) |= TRNG_MCTL_RST;
+
+	/* Set to run mode */
+	*(trng_common.base + mctl) &= ~TRNG_MCTL_PRGM;
+	/* TODO: access bit? */
+
+	/* Start generation */
+	(void)trng_readEnt(TRNG_ENT_COUNT - 1);
+
+	return EOK;
+}

--- a/multi/imxrt-multi/trng.h
+++ b/multi/imxrt-multi/trng.h
@@ -1,0 +1,26 @@
+/*
+ * Phoenix-RTOS
+ *
+ * i.MX RT TRNG driver
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Maciej Purski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#ifndef _TRNG_H_
+#define _TRNG_H_
+
+#include <sys/msg.h>
+
+int trng_handleMsg(msg_t *msg);
+
+
+int trng_init(void);
+
+
+#endif


### PR DESCRIPTION
JIRA: BES-180

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This change adds the True Random Number Generator driver for imxrt106x and imxrt105x.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is needed in order to provide a reliable source of entropy for applications using secure protocols, such as SSL. The interface for the driver is a dev file `/dev/trng`. Client applications should communicate with it using msg API and `multi_i_t` structure. For now it is not possible to communicate with the multidriver using open()/read()/write() syscalls. Therefore I decided not to name the file `/dev/random`, as it might be misleading.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt106x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
