### PR TITLE
stm32l4-multi/i2c: Fixed deadlock when device is not present or faulty

### DIFF
--- a/multi/stm32l4-multi/libmulti/libi2c.h
+++ b/multi/stm32l4-multi/libmulti/libi2c.h
@@ -38,10 +38,10 @@ ssize_t libi2c_read(libi2c_ctx_t *ctx, unsigned char addr, void *buff, size_t le
 ssize_t libi2c_readReg(libi2c_ctx_t *ctx, unsigned char addr, unsigned char reg, void *buff, size_t len);
 
 
-ssize_t libi2c_write(libi2c_ctx_t *ctx, unsigned char addr, void *buff, size_t len);
+ssize_t libi2c_write(libi2c_ctx_t *ctx, unsigned char addr, const void *buff, size_t len);
 
 
-ssize_t libi2c_writeReg(libi2c_ctx_t *ctx, unsigned char addr, unsigned char reg, void *buff, size_t len);
+ssize_t libi2c_writeReg(libi2c_ctx_t *ctx, unsigned char addr, unsigned char reg, const void *buff, size_t len);
 
 
 int libi2c_init(libi2c_ctx_t *ctx, int i2c);


### PR DESCRIPTION
JIRA: ISC-141

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added timeout for waiting for I2C interrupt

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Faulty or not present device will cause interrupt to never come - previously will cause multidrv thread to deadlock forever.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
