### PR TITLE
libtty: fix VTIME timeout value

### DIFF
--- a/tty/libtty/libtty_disc.c
+++ b/tty/libtty/libtty_disc.c
@@ -460,7 +460,7 @@ ssize_t libttydisc_read_raw(libtty_common_t *tty, char *data, size_t size, unsig
 								return len;
 							}
 
-							int ret = condWait(tty->rx_waitq, tty->rx_mutex, (len == 0) ? first_char_timeout : vtime);
+							int ret = condWait(tty->rx_waitq, tty->rx_mutex, ((len == 0) ? first_char_timeout : vtime) * 1000);
 							if (ret == -ETIME) {
 								mutexUnlock(tty->rx_mutex);
 								return len; // timer expired


### PR DESCRIPTION
## Description
`condWait` takes timeout in microseconds, not in milliseconds

## Motivation and Context
JIRA: DTR-197

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
