### PR TITLE
imx6ull-flashnor: print error logs on stdout

### DIFF
--- a/storage/imx6ull-flashnor/flashnor.c
+++ b/storage/imx6ull-flashnor/flashnor.c
@@ -16,6 +16,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #include <sys/file.h>
@@ -170,13 +171,13 @@ int main(int argc, char *argv[])
 		exit(EXIT_FAILURE);
 
 	if ((err = storage_init(flashnor_msgloop, 16)) < 0) {
-		fprintf(stderr, "imx6ull-flashnor: failed to initialize server, err: %d\n", err);
+		printf("imx6ull-flashnor: failed to initialize server, err: %s\n", strerror(err));
 		return err;
 	}
 	port = err;
 
 	if ((err = storage_registerfs("meterfs", meterfs_mount, meterfs_umount, meterfs_handler)) < 0) {
-		fprintf(stderr, "imx6ull-flashnor: failed to register filesystem, err: %d\n", err);
+		printf("imx6ull-flashnor: failed to register filesystem, err: %s\n", strerror(err));
 		return err;
 	}
 
@@ -186,17 +187,17 @@ int main(int argc, char *argv[])
 				case 'e':
 					if ((dev = malloc(sizeof(storage_t))) == NULL) {
 						err = -ENOMEM;
-						fprintf(stderr, "imx6ull-flashnor: failed to allocate device, err: %d\n", err);
+						printf("imx6ull-flashnor: failed to allocate device, err: %s\n", strerror(err));
 						return err;
 					}
 
 					if ((err = flashnor_ecspiInit(strtoul(optarg, NULL, 0), dev)) < 0) {
-						fprintf(stderr, "imx6ull-flashnor: failed to initialize device, err: %d\n", err);
+						printf("imx6ull-flashnor: failed to initialize device, err: %s\n", strerror(err));
 						return err;
 					}
 
 					if ((err = storage_add(dev)) < 0) {
-						fprintf(stderr, "imx6ull-flashnor: failed to register device, err: %d\n", err);
+						printf("imx6ull-flashnor: failed to register device, err: %s\n", strerror(err));
 						return err;
 					}
 
@@ -204,12 +205,12 @@ int main(int argc, char *argv[])
 					oid.id = err;
 					if (snprintf(path, sizeof(path), "/dev/%s%u", prefix, id++) >= sizeof(path)) {
 						err = -ENAMETOOLONG;
-						fprintf(stderr, "imx6ull-flashnor: failed to build device file path, err: %d\n", err);
+						printf("imx6ull-flashnor: failed to build device file path, err: %s\n", strerror(err));
 						return err;
 					}
 
 					if ((err = create_dev(&oid, path)) < 0) {
-						fprintf(stderr, "imx6ull-flashnor: failed to create device file, err: %d\n", err);
+						printf("imx6ull-flashnor: failed to create device file, err: %s\n", strerror(err));
 						return err;
 					}
 					break;
@@ -221,19 +222,19 @@ int main(int argc, char *argv[])
 				case 'p':
 					if ((arg = optind - 1) + 3 > argc) {
 						err = -EINVAL;
-						fprintf(stderr, "imx6ull-flashnor: missing arg(s) for -p option, err: %d\n", err);
+						printf("imx6ull-flashnor: missing arg(s) for -p option, err: %s\n", strerror(err));
 						return err;
 					}
 
 					if ((dev = malloc(sizeof(storage_t))) == NULL) {
 						err = -ENOMEM;
-						fprintf(stderr, "imx6ull-flashnor: failed to allocate device, err: %d\n", err);
+						printf("imx6ull-flashnor: failed to allocate device, err: %s\n", strerror(err));
 						return err;
 					}
 
 					if ((parent = storage_get(strtoul(argv[arg++], NULL, 0))) == NULL) {
 						err = -EINVAL;
-						fprintf(stderr, "imx6ull-flashnor: failed to find parent device, err: %d\n", err);
+						printf("imx6ull-flashnor: failed to find parent device, err: %s\n", strerror(err));
 						return err;
 					}
 
@@ -244,7 +245,7 @@ int main(int argc, char *argv[])
 					optind += 2;
 
 					if ((err = storage_add(dev)) < 0) {
-						fprintf(stderr, "imx6ull-flashnor: failed to create partition, err: %d\n", err);
+						printf("imx6ull-flashnor: failed to create partition, err: %s\n", strerror(err));
 						return err;
 					}
 
@@ -252,12 +253,12 @@ int main(int argc, char *argv[])
 					oid.id = err;
 					if (snprintf(path, sizeof(path), "/dev/%s%u", prefix, id++) >= sizeof(path)) {
 						err = -ENAMETOOLONG;
-						fprintf(stderr, "imx6ull-flashnor: failed to build partition file path, err: %d\n", err);
+						printf("imx6ull-flashnor: failed to build partition file path, err: %s\n", strerror(err));
 						return err;
 					}
 
 					if ((err = create_dev(&oid, path)) < 0) {
-						fprintf(stderr, "imx6ull-flashnor: failed to create partition file, err: %d\n", err);
+						printf("imx6ull-flashnor: failed to create partition file, err: %s\n", strerror(err));
 						return err;
 					}
 					break;
@@ -269,7 +270,7 @@ int main(int argc, char *argv[])
 				case 'n':
 					if ((arg = optind - 1) + 2 > argc) {
 						err = -EINVAL;
-						fprintf(stderr, "imx6ull-flashnor: missing arg(s) for -n option, err: %d\n", err);
+						printf("imx6ull-flashnor: missing arg(s) for -n option, err: %s\n", strerror(err));
 						return err;
 					}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changed printing errors to stdout instead of stderr. Replaced error numbers by their names with `strerror()` usage.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-292](https://jira.phoenix-rtos.com/browse/DTR-292)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
