### PR TITLE
imx6ull-flashnor: fix meterfs_handler() not setting msg.o.lookup.fil.port for mtLookup message

### DIFF
--- a/storage/imx6ull-flashnor/flashnor.c
+++ b/storage/imx6ull-flashnor/flashnor.c
@@ -71,6 +71,7 @@ static void meterfs_handler(void *arg, msg_t *msg)
 			break;
 
 		case mtLookup:
+			msg->o.lookup.fil.port = msg->i.lookup.dir.port;
 			msg->o.lookup.err = meterfs_lookup(msg->i.data, &msg->o.lookup.fil.id, ctx);
 			break;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added setting `msg.o.lookup.fil.port` for `meterfs_handler()` mtLookup request.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-183](https://jira.phoenix-rtos.com/browse/DTR-183)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
