### PR TITLE
imxrt-multi: Fix incorrect daisy definitions for spi

### DIFF
--- a/multi/imxrt-multi/spi.c
+++ b/multi/imxrt-multi/spi.c
@@ -363,8 +363,8 @@ static int spi_getIsel(int mux, int *isel, int *val)
 		case pctl_mux_gpio_disp_b1_10 : *isel = pctl_isel_lpspi3_pcs_3; *val = 1; break;
 		case pctl_mux_gpio_emc_b2_04 :  *isel = pctl_isel_lpspi3_sck; *val = 0; break;
 		case pctl_mux_gpio_disp_b1_04 : *isel = pctl_isel_lpspi3_sck; *val = 1; break;
-		case pctl_mux_gpio_emc_b2_07 :  *isel = pctl_isel_lpspi3_sdi; *val = 1; break;
-		case pctl_mux_gpio_disp_b1_05 : *isel = pctl_isel_lpspi3_sdi; *val = 0; break;
+		case pctl_mux_gpio_emc_b2_07 :  *isel = pctl_isel_lpspi3_sdi; *val = 0; break;
+		case pctl_mux_gpio_disp_b1_05 : *isel = pctl_isel_lpspi3_sdi; *val = 1; break;
 		case pctl_mux_gpio_emc_b2_06 :  *isel = pctl_isel_lpspi3_sdo; *val = 0; break;
 		case pctl_mux_gpio_disp_b1_06 : *isel = pctl_isel_lpspi3_sdo; *val = 1; break;
 		case pctl_mux_gpio_sd_b2_01 :   *isel = pctl_isel_lpspi4_pcs_0; *val = 0; break;
@@ -622,8 +622,8 @@ static int spi_getIsel(int mux, int *isel, int *val)
 		case pctl_mux_gpio_ad_b1_15 :  *isel = pctl_isel_lpspi3_sck; *val = 1; break;
 		case pctl_mux_gpio_ad_b1_13 :  *isel = pctl_isel_lpspi3_sdi; *val = 1; break;
 		case pctl_mux_gpio_ad_b0_02 :  *isel = pctl_isel_lpspi3_sdi; *val = 0; break;
-		case pctl_mux_gpio_ad_b1_14 :  *isel = pctl_isel_lpspi3_sdo; *val = 0; break;
-		case pctl_mux_gpio_ad_b0_01 :  *isel = pctl_isel_lpspi3_sdo; *val = 1; break;
+		case pctl_mux_gpio_ad_b1_14 :  *isel = pctl_isel_lpspi3_sdo; *val = 1; break;
+		case pctl_mux_gpio_ad_b0_01 :  *isel = pctl_isel_lpspi3_sdo; *val = 0; break;
 		case pctl_mux_gpio_b0_00 :     *isel = pctl_isel_lpspi4_pcs0; *val = 0; break;
 		case pctl_mux_gpio_b1_04 :     *isel = pctl_isel_lpspi4_pcs0; *val = 1; break;
 		case pctl_mux_gpio_b0_03 :     *isel = pctl_isel_lpspi4_sck; *val = 0; break;


### PR DESCRIPTION
JIRA: RTOS-126

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Daisy chain definitions for SPI on imxrt targets are incorrect for a few inputs, according to the reference manuals.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1176.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
