### PR TITLE
ad7779: turn on crc in the sample header

### DIFF
--- a/adc/ad7779/ad7779.c
+++ b/adc/ad7779/ad7779.c
@@ -606,7 +606,7 @@ int ad7779_init(int hard)
 
 	/* Use one DOUTx line; DCLK_CLK_DIV = 1 */
 	log_debug("setting DOUT_FORMAT");
-	if ((res = ad7779_write_reg(AD7779_DOUT_FORMAT, 0xc0)) < 0)
+	if ((res = ad7779_write_reg(AD7779_DOUT_FORMAT, 0xe0)) < 0)
 		return res;
 
 	/* Make sure SRC_LOAD_SOURCE bit is cleared */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Currently, if the channel is disabled, the header of sample is empty. Turn on the crc mode to keep channel number in the header even if it's disabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull, imxrt106x.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
