### PR TITLE
libtty: Fix RX overrun handling

### DIFF
--- a/tty/libtty/libtty_disc.c
+++ b/tty/libtty/libtty_disc.c
@@ -66,10 +66,10 @@
 #define COL_NORMAL  "\033[0m"
 
 #define LOG_TAG "libtty-disc: "
-#define log_debug(fmt, ...)     do { if (1) printf(LOG_TAG fmt "\n", ##__VA_ARGS__); } while (0)
-#define log_info(fmt, ...)      do { if (1) printf(COL_CYAN LOG_TAG fmt "\n" COL_NORMAL, ##__VA_ARGS__); } while (0)
-#define log_warn(fmt, ...)      do { if (1) printf(COL_YELLOW LOG_TAG fmt "\n" COL_NORMAL, ##__VA_ARGS__); } while (0)
-#define log_error(fmt, ...)     do { if (1) printf(COL_RED  LOG_TAG fmt "\n" COL_NORMAL, ##__VA_ARGS__); } while (0)
+#define log_debug(fmt, ...)     do { if (0) printf(LOG_TAG fmt "\n", ##__VA_ARGS__); } while (0)
+#define log_info(fmt, ...)      do { if (0) printf(COL_CYAN LOG_TAG fmt "\n" COL_NORMAL, ##__VA_ARGS__); } while (0)
+#define log_warn(fmt, ...)      do { if (0) printf(COL_YELLOW LOG_TAG fmt "\n" COL_NORMAL, ##__VA_ARGS__); } while (0)
+#define log_error(fmt, ...)     do { if (0) printf(COL_RED  LOG_TAG fmt "\n" COL_NORMAL, ##__VA_ARGS__); } while (0)
 // } DEBUG
 
 #define CALLBACK(cb_name, ...) do {\
@@ -270,11 +270,11 @@ int libtty_putchar(libtty_common_t *tty, unsigned char c, int *wake_reader)
 
 processed:
 	mutexLock(tty->rx_mutex);
-	if (!fifo_is_full(tty->rx_fifo)) {
-		fifo_push(tty->rx_fifo, c);
-	} else {
+	if (fifo_is_full(tty->rx_fifo)) {
 		log_warn("RX OVERRUN!");
+		fifo_pop_back(tty->rx_fifo);
 	}
+	fifo_push(tty->rx_fifo, c);
 
 	libttydisc_echo(tty, c);
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
When FIFO is full, pop the oldest character and always push the received
one.
Disable "log_warn()" as it might cause stack overflow.

JIRA: BES-184
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is needed in order to prevent our devices from "bricking", when uart receives lots of random bytes, e.g. when connecting RX without GND or as a result of the USB-UART converter error.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
