### PR TITLE
imx6ull-flashnor: remove partitionErase() usage

### DIFF
--- a/storage/imx6ull-flashnor/flashnor-ecspi.c
+++ b/storage/imx6ull-flashnor/flashnor-ecspi.c
@@ -222,34 +222,6 @@ static int flashnor_ecspiEraseSector(unsigned int addr)
 }
 
 
-static int flashnor_escpiEraseChip(void)
-{
-	unsigned char cmd = cmd_erase_chip;
-	int err;
-
-	mutexLock(flashnor_common.lock);
-
-	if ((err = _flashnor_ecspiWriteEnable()) < 0) {
-		mutexUnlock(flashnor_common.lock);
-		return err;
-	}
-
-	if ((err = ecspi_exchangeBusy(flashnor_common.ndev, &cmd, &cmd, 1)) < 0) {
-		mutexUnlock(flashnor_common.lock);
-		return err;
-	}
-
-	if ((err = _flashnor_ecspiWaitBusy()) < 0) {
-		mutexUnlock(flashnor_common.ndev);
-		return err;
-	}
-
-	mutexUnlock(flashnor_common.lock);
-
-	return EOK;
-}
-
-
 int flashnor_ecspiInit(unsigned int ndev, storage_t *dev)
 {
 	unsigned char *jedec, data[4] = { cmd_jedec, 0xff, 0xff, 0xff };
@@ -292,7 +264,6 @@ int flashnor_ecspiInit(unsigned int ndev, storage_t *dev)
 			flashnor_common.ctx.read = flashnor_ecspiRead;
 			flashnor_common.ctx.write = flashnor_ecspiWrite;
 			flashnor_common.ctx.eraseSector = flashnor_ecspiEraseSector;
-			flashnor_common.ctx.partitionErase = flashnor_escpiEraseChip;
 			flashnor_common.ctx.powerCtrl = NULL;
 
 			if ((err = meterfs_init(&flashnor_common.ctx)) < 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Removed `flashnor_escpiEraseChip()` as it's not needed anymore.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-184](https://jira.phoenix-rtos.com/browse/DTR-184)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-filesystems/pull/54
- [ ] I will merge this PR by myself when appropriate.
