### PR TITLE
stm32l4-multi: add libspi_readwrite fix

### DIFF
--- a/multi/stm32l4-multi/libmulti/libspi.c
+++ b/multi/stm32l4-multi/libmulti/libspi.c
@@ -71,6 +71,12 @@ static unsigned char libspi_readwrite(libspi_ctx_t *ctx, unsigned char txd)
 	/* Initiate transmission */
 	*((volatile uint8_t *)(ctx->base + dr)) = txd;
 
+	/* Wait until TXNE==1 */
+	while (!(*(ctx->base + sr) & 0x2))
+		;
+	/* Clear data register */
+	rxd = *((volatile uint8_t *)(ctx->base + dr));
+
 	/* Wait until RXNE==1 */
 	while (!(*(ctx->base + sr) & 0x1))
 		;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- Add waiting for transmit buffer empty after sending transmit data
- add first init read before save data from receive buffer

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Sometimes, when reading for example sensor address using SPI, unwanted received data (from first cycle) was presented in data register. To clear data register and prepare to read next byte from rx buffer, the register is read double times.

Different read values (before changes from this pr) using same method:
![Screenshot from 2021-11-16 22-57-32](https://user-images.githubusercontent.com/77304431/142075077-f6421484-e8a1-4857-b79b-a154660009d9.png)

Signal from both 0xff and 0x69 readings:

![Screenshot from 2021-11-16 23-24-14](https://user-images.githubusercontent.com/77304431/142075893-81b8cf1c-fe1d-4116-837e-5cc7c2f1f423.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4x6 - nucleo, lsm6ds3 sensor).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
