### PR TITLE
host-flash, imxrt-flash: Added missing const to write callbacks

### DIFF
--- a/storage/host-flash/host-flash.c
+++ b/storage/host-flash/host-flash.c
@@ -50,7 +50,7 @@ ssize_t hostflash_read(unsigned int addr, void *buff, size_t bufflen)
 }
 
 
-ssize_t hostflash_write(unsigned int addr, void *buff, size_t bufflen)
+ssize_t hostflash_write(unsigned int addr, const void *buff, size_t bufflen)
 {
 	char tempTab[256];
 	size_t wrote = 0, i;
@@ -71,7 +71,7 @@ ssize_t hostflash_write(unsigned int addr, void *buff, size_t bufflen)
 			return readsz;
 
 		for (i = 0; i < readsz; i++)
-			tempTab[i] = tempTab[i] & *((char *)buff + wrote + i);
+			tempTab[i] = tempTab[i] & *((const char *)buff + wrote + i);
 
 		len = 0;
 		while (len != readsz) {

--- a/storage/host-flash/host-flash.h
+++ b/storage/host-flash/host-flash.h
@@ -17,7 +17,7 @@
 ssize_t hostflash_read(unsigned int addr, void *buff, size_t bufflen);
 
 
-ssize_t hostflash_write(unsigned int addr, void *buff, size_t bufflen);
+ssize_t hostflash_write(unsigned int addr, const void *buff, size_t bufflen);
 
 
 int hostflash_sectorErase(unsigned int addr);

--- a/storage/imxrt-flash/flashsrv.c
+++ b/storage/imxrt-flash/flashsrv.c
@@ -142,7 +142,7 @@ static int flashsrv_chipErase(unsigned char fID)
 
 /* Callbacks to meterfs - wrappers for basic flash functions */
 
-static ssize_t flashsrv_fsWritef0(unsigned int addr, void *buff, size_t bufflen)
+static ssize_t flashsrv_fsWritef0(unsigned int addr, const void *buff, size_t bufflen)
 {
 	flash_memory_t *flash_memory = flashsrv_common.flash_memories + 0;
 
@@ -153,7 +153,7 @@ static ssize_t flashsrv_fsWritef0(unsigned int addr, void *buff, size_t bufflen)
 }
 
 
-static ssize_t flashsrv_fsWritef1(unsigned int addr, void *buff, size_t bufflen)
+static ssize_t flashsrv_fsWritef1(unsigned int addr, const void *buff, size_t bufflen)
 {
 	flash_memory_t *flash_memory = flashsrv_common.flash_memories + 1;
 


### PR DESCRIPTION
Adapted to change in meterfs

JIRA: DTR-179

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-filesystems/pull/61).
- [x] I will merge this PR by myself when appropriate.
