### PR TITLE
stm32l4-multi/adc: Added sleep during ADC probe

### DIFF
--- a/multi/stm32l4-multi/adc.c
+++ b/multi/stm32l4-multi/adc.c
@@ -109,7 +109,7 @@ static void adc_disable(int adc)
 static void adc_calibration(int adc)
 {
 	volatile unsigned int *base = adc_common.base + adc_getOffs(adc);
-	useconds_t sleep = 1 * 1000;
+	useconds_t sleep = 2 * 1000;
 
 	*(base + cr) &= ~(1 << 30);
 	*(base + cr) |= 1 << 31;
@@ -141,7 +141,7 @@ static unsigned short adc_probeChannel(int adc, char chan)
 
 	/* Wait for overrun */
 	while (!(*(base + isr) & (1 << 4)))
-		usleep(0);
+		usleep(1000);
 
 	/* Clear flags */
 	*(base + isr) |= 0x7ff;


### PR DESCRIPTION
JIRA: SKAL-420

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Some ADC operations are very fast and reschedule is really just in case. ADC channel probing takes about 1-2 ms, so sleep is a good idea after all.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
