### PR TITLE
stm32l4-multi/libspi: Remove interrupt waitng

### DIFF
--- a/multi/stm32l4-multi/libmulti/libspi.h
+++ b/multi/stm32l4-multi/libmulti/libspi.h
@@ -28,10 +28,6 @@ typedef struct {
 	size_t cnt;
 
 	int usedma;
-
-	handle_t irqLock;
-	handle_t cond;
-	handle_t inth;
 } libspi_ctx_t;
 
 


### PR DESCRIPTION
Interrupt waiting causes unneded overhead on operation that last for
some cycles

JIRA: ISC-154

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Remove interrupt in libspi and a little cleanup

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Many spi interrupts causes overhead that can cause invalid work of uart due to overrun. Proposed fix will avoid that issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4x6).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
