### PR TITLE
imxrt-multi: Use integer values for setting uart baudrate

### DIFF
--- a/multi/imxrt-multi/config.h
+++ b/multi/imxrt-multi/config.h
@@ -37,7 +37,7 @@
 #endif
 
 #ifndef UART1_BAUDRATE
-#define UART1_BAUDRATE B115200
+#define UART1_BAUDRATE 115200
 #endif
 
 #ifndef UART2
@@ -49,7 +49,7 @@
 #endif
 
 #ifndef UART2_BAUDRATE
-#define UART2_BAUDRATE B115200
+#define UART2_BAUDRATE 115200
 #endif
 
 #ifndef UART3
@@ -61,7 +61,7 @@
 #endif
 
 #ifndef UART3_BAUDRATE
-#define UART3_BAUDRATE B115200
+#define UART3_BAUDRATE 115200
 #endif
 
 #ifndef UART4
@@ -73,7 +73,7 @@
 #endif
 
 #ifndef UART4_BAUDRATE
-#define UART4_BAUDRATE B115200
+#define UART4_BAUDRATE 115200
 #endif
 
 #ifndef UART5
@@ -85,7 +85,7 @@
 #endif
 
 #ifndef UART5_BAUDRATE
-#define UART5_BAUDRATE B115200
+#define UART5_BAUDRATE 115200
 #endif
 
 #ifndef UART6
@@ -97,7 +97,7 @@
 #endif
 
 #ifndef UART6_BAUDRATE
-#define UART6_BAUDRATE B115200
+#define UART6_BAUDRATE 115200
 #endif
 
 #ifndef UART7
@@ -109,7 +109,7 @@
 #endif
 
 #ifndef UART7_BAUDRATE
-#define UART7_BAUDRATE B115200
+#define UART7_BAUDRATE 115200
 #endif
 
 #ifndef UART8
@@ -121,7 +121,7 @@
 #endif
 
 #ifndef UART8_BAUDRATE
-#define UART8_BAUDRATE B115200
+#define UART8_BAUDRATE 115200
 #endif
 
 #ifdef TARGET_IMXRT1170
@@ -135,7 +135,7 @@
 #endif
 
 #ifndef UART9_BAUDRATE
-#define UART9_BAUDRATE B115200
+#define UART9_BAUDRATE 115200
 #endif
 
 #ifndef UART10
@@ -147,7 +147,7 @@
 #endif
 
 #ifndef UART10_BAUDRATE
-#define UART10_BAUDRATE B115200
+#define UART10_BAUDRATE 115200
 #endif
 
 #ifndef UART11
@@ -159,7 +159,7 @@
 #endif
 
 #ifndef UART11_BAUDRATE
-#define UART11_BAUDRATE B115200
+#define UART11_BAUDRATE 115200
 #endif
 
 #ifndef UART12
@@ -171,7 +171,7 @@
 #endif
 
 #ifndef UART12_BAUDRATE
-#define UART12_BAUDRATE B115200
+#define UART12_BAUDRATE 115200
 #endif
 
 #else


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Use speed_t type only, when communicating with libtty. Internally use
a plain uint32_t.

JIRA: RTOS-122

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change allows setting uart baudrate through BOARD_CONFIG using integer values instead of speed_t. Thanks to this change we can set uart baudrate in plo, kernel and in imxrt-multi using the same value without the need for any conversion. It makes setting uart baudrate less error prone.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
In all projects using imxrt-multi, which set the baudrate value through BOARD_CONFIG, we shall change the values from speed_t to integer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
