### PR TITLE
stm32l4-multi: Use create_dev for tty devices

### DIFF
--- a/multi/stm32l4-multi/tty.h
+++ b/multi/stm32l4-multi/tty.h
@@ -18,7 +18,7 @@
 void tty_log(const char *str);
 
 
-int tty_init(void);
+int tty_init(unsigned int *port);
 
 
 #endif


### PR DESCRIPTION
tty devices was not available on /dev
This commit fixes that

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
It's quite complicated because:
- Port for main console have to be first registered port (depending on configuration it's tty or multidrv port)
- Rootfs have to be initialized before tty want's to create dev on it
- tty will not work if rootfs is not created (it's not possible to create entries in /dev then)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Required for use open("/dev/uartX') in application code again, after posixifyizing open on stm32l4. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7m4-stm32l4x6).

psh run on target. Directory /dev appeared with tty, uart1 and uart3 files.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
