### PR TITLE
usb/ehci: Fix qtds management

### DIFF
--- a/usb/ehci/ehci.h
+++ b/usb/ehci/ehci.h
@@ -164,6 +164,7 @@ struct qh {
 typedef struct _ehci_qtd {
 	struct _ehci_qtd *prev, *next;
 	volatile struct qtd *hw;
+	uint32_t paddr;
 	size_t bytes;
 } ehci_qtd_t;
 


### PR DESCRIPTION
Save qtd physical address to avoid calling va2pa() every time.
Move the queue forward, when it gets stuck due to hardware racing
with ehci_enqueue() function.

JIRA: DTR-227

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes an issue, when new transfers are being enqueued constantly and they tend to race with the hardware.
When executing transfers, ehci fetches first qtd from the queue by copying it to an "overlay area" in a Queue Head structure. It then performs a transfers and afterwards saves the modifications back in the original qtd and follows the `next` pointer from the overlay area. If we modify a qtd that is now being processed in the overlay area, the controller won't see the modifications. If the modification is based on updating the `next` pointer it causes the queue to get stucked. This commit fixes this situation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
