### PR TITLE
zynq7000-flash: apply libstorage interface to flashdrv

### DIFF
--- a/storage/zynq7000-flash/Makefile
+++ b/storage/zynq7000-flash/Makefile
@@ -10,5 +10,6 @@
 NAME := libflashdrv-zynq
 LOCAL_SRCS := qspi.c flashcfg.c flashdrv.c
 LOCAL_HEADERS := flashdrv.h flashcfg.h
+LIBS := libstorage
 
 include $(static-lib.mk)

--- a/storage/zynq7000-flash/flashcfg.c
+++ b/storage/zynq7000-flash/flashcfg.c
@@ -90,8 +90,8 @@ int flashcfg_infoResolve(flash_info_t *info)
 		info->cfi.fdiDesc = 0x0102;
 		info->cfi.pageSize = 0x08;
 		info->cfi.regsCount = 1;
-		info->cfi.regs[0].count = 0xfff;
-		info->cfi.regs[0].size = 0x10;
+		info->cfi.regs[0].count = 0xff;
+		info->cfi.regs[0].size = 0x100;
 
 		memcpy(info->cmds, defCmds, sizeof(defCmds));
 

--- a/storage/zynq7000-flash/flashdrv.c
+++ b/storage/zynq7000-flash/flashdrv.c
@@ -11,30 +11,42 @@
  * %LICENSE%
  */
 
-#include "qspi.h"
+#include "flashdrv.h"
 #include "flashcfg.h"
+#include "qspi.h"
 
 #include <stdlib.h>
 #include <errno.h>
 #include <string.h>
 #include <sys/time.h>
+#include <sys/threads.h>
 
-#define TIMEOUT_CMD_MS 0x05
+/* Value determined empirically, contains time for communication via qspi and system calls invocations. */
+#define TIMEOUT_CMD_MS 1000
 #define MAX_SIZE_CMD   0x20
 
+#define MTD_DEFAULT_ERASESZ 0x10000
 
-struct {
+
+typedef struct {
+	/* Data caching in sector's buffer */
+	uint8_t *buff;
+	uint32_t buffPos;
+	uint32_t sectID;
+
 	/* Buffers for command transactions */
 	uint8_t cmdRx[MAX_SIZE_CMD];
 	uint8_t cmdTx[MAX_SIZE_CMD];
 
-	/* Data caching in sector's buffer */
-	uint8_t *buff;
-	uint32_t buffPos;
-	uint32_t regID;
-	uint32_t sectID;
+	handle_t lock;
+} flash_reg_t;
 
-	flash_info_t info;
+
+struct {
+	flash_reg_t *regs;
+
+	flash_info_t info;     /* CFI structure for NOR flash memory */
+	unsigned int initRegs; /* Number of initialized regions */
 } fdrv_common;
 
 
@@ -49,47 +61,27 @@ static inline time_t flashdrv_timeMsGet(void)
 }
 
 
-static int flashdrv_regionFind(addr_t offs, uint32_t *id)
-{
-	int i;
-	size_t sz;
-	addr_t start = 0;
-	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
-
-	for (i = 0; i < cfi->regsCount; ++i) {
-		sz = CFI_SIZE_REGION(cfi->regs[i].size, cfi->regs[i].count);
-		if (offs >= start && offs < (start + sz)) {
-			*id = i;
-			return EOK;
-		}
-
-		start = sz;
-	}
-
-	return -EINVAL;
-}
-
-
 static size_t flashdrv_regStart(int id)
 {
 	int i;
 	size_t regStart = 0;
 	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
 
-	for (i = 0; i < id; ++i)
+	for (i = 0; i < id; ++i) {
 		regStart += CFI_SIZE_REGION(cfi->regs[i].size, cfi->regs[i].count);
+	}
 
 	return regStart;
 }
 
 
-static inline void flashdrv_initCmdBuff(const flash_cmd_t *cmd, addr_t offs)
+static inline void _flashdrv_initCmdBuff(unsigned int id, const flash_cmd_t *cmd, addr_t offs)
 {
-	memset(fdrv_common.cmdTx, 0, cmd->size);
-	fdrv_common.cmdTx[0] = cmd->opCode;
-	fdrv_common.cmdTx[1] = (offs >> 16) & 0xff;
-	fdrv_common.cmdTx[2] = (offs >> 8) & 0xff;
-	fdrv_common.cmdTx[3] = offs & 0xff;
+	memset(fdrv_common.regs[id].cmdTx, 0, cmd->size);
+	fdrv_common.regs[id].cmdTx[0] = cmd->opCode;
+	fdrv_common.regs[id].cmdTx[1] = (offs >> 16) & 0xff;
+	fdrv_common.regs[id].cmdTx[2] = (offs >> 8) & 0xff;
+	fdrv_common.regs[id].cmdTx[3] = offs & 0xff;
 }
 
 
@@ -99,6 +91,8 @@ static int flashdrv_cfiRead(flash_cfi_t *cfi)
 {
 	ssize_t res;
 	size_t cmdSz, dataSz;
+	static uint8_t cmdRx[MAX_SIZE_CMD];
+	static uint8_t cmdTx[MAX_SIZE_CMD];
 	/* RDID instruction is a generic for each flash memory */
 	flash_cmd_t cmd;
 
@@ -109,18 +103,18 @@ static int flashdrv_cfiRead(flash_cfi_t *cfi)
 	/* Size of the data which is received during cmd transfer */
 	dataSz = cmdSz - cmd.size;
 
-	memset(fdrv_common.cmdTx, 0, cmdSz);
-	fdrv_common.cmdTx[0] = cmd.opCode;
+	memset(cmdTx, 0, cmdSz);
+	cmdTx[0] = cmd.opCode;
 
 	qspi_start();
-	res = qspi_transfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmdSz, TIMEOUT_CMD_MS);
+	res = qspi_transfer(cmdTx, cmdRx, cmdSz, TIMEOUT_CMD_MS);
 	if (res < 0) {
 		qspi_stop();
 		return res;
 	}
 
 	/* Copy data received after dummy bytes */
-	memcpy(cfi, (fdrv_common.cmdRx + cmd.size), dataSz);
+	memcpy(cfi, (cmdRx + cmd.size), dataSz);
 	res = qspi_transfer(NULL, (uint8_t *)cfi + dataSz, sizeof(flash_cfi_t) - dataSz, 5 * TIMEOUT_CMD_MS);
 	qspi_stop();
 
@@ -128,7 +122,7 @@ static int flashdrv_cfiRead(flash_cfi_t *cfi)
 }
 
 
-static int flashdrv_statusRegGet(unsigned int *val)
+static int _flashdrv_statusRegGet(unsigned int id, unsigned int *val)
 {
 	ssize_t res;
 	size_t cmdSz;
@@ -137,80 +131,85 @@ static int flashdrv_statusRegGet(unsigned int *val)
 	*val = 0;
 
 	cmdSz = cmd->size + cmd->dummyCyc / 8;
-	memset(fdrv_common.cmdTx, 0, cmdSz);
+	memset(fdrv_common.regs[id].cmdTx, 0, cmdSz);
 
-	fdrv_common.cmdTx[0] = cmd->opCode;
+	fdrv_common.regs[id].cmdTx[0] = cmd->opCode;
 
 	qspi_start();
-	res = qspi_transfer(fdrv_common.cmdTx, (uint8_t *)val, cmdSz, TIMEOUT_CMD_MS);
+	res = qspi_transfer(fdrv_common.regs[id].cmdTx, (uint8_t *)val, cmdSz, TIMEOUT_CMD_MS);
 	qspi_stop();
 
 	return res;
 }
 
 
-static int flashdrv_wipCheck(time_t timeout)
+static int _flashdrv_wipCheck(unsigned int id, time_t timeout)
 {
 	int res;
 	unsigned int st;
 	time_t start = flashdrv_timeMsGet();
 
 	do {
-		res = flashdrv_statusRegGet(&st);
-		if (res < 0)
+		res = _flashdrv_statusRegGet(id, &st);
+		if (res < 0) {
 			return res;
+		}
 
-		if ((flashdrv_timeMsGet() - start) >= timeout)
+		if ((flashdrv_timeMsGet() - start) >= timeout) {
 			return -ETIME;
-
+		}
 	} while ((st >> 8) & 0x1);
 
 	return EOK;
 }
 
 
-static int flashdrv_welSet(unsigned int cmdID)
+static int _flashdrv_welSet(unsigned int id, unsigned int cmdID)
 {
 	ssize_t res;
 	const flash_cmd_t *cmd;
 
-	if (cmdID != flash_cmd_wrdi && cmdID != flash_cmd_wren)
+	if (cmdID != flash_cmd_wrdi && cmdID != flash_cmd_wren) {
 		return -EINVAL;
+	}
 
 	cmd = &fdrv_common.info.cmds[cmdID];
 
-	memset(fdrv_common.cmdTx, 0, cmd->size);
-	fdrv_common.cmdTx[0] = cmd->opCode;
+	memset(fdrv_common.regs[id].cmdTx, 0, cmd->size);
+	fdrv_common.regs[id].cmdTx[0] = cmd->opCode;
 
 	qspi_start();
-	res = qspi_transfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmd->size, TIMEOUT_CMD_MS);
+	res = qspi_transfer(fdrv_common.regs[id].cmdTx, fdrv_common.regs[id].cmdRx, cmd->size, TIMEOUT_CMD_MS);
 	qspi_stop();
 
 	return res;
 }
 
 
-static ssize_t flashdrv_pageProgram(addr_t offs, const void *buff, size_t len)
+static ssize_t _flashdrv_pageProgram(unsigned int id, addr_t offs, const void *buff, size_t len)
 {
 	ssize_t res;
 	time_t timeout;
 	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
 	const flash_cmd_t *cmd = &fdrv_common.info.cmds[flash_cmd_pp];
 
-	if (len == 0)
+	if (len == 0) {
 		return 0;
+	}
 
-	if (buff == NULL || len % CFI_SIZE_PAGE(cfi->pageSize))
+	if (buff == NULL) {
 		return -EINVAL;
+	}
 
-	res = flashdrv_welSet(flash_cmd_wren);
-	if (res < 0)
+	res = _flashdrv_welSet(id, flash_cmd_wren);
+	if (res < 0) {
 		return res;
+	}
 
-	flashdrv_initCmdBuff(cmd, offs);
+	_flashdrv_initCmdBuff(id, cmd, offs);
 
 	qspi_start();
-	res = qspi_transfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmd->size, TIMEOUT_CMD_MS);
+	res = qspi_transfer(fdrv_common.regs[id].cmdTx, fdrv_common.regs[id].cmdRx, cmd->size, TIMEOUT_CMD_MS);
 	if (res < 0) {
 		qspi_stop();
 		return res;
@@ -227,77 +226,32 @@ static ssize_t flashdrv_pageProgram(addr_t offs, const void *buff, size_t len)
 	len = res;
 
 	timeout = CFI_TIMEOUT_MAX_PROGRAM(cfi->timeoutTypical.pageWrite, cfi->timeoutMax.pageWrite) + TIMEOUT_CMD_MS;
-	res = flashdrv_wipCheck(timeout);
-	if (res < 0)
+	res = _flashdrv_wipCheck(id, timeout);
+	if (res < 0) {
 		return res;
+	}
 
 	return len;
 }
 
 
-/* Device interface */
-
-const flash_info_t *flashdrv_flashInfo(void)
-{
-	return &fdrv_common.info;
-}
-
-
-int flashdrv_sync(void)
-{
-	uint8_t *src;
-	addr_t dst;
-	ssize_t res;
-	unsigned int i, pgNb;
-
-	size_t pageSz, sectSz, regStart;
-	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
-
-	if (fdrv_common.buffPos == 0)
-		return EOK;
-
-	regStart = flashdrv_regStart(fdrv_common.regID);
-	sectSz = CFI_SIZE_SECTION(cfi->regs[fdrv_common.regID].size);
-	pageSz = CFI_SIZE_PAGE(cfi->pageSize);
-	pgNb = sectSz / pageSz;
-
-	for (i = 0; i < pgNb; ++i) {
-		dst = regStart + fdrv_common.sectID * sectSz + i * pageSz;
-		src = fdrv_common.buff + i * pageSz;
-
-		res = flashdrv_pageProgram(dst, src, pageSz);
-		if (res < 0)
-			return res;
-	}
-
-	fdrv_common.regID = (uint32_t)-1;
-	fdrv_common.sectID = (uint32_t)-1;
-	fdrv_common.buffPos = 0;
-
-	return EOK;
-}
-
-
-int flashdrv_sectorErase(addr_t offs)
+static int _flashdrv_sectorErase(unsigned int id, addr_t offs)
 {
 	ssize_t res;
-	uint32_t id = 0;
 	size_t sectorSz;
 	time_t timeout;
 	const flash_cmd_t *cmd;
 	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
 
-	if (offs >= CFI_SIZE_FLASH(cfi->chipSize))
+	if (offs >= CFI_SIZE_FLASH(cfi->chipSize)) {
 		return -EINVAL;
-
-	res = flashdrv_regionFind(offs, &id);
-	if (res < 0)
-		return res;
+	}
 
 	/* Check offset alligment */
 	sectorSz = CFI_SIZE_SECTION(cfi->regs[id].size);
-	if (offs & (sectorSz - 1))
+	if (offs & (sectorSz - 1)) {
 		return -EINVAL;
+	}
 
 	switch (sectorSz) {
 		case 0x1000:
@@ -310,14 +264,15 @@ int flashdrv_sectorErase(addr_t offs)
 			return -EINVAL;
 	}
 
-	res = flashdrv_welSet(flash_cmd_wren);
-	if (res < 0)
+	res = _flashdrv_welSet(id, flash_cmd_wren);
+	if (res < 0) {
 		return res;
+	}
 
-	flashdrv_initCmdBuff(cmd, offs);
+	_flashdrv_initCmdBuff(id, cmd, offs);
 
 	qspi_start();
-	res = qspi_transfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmd->size, TIMEOUT_CMD_MS);
+	res = qspi_transfer(fdrv_common.regs[id].cmdTx, fdrv_common.regs[id].cmdRx, cmd->size, TIMEOUT_CMD_MS);
 	if (res < 0) {
 		qspi_stop();
 		return res;
@@ -326,11 +281,11 @@ int flashdrv_sectorErase(addr_t offs)
 
 	timeout = CFI_TIMEOUT_MAX_ERASE(cfi->timeoutTypical.sectorErase, cfi->timeoutMax.sectorErase) + TIMEOUT_CMD_MS;
 
-	return flashdrv_wipCheck(timeout);
+	return _flashdrv_wipCheck(id, timeout);
 }
 
 
-int flashdrv_chipErase(void)
+static int _flashdrv_chipErase(unsigned int id)
 {
 	ssize_t res;
 	size_t cmdSz;
@@ -339,41 +294,45 @@ int flashdrv_chipErase(void)
 	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
 	const flash_cmd_t *cmd = &fdrv_common.info.cmds[flash_cmd_be];
 
-	res = flashdrv_welSet(flash_cmd_wren);
-	if (res < 0)
+	res = _flashdrv_welSet(id, flash_cmd_wren);
+	if (res < 0) {
 		return res;
+	}
 
 	cmdSz = cmd->size + cmd->dummyCyc / 8;
-	memset(fdrv_common.cmdTx, 0, cmdSz);
+	memset(fdrv_common.regs[id].cmdTx, 0, cmdSz);
 
-	fdrv_common.cmdTx[0] = cmd->opCode;
+	fdrv_common.regs[id].cmdTx[0] = cmd->opCode;
 
 	qspi_start();
-	res = qspi_transfer(fdrv_common.cmdTx, NULL, cmdSz, TIMEOUT_CMD_MS);
+	res = qspi_transfer(fdrv_common.regs[id].cmdTx, NULL, cmdSz, TIMEOUT_CMD_MS);
 	qspi_stop();
 
-	if (res < 0)
+	if (res < 0) {
 		return res;
+	}
 
 	timeout = CFI_TIMEOUT_MAX_ERASE(cfi->timeoutTypical.chipErase, cfi->timeoutMax.chipErase) + TIMEOUT_CMD_MS;
 
-	return flashdrv_wipCheck(timeout);
+	return _flashdrv_wipCheck(id, timeout);
 }
 
 
-ssize_t flashdrv_read(addr_t offs, void *buff, size_t len, time_t timeout)
+static ssize_t _flashdrv_read(unsigned int id, addr_t offs, void *buff, size_t len)
 {
 	ssize_t res;
 	size_t cmdSz, dataSz, transferSz;
 	const flash_cmd_t *cmd = &fdrv_common.info.cmds[flash_cmd_qior];
 
-	if (len == 0)
+	if (len == 0) {
 		return 0;
+	}
 
-	if (buff == NULL || (offs + len) > CFI_SIZE_FLASH(fdrv_common.info.cfi.chipSize))
+	if (buff == NULL || (offs + len) > CFI_SIZE_FLASH(fdrv_common.info.cfi.chipSize)) {
 		return -EINVAL;
+	}
 
-	flashdrv_initCmdBuff(cmd, offs);
+	_flashdrv_initCmdBuff(id, cmd, offs);
 
 	/* Cmd size is rounded to 4 bytes, it includes dummy cycles [b]. */
 	cmdSz = (cmd->size + cmd->dummyCyc / 8 + 0x3) & ~0x3;
@@ -383,141 +342,433 @@ ssize_t flashdrv_read(addr_t offs, void *buff, size_t len, time_t timeout)
 	dataSz = (transferSz > len) ? len : transferSz;
 
 	qspi_start();
-	res = qspi_transfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmdSz, TIMEOUT_CMD_MS);
+	res = qspi_transfer(fdrv_common.regs[id].cmdTx, fdrv_common.regs[id].cmdRx, cmdSz, TIMEOUT_CMD_MS);
 	if (res < 0) {
 		qspi_stop();
 		return res;
 	}
 	/* Copy data received after dummy bytes */
-	memcpy(buff, (fdrv_common.cmdRx + cmd->size + cmd->dummyCyc / 8), dataSz);
+	memcpy(buff, (fdrv_common.regs[id].cmdRx + cmd->size + cmd->dummyCyc / 8), dataSz);
 
-	res = qspi_transfer(NULL, (uint8_t *)buff + dataSz, len - dataSz, timeout);
+	res = qspi_transfer(NULL, (uint8_t *)buff + dataSz, len - dataSz, TIMEOUT_CMD_MS * len);
 	qspi_stop();
 
 	return (res < 0) ? res : (res + dataSz);
 }
 
 
-ssize_t flashdrv_write(addr_t offs, const void *buff, size_t len)
+/* Block device interface */
+
+static int _flashdrv_sync(unsigned int id, size_t regStart)
 {
+	uint8_t *src;
+	addr_t dst;
 	ssize_t res;
-	time_t timeout;
-	size_t chunkSz = 0, freeSz = 0, saveSz = 0;
-	static const uint32_t timeoutFactor = 0x100;
+	unsigned int i, pgNb;
 
-	uint32_t regID = 0, sectID = 0;
-	size_t sectSz, regStart;
-
+	size_t pageSz, sectSz;
 	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
 
-	if (len == 0)
-		return 0;
+	if (fdrv_common.regs[id].buffPos == 0) {
+		return EOK;
+	}
 
-	if (buff == NULL || (offs + len) > CFI_SIZE_FLASH(cfi->chipSize))
+	sectSz = CFI_SIZE_SECTION(cfi->regs[id].size);
+	pageSz = CFI_SIZE_PAGE(cfi->pageSize);
+	pgNb = sectSz / pageSz;
+
+	for (i = 0; i < pgNb; ++i) {
+		dst = regStart + fdrv_common.regs[id].sectID * sectSz + i * pageSz;
+		src = fdrv_common.regs[id].buff + i * pageSz;
+
+		res = _flashdrv_pageProgram(id, dst, src, pageSz);
+		if (res < 0) {
+			return res;
+		}
+	}
+
+	fdrv_common.regs[id].sectID = (uint32_t)-1;
+	fdrv_common.regs[id].buffPos = 0;
+
+	return EOK;
+}
+
+
+static ssize_t flashdrv_blkRead(struct _storage_t *strg, off_t start, void *data, size_t size)
+{
+	ssize_t res;
+
+	if ((start + size) > strg->size) {
 		return -EINVAL;
+	}
 
-	while (saveSz < len) {
-		offs += chunkSz;
+	mutexLock(fdrv_common.regs[strg->dev->id].lock);
+	res = _flashdrv_read(strg->dev->id, start + strg->start, data, size);
+	mutexUnlock(fdrv_common.regs[strg->dev->id].lock);
 
-		res = flashdrv_regionFind(offs, &regID);
-		if (res < 0)
-			return -EINVAL;
+	return res;
+}
 
-		regStart = flashdrv_regStart(regID);
-		sectSz = CFI_SIZE_SECTION(cfi->regs[regID].size);
-		sectID = (offs - regStart) / sectSz;
 
-		if (regID != fdrv_common.regID || sectID != fdrv_common.sectID) {
-			res = flashdrv_sync();
-			if (res < 0)
+static ssize_t flashdrv_blkWrite(struct _storage_t *strg, off_t start, const void *data, size_t size)
+{
+	ssize_t res;
+	size_t sectSz;
+	unsigned int sectID, regID;
+
+	size_t chunkSz = 0, freeSz = 0, saveSz = 0;
+
+	if (strg == NULL || strg->dev == NULL || (start + size) > strg->size || data == NULL) {
+		return -EINVAL;
+	}
+
+	if (size == 0) {
+		return 0;
+	}
+
+	regID = strg->dev->id;
+	sectSz = CFI_SIZE_SECTION(fdrv_common.info.cfi.regs[regID].size);
+
+	mutexLock(fdrv_common.regs[regID].lock);
+	while (saveSz < size) {
+		start += chunkSz;
+		sectID = start / sectSz;
+
+		if (sectID != fdrv_common.regs[regID].sectID) {
+			res = _flashdrv_sync(regID, strg->start);
+			if (res < 0) {
+				mutexUnlock(fdrv_common.regs[regID].lock);
 				return res;
+			}
 
-			/* Read operation timeout depends on sector size. Factor value selected empirically. */
-			timeout = (sectSz * TIMEOUT_CMD_MS) / timeoutFactor;
-			res = flashdrv_read(regStart + (sectSz * sectID), fdrv_common.buff, sectSz, timeout);
-			if (res < 0)
+			res = _flashdrv_read(regID, strg->start + (sectSz * sectID), fdrv_common.regs[regID].buff, sectSz);
+			if (res < 0) {
+				mutexUnlock(fdrv_common.regs[regID].lock);
 				return res;
+			}
 
-			res = flashdrv_sectorErase(regStart + (sectSz * sectID));
-			if (res < 0)
+			res = _flashdrv_sectorErase(regID, strg->start + (sectSz * sectID));
+			if (res < 0) {
+				mutexUnlock(fdrv_common.regs[regID].lock);
 				return res;
+			}
 
-			fdrv_common.regID = regID;
-			fdrv_common.sectID = sectID;
-			fdrv_common.buffPos = offs - regStart - (sectID * sectSz);
+			fdrv_common.regs[regID].sectID = sectID;
+			fdrv_common.regs[regID].buffPos = start - (sectID * sectSz);
 		}
 
-		freeSz = sectSz - fdrv_common.buffPos;
-		chunkSz = (freeSz > (len - saveSz)) ? (len - saveSz) : freeSz;
-		memcpy(fdrv_common.buff + fdrv_common.buffPos, (const uint8_t *)buff + saveSz, chunkSz);
+		freeSz = sectSz - fdrv_common.regs[regID].buffPos;
+		chunkSz = (freeSz > (size - saveSz)) ? (size - saveSz) : freeSz;
+		memcpy(fdrv_common.regs[regID].buff + fdrv_common.regs[regID].buffPos, (const uint8_t *)data + saveSz, chunkSz);
 
 		saveSz += chunkSz;
-		fdrv_common.buffPos += chunkSz;
+		fdrv_common.regs[regID].buffPos += chunkSz;
 
-		if (fdrv_common.buffPos < sectSz)
+		if (fdrv_common.regs[regID].buffPos < sectSz) {
 			continue;
+		}
 
-		res = flashdrv_sync();
-		if (res < 0)
+		res = _flashdrv_sync(regID, strg->start);
+		if (res < 0) {
+			mutexUnlock(fdrv_common.regs[regID].lock);
 			return res;
+		}
 	}
+	mutexUnlock(fdrv_common.regs[strg->dev->id].lock);
 
 	return saveSz;
 }
 
 
-int flashdrv_done(void)
+static int flashdrv_blkSync(struct _storage_t *strg)
 {
-	int res = EOK;
+	int res;
+
+	if (strg == NULL || strg->dev == NULL) {
+		return -EINVAL;
+	}
+
+	mutexLock(fdrv_common.regs[strg->dev->id].lock);
+	res = _flashdrv_sync(strg->dev->id, strg->start);
+	mutexUnlock(fdrv_common.regs[strg->dev->id].lock);
+
+	return res;
+}
+
+
+const static storage_blkops_t blkOps = {
+	.read = flashdrv_blkRead,
+	.write = flashdrv_blkWrite,
+	.sync = flashdrv_blkSync
+};
+
+
+/* MTD interface */
+
+static int flashdrv_mtdErase(struct _storage_t *strg, off_t offs, size_t size)
+{
+	int res;
+	size_t len = 0;
+	size_t secSz = CFI_SIZE_SECTION(fdrv_common.info.cfi.regs[strg->dev->id].size);
+
+	if ((offs == 0) && (size == CFI_SIZE_FLASH(fdrv_common.info.cfi.chipSize))) {
+		mutexLock(fdrv_common.regs[strg->dev->id].lock);
+		res = _flashdrv_chipErase(strg->dev->id);
+		mutexUnlock(fdrv_common.regs[strg->dev->id].lock);
+		return res;
+	}
+
+	mutexLock(fdrv_common.regs[strg->dev->id].lock);
+	while (len < size) {
+		res = _flashdrv_sectorErase(strg->dev->id, offs + strg->start + len);
+		if (res < 0) {
+			mutexUnlock(fdrv_common.regs[strg->dev->id].lock);
+			return res;
+		}
+
+		len += secSz;
+	}
+	mutexUnlock(fdrv_common.regs[strg->dev->id].lock);
+
+	return EOK;
+}
+
+
+static ssize_t flashdrv_mtdRead(struct _storage_t *strg, off_t offs, void *data, size_t len)
+{
+	int res;
+
+	mutexLock(fdrv_common.regs[strg->dev->id].lock);
+	res = _flashdrv_read(strg->dev->id, offs + strg->start, data, len);
+	mutexUnlock(fdrv_common.regs[strg->dev->id].lock);
+
+	return res;
+}
+
+
+static ssize_t flashdrv_mtdWrite(struct _storage_t *strg, off_t offs, const void *data, size_t len)
+{
+	ssize_t res = 0;
+	size_t tempSz = 0, chunkSz = 0;
+
+	mutexLock(fdrv_common.regs[strg->dev->id].lock);
+	chunkSz = offs % strg->dev->mtd->writeBuffsz;
+	if (chunkSz != 0) {
+		chunkSz = len < (strg->dev->mtd->writeBuffsz - chunkSz) ? len : (strg->dev->mtd->writeBuffsz - chunkSz);
+		res = _flashdrv_pageProgram(strg->dev->id, strg->start + offs, data, chunkSz);
+		if (res < 0) {
+			mutexUnlock(fdrv_common.regs[strg->dev->id].lock);
+			return res;
+		}
+
+		tempSz = res;
+	}
+
+	while (tempSz < len) {
+		chunkSz = ((len - tempSz) > strg->dev->mtd->writeBuffsz) ? strg->dev->mtd->writeBuffsz : (len - tempSz);
+		res = _flashdrv_pageProgram(strg->dev->id, strg->start + offs + tempSz, (const char *)data + tempSz, chunkSz);
+		if (res < 0) {
+			mutexUnlock(fdrv_common.regs[strg->dev->id].lock);
+			return res;
+		}
+
+		tempSz += res;
+	}
+	mutexUnlock(fdrv_common.regs[strg->dev->id].lock);
+
+	return tempSz;
+}
+
+
+const static storage_mtdops_t mtdOps = {
+	.erase = flashdrv_mtdErase,
+	.unPoint = NULL,
+	.point = NULL,
+	.read = flashdrv_mtdRead,
+	.write = flashdrv_mtdWrite,
+
+	.meta_read = NULL,
+	.meta_write = NULL,
+
+	.sync = NULL,
+	.lock = NULL,
+	.unLock = NULL,
+	.isLocked = NULL,
+
+	.block_isBad = NULL,
+	.block_isReserved = NULL,
+	.block_markBad = NULL,
+	.block_maxBadNb = NULL,
+
+	.suspend = NULL,
+	.resume = NULL,
+	.reboot = NULL,
+};
+
+
+/* Flash driver interface */
+
+int flashdrv_done(storage_t *strg)
+{
+	int i, res;
+
+	res = flashdrv_blkSync(strg);
+
+	free(fdrv_common.regs[strg->dev->id].buff);
+	fdrv_common.regs[strg->dev->id].buff = NULL;
+
+	resourceDestroy(fdrv_common.regs[strg->dev->id].lock);
+	free(strg->dev->mtd);
+	free(strg->dev->blk);
+	free(strg->dev);
+
+	for (i = 0; i < fdrv_common.info.cfi.regsCount; ++i) {
+		if (fdrv_common.regs[i].buff != NULL) {
+			return res;
+		}
+	}
+
+	fdrv_common.initRegs = 0;
+	free(fdrv_common.regs);
 
 	do {
-		res = flashdrv_sync();
 		if (res < 0) {
 			qspi_deinit();
 			break;
 		}
 
 		res = qspi_deinit();
-		if (res < 0)
+		if (res < 0) {
 			break;
+		}
 	} while (0);
-
-	free(fdrv_common.buff);
 
 	return res;
 }
 
 
-int flashdrv_init(void)
+int flashdrv_devInit(storage_t *strg)
 {
-	int i, res;
-	size_t sectorSz = 0;
+	int res;
+	flash_reg_t *reg;
+	size_t secSz;
+
+	int id = fdrv_common.initRegs;
 	flash_info_t *info = &fdrv_common.info;
 
-	fdrv_common.regID = (uint32_t)-1;
-	fdrv_common.sectID = (uint32_t)-1;
-	fdrv_common.buffPos = 0;
-
-	res = qspi_init();
-	if (res < 0)
+	/* Initialize region data */
+	reg = &fdrv_common.regs[id];
+	res = mutexCreate(&reg->lock);
+	if (res < 0) {
 		return res;
-
-	res = flashdrv_cfiRead(&info->cfi);
-	if (res < 0)
-		return res;
-
-	res = flashcfg_infoResolve(info);
-	if (res < 0)
-		return res;
-
-	for (i = 0; i < info->cfi.regsCount; ++i) {
-		if (CFI_SIZE_SECTION(info->cfi.regs[i].size) > sectorSz)
-			sectorSz = CFI_SIZE_SECTION(info->cfi.regs[i].size);
 	}
 
-	fdrv_common.buff = (uint8_t *)malloc(sectorSz);
-	if (fdrv_common.buff == NULL)
+	secSz = CFI_SIZE_SECTION(info->cfi.regs[id].size);
+	reg->buffPos = 0;
+	reg->sectID = (uint32_t)-1;
+	reg->buff = malloc(secSz);
+	if (reg->buff == NULL) {
+		resourceDestroy(reg->lock);
 		return -ENOMEM;
+	}
 
-	return EOK;
+	/* Initialize dev structure for new region */
+	strg->dev = malloc(sizeof(storage_dev_t));
+	if (strg->dev == NULL) {
+		resourceDestroy(reg->lock);
+		free(reg->buff);
+		return -ENOMEM;
+	}
+
+	/* Initialize storage device properties */
+	strg->parent = NULL;
+	strg->start = flashdrv_regStart(id);
+	strg->size = CFI_SIZE_REGION(info->cfi.regs[id].size, info->cfi.regs[id].count);
+
+	/* NOR flash driver supports MTD interface */
+	strg->dev->mtd = malloc(sizeof(storage_mtd_t));
+	if (strg->dev->mtd == NULL) {
+		resourceDestroy(reg->lock);
+		free(reg->buff);
+		free(strg->dev);
+		return -ENOMEM;
+	}
+
+/* In case of non-standard erase size, warning information is printed */
+#ifndef NDEBUG
+	if (secSz > MTD_DEFAULT_ERASESZ) {
+		printf("flashdrv: non-standard erase size, file system image properties have to be changed to suit greater size.");
+	}
+#endif
+
+	strg->dev->id = id;
+	strg->dev->mtd->ops = &mtdOps;
+	strg->dev->mtd->type = mtd_norFlash;
+	strg->dev->mtd->name = info->name;
+	strg->dev->mtd->metaSize = 0;
+	strg->dev->mtd->metaAvail = 0;
+	strg->dev->mtd->writesz = 0x1;
+	strg->dev->mtd->writeBuffsz = CFI_SIZE_PAGE(info->cfi.pageSize);
+	strg->dev->mtd->erasesz = secSz < MTD_DEFAULT_ERASESZ ? MTD_DEFAULT_ERASESZ : secSz;
+
+
+	/* NOR flash supports block device interface */
+	strg->dev->blk = malloc(sizeof(storage_blk_t));
+	if (strg->dev->blk == NULL) {
+		resourceDestroy(reg->lock);
+		free(reg->buff);
+		free(strg->dev);
+		free(strg->dev->mtd);
+		return -ENOMEM;
+	}
+	strg->dev->blk->ops = &blkOps;
+
+	fdrv_common.initRegs++;
+
+	return (info->cfi.regsCount - fdrv_common.initRegs);
+}
+
+
+int flashdrv_init(storage_t *strg)
+{
+	int res;
+
+	if (strg == NULL) {
+		return -EINVAL;
+	}
+
+	/* Initialize driver components - performs only once */
+	if (fdrv_common.initRegs == 0) {
+		res = qspi_init();
+		if (res < 0) {
+			return res;
+		}
+
+		res = flashdrv_cfiRead(&fdrv_common.info.cfi);
+		if (res < 0) {
+			return res;
+		}
+
+		res = flashcfg_infoResolve(&fdrv_common.info);
+		if (res < 0) {
+			return res;
+		}
+
+		fdrv_common.regs = malloc(fdrv_common.info.cfi.regsCount * sizeof(flash_reg_t));
+		if (fdrv_common.regs == NULL) {
+			return -ENOMEM;
+		}
+	}
+
+	/* All regions are initialized */
+	if (fdrv_common.initRegs >= fdrv_common.info.cfi.regsCount) {
+		return 0;
+	}
+
+	res = flashdrv_devInit(strg);
+	if (res < 0) {
+		free(fdrv_common.regs);
+	}
+
+	return res;
 }

--- a/storage/zynq7000-flash/flashdrv.h
+++ b/storage/zynq7000-flash/flashdrv.h
@@ -14,44 +14,21 @@
 #ifndef _FLASH_DRIVER_H_
 #define _FLASH_DRIVER_H_
 
-#include "flashcfg.h"
 #include <stdint.h>
-
-
-/* Get information about flash memory properties based on CFI (Common Flash Interface) */
-const flash_info_t *flashdrv_flashInfo(void);
-
-
-/* Force writing data keeping in cache buffer to flash memory, returns 0 on success <0 on error */
-int flashdrv_sync(void);
-
-
-/* Erase single sector. 'offs' argument has to be align to sector size, returns 0 on success <0 on error */
-int flashdrv_sectorErase(addr_t offs);
-
-
-/* Erase the whole flash memory, returns 0 on success <0 on error */
-int flashdrv_chipErase(void);
-
-
-/* Below read/write operations return:
- *   >0 read/written data length
- *  -EINVAL - wrong args,
- *  -ETIMEDOUT - timed out waiting for the transfer to succeed */
-
-/* Read data from the given address on flash memory */
-ssize_t flashdrv_read(addr_t offs, void *buff, size_t len, time_t timeout);
-
-
-/* Write data to the given address on flash memory */
-ssize_t flashdrv_write(addr_t offs, const void *buff, size_t len);
+#include <storage/storage.h>
+#include <mtd/mtd.h>
 
 
 /* Clean up flash memory driver, returns 0 on success <0 on error */
-int flashdrv_done(void);
+extern int flashdrv_done(storage_t *strg);
 
 
-/* Initialize flash memory, returns 0 on success <0 on error */
-int flashdrv_init(void);
+/* Initialize only a one physicall flash memory via qspi interface, returns:
+    - >0 - number of remaining logic devices for initialization (in case where there are multiple regions)
+    - <0 - on error
+    - 0  - all logic devices are initialized
+*/
+extern int flashdrv_init(storage_t *strg);
+
 
 #endif

--- a/storage/zynq7000-flash/tests/Makefile
+++ b/storage/zynq7000-flash/tests/Makefile
@@ -9,6 +9,6 @@
 NAME := test_flashdrv
 LOCAL_SRCS := flashdrv.c
 DEP_LIBS := libflashdrv-zynq
-LIBS := unity
+LIBS := unity libstorage
 
 include $(binary.mk)

--- a/storage/zynq7000-flash/tests/flashdrv.c
+++ b/storage/zynq7000-flash/tests/flashdrv.c
@@ -26,7 +26,7 @@ struct {
 	uint8_t *rxBuff;
 	size_t buffSz;
 
-	const flash_info_t *info;
+	idtree_t strgs;
 } common;
 
 
@@ -45,20 +45,19 @@ static inline void test_initBuffs(size_t sz)
 }
 
 
-static void test_writeSyncVerify(addr_t offs, size_t sz)
+static void test_writeSyncVerify(storage_t *strg, addr_t offs, size_t sz)
 {
 	/* Prepare sample data to write */
 	test_initBuffs(sz);
 
 	/* Write */
-	TEST_ASSERT_GREATER_OR_EQUAL_INT32_MESSAGE(offs + sz, CFI_SIZE_FLASH(common.info->cfi.chipSize), "wrong offset");
-	TEST_ASSERT_EQUAL(sz, flashdrv_write(offs, common.txBuff, sz));
+	TEST_ASSERT_EQUAL(sz, strg->dev->blk->ops->write(strg, offs, common.txBuff, sz));
 
 	/* Synchronize */
-	TEST_ASSERT_EQUAL(EOK, flashdrv_sync());
+	TEST_ASSERT_EQUAL(EOK, strg->dev->blk->ops->sync(strg));
 
 	/* Verify */
-	TEST_ASSERT_EQUAL(sz, flashdrv_read(offs, common.rxBuff, sz, 0));
+	TEST_ASSERT_EQUAL(sz, strg->dev->blk->ops->read(strg, offs, common.rxBuff, sz));
 	TEST_ASSERT_EQUAL_UINT8_ARRAY(common.txBuff, common.rxBuff, sz);
 	if (sz < common.buffSz)
 		TEST_ASSERT_EQUAL(VALUE_DEFAULT_SAMPLE, common.rxBuff[sz]);
@@ -67,27 +66,40 @@ static void test_writeSyncVerify(addr_t offs, size_t sz)
 
 /* Setup */
 
-TEST_GROUP(test_flashdrv);
+TEST_GROUP(test_flashblk);
 
 
-TEST_SETUP(test_flashdrv)
+TEST_SETUP(test_flashblk)
 {
-	int i;
-	size_t sz;
+	int fdrvRes;
+	storage_t *strg;
+
+	common.txBuff = NULL;
+	common.rxBuff = NULL;
+	common.buffSz = SIZE_DEFAULT_BUFF;
+	idtree_init(&common.strgs);
 
 	/* Initialize flash memory */
-	TEST_ASSERT_EQUAL(EOK, flashdrv_init());
+	do {
+		strg = calloc(1, sizeof(storage_t));
+		TEST_ASSERT_NOT_NULL(strg);
 
-	common.info = flashdrv_flashInfo();
-	common.buffSz = SIZE_DEFAULT_BUFF;
+		fdrvRes = flashdrv_init(strg);
+		TEST_ASSERT_GREATER_OR_EQUAL(0, fdrvRes);
 
-	/* Find max sector size */
-	for (i = 0; i < common.info->cfi.regsCount; ++i) {
-		sz = CFI_SIZE_SECTION(common.info->cfi.regs[i].size);
+		TEST_ASSERT_NOT_NULL(strg->dev);
+		TEST_ASSERT_NOT_NULL(strg->dev->blk);
+		TEST_ASSERT_NOT_NULL(strg->dev->blk->ops);
+		TEST_ASSERT_NOT_NULL(strg->dev->blk->ops->sync);
+		TEST_ASSERT_NOT_NULL(strg->dev->blk->ops->write);
+		TEST_ASSERT_NOT_NULL(strg->dev->blk->ops->read);
 
-		if (sz > common.buffSz)
-			common.buffSz = sz;
-	}
+		idtree_alloc(&common.strgs, &strg->node);
+
+		/* Find max sector size */
+		if (strg->size > common.buffSz)
+			common.buffSz = strg->size;
+	} while (fdrvRes > 0);
 
 	/* Initialize buffers */
 	common.rxBuff = malloc(common.buffSz);
@@ -98,297 +110,281 @@ TEST_SETUP(test_flashdrv)
 }
 
 
-TEST_TEAR_DOWN(test_flashdrv)
+TEST_TEAR_DOWN(test_flashblk)
 {
+	rbnode_t *node;
+	storage_t *strg;
+
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
+
+		flashdrv_done(strg);
+		idtree_remove(&common.strgs, &strg->node);
+
+		free(strg);
+	}
+
 	free(common.rxBuff);
 	free(common.txBuff);
-
-	TEST_ASSERT_EQUAL(EOK, flashdrv_done());
 }
 
 
 /* Test info about flash */
 
-TEST(test_flashdrv, info_validate)
+TEST(test_flashblk, info_blk)
 {
-	TEST_ASSERT_NOT_NULL(common.info->name);
-	TEST_ASSERT_NOT_EQUAL(0, common.info->cfi.chipSize);
-	TEST_ASSERT_NOT_EQUAL(0, common.info->cfi.pageSize);
-	TEST_ASSERT_NOT_EQUAL(0, common.info->cfi.regsCount);
+	rbnode_t *node;
+	storage_t *strg;
+
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
+
+		TEST_ASSERT_NOT_EQUAL(0, strg->size);
+	}
 }
 
 
 /* Test read operation */
 
-TEST(test_flashdrv, read_toInvalBuff)
+TEST(test_flashblk, read_toInvalBuff)
 {
-	TEST_ASSERT_EQUAL(-EINVAL, flashdrv_read(0, NULL, 0x1000, 0));
-}
+	rbnode_t *node;
+	storage_t *strg;
 
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
 
-TEST(test_flashdrv, read_fromInvalOffs)
-{
-	TEST_ASSERT_EQUAL(-EINVAL, flashdrv_read(CFI_SIZE_FLASH(common.info->cfi.chipSize), common.txBuff, 0x1, 0));
-}
-
-
-/* Test erase operations */
-
-TEST(test_flashdrv, erase_invalOffs)
-{
-	int i = 0;
-	addr_t offs;
-	size_t sz = 0, regSz = 0;
-
-	/* Check wrong section alligment */
-	for (i = 0; i < common.info->cfi.regsCount; ++i) {
-		regSz += CFI_SIZE_REGION(common.info->cfi.regs[i].size, common.info->cfi.regs[i].count);
-		sz = CFI_SIZE_SECTION(common.info->cfi.regs[i].size);
-
-		/* Offset in the quarter of sector */
-		offs = regSz - sz + (sz / 4);
-		TEST_ASSERT_EQUAL(-EINVAL, flashdrv_sectorErase(offs));
+		TEST_ASSERT_EQUAL(-EINVAL, strg->dev->blk->ops->read(strg, 0, NULL, 0x1000));
 	}
 }
 
 
-TEST(test_flashdrv, erase_outOfMem)
+TEST(test_flashblk, read_fromInvalOffs)
 {
-	/* Erase out of flash memory range */
-	TEST_ASSERT_EQUAL(-EINVAL, flashdrv_sectorErase(CFI_SIZE_FLASH(common.info->cfi.chipSize)));
-}
+	rbnode_t *node;
+	storage_t *strg;
 
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
 
-TEST(test_flashdrv, erase_sector)
-{
-	addr_t offs;
-	size_t sz;
-
-	/* Sample offset in nor flash memory */
-	sz = CFI_SIZE_SECTION(common.info->cfi.regs[0].size);
-	offs = (common.info->cfi.regs[0].count - 1) * sz;
-
-	/* Prepare sample data to write */
-	test_initBuffs(sz);
-
-	TEST_ASSERT_EQUAL(sz, flashdrv_write(offs, common.txBuff, sz));
-	TEST_ASSERT_EQUAL(EOK, flashdrv_sectorErase(offs));
-	TEST_ASSERT_EQUAL(sz, flashdrv_read(offs, common.rxBuff, sz, 0));
-	TEST_ASSERT_EACH_EQUAL_UINT8(0xff, common.rxBuff, sz);
-}
-
-
-TEST(test_flashdrv, erase_chip)
-{
-	int i;
-	addr_t offs[3];
-	static const size_t sz = 0x1000;
-
-	offs[0] = 0;
-	offs[1] = CFI_SIZE_FLASH(common.info->cfi.chipSize) / 2;
-	offs[2] = CFI_SIZE_FLASH(common.info->cfi.chipSize) - sz;
-
-	/* Write data at begin, in the middle and at the end of memory */
-	for (i = 0; i < (sizeof(offs) / sizeof(offs[0])); ++i)
-		test_writeSyncVerify(offs[i], sz);
-
-	/* Erase the whole memory */
-	TEST_ASSERT_EQUAL(EOK, flashdrv_chipErase());
-
-	/* Check if data is erased at begin, in the middle and at the end of memory */
-	for (i = 0; i < (sizeof(offs) / sizeof(offs[0])); ++i) {
-		TEST_ASSERT_EQUAL(sz, flashdrv_read(offs[i], common.rxBuff, sz, 0));
-		TEST_ASSERT_EACH_EQUAL_UINT8(0xff, common.rxBuff, sz);
+		TEST_ASSERT_EQUAL(-EINVAL, strg->dev->blk->ops->read(strg, strg->size, common.txBuff, 0x1));
 	}
 }
 
 
 /* Test write & read operations */
 
-TEST(test_flashdrv, write_outOfRange)
+TEST(test_flashblk, write_outOfRange)
 {
-	TEST_ASSERT_EQUAL(-EINVAL, flashdrv_write(CFI_SIZE_FLASH(common.info->cfi.chipSize), common.txBuff, 0x1));
-}
+	rbnode_t *node;
+	storage_t *strg;
 
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
 
-TEST(test_flashdrv, write_fromInvalBuff)
-{
-	TEST_ASSERT_EQUAL(-EINVAL, flashdrv_write(0, NULL, 0x1000));
-}
-
-
-TEST(test_flashdrv, write_flashSync)
-{
-	addr_t offs;
-	size_t sectorSz, sz;
-
-	/* Set sample offset in nor flash memory */
-	sectorSz = CFI_SIZE_SECTION(common.info->cfi.regs[0].size);
-	offs = (common.info->cfi.regs[0].count - 1) * sectorSz;
-	sz = sectorSz - (sectorSz / 4);
-
-	/* Data size is not equal sector size, using flashdrv_sync data should be flashed */
-	test_writeSyncVerify(offs, sz);
-}
-
-
-TEST(test_flashdrv, write_flashNonSync)
-{
-	addr_t offs;
-	size_t sectorSz, sz;
-
-	/* Sample offset in nor flash memory */
-	sectorSz = CFI_SIZE_SECTION(common.info->cfi.regs[0].size);
-	sz = sectorSz - sectorSz / 4;
-	offs = (common.info->cfi.regs[0].count - 1) * sectorSz;
-
-	/* Prepare sample data to write */
-	test_initBuffs(sz);
-
-	/* Data size is not equal sector size, without flashdrv_sync data should not be flashed */
-	TEST_ASSERT_GREATER_OR_EQUAL_INT32_MESSAGE(offs + sz, CFI_SIZE_FLASH(common.info->cfi.chipSize), "wrong offset");
-	TEST_ASSERT_EQUAL(sz, flashdrv_write(offs, common.txBuff, sz));
-	TEST_ASSERT_EQUAL(sz, flashdrv_read(offs, common.rxBuff, sz, 0));
-	TEST_ASSERT_EQUAL(-EINVAL, memcmp(common.rxBuff, common.txBuff, sz) != 0 ? -EINVAL : 0);
-}
-
-
-TEST(test_flashdrv, write_smallSectorSz)
-{
-	int i;
-	addr_t offs;
-	size_t sz = 0, minSz = (size_t)-1;
-
-	/* Find min section size */
-	for (i = 0; i < common.info->cfi.regsCount; ++i) {
-		sz = CFI_SIZE_SECTION(common.info->cfi.regs[i].size);
-
-		if (sz < minSz)
-			minSz = sz;
+		TEST_ASSERT_EQUAL(-EINVAL, strg->dev->blk->ops->write(strg, strg->size, common.txBuff, 0x1));
 	}
-
-	/* Sample offset in nor flash memory */
-	offs = 14 * minSz;
-
-	/* Data size might not be equaled sector size, using flashdrv_sync data should be flashed */
-	test_writeSyncVerify(offs, sz);
 }
 
 
-TEST(test_flashdrv, write_bigSectorSz)
+TEST(test_flashblk, write_fromInvalBuff)
 {
-	int i;
-	addr_t offs;
-	size_t sz = 0, maxSz = 0;
+	rbnode_t *node;
+	storage_t *strg;
 
-	/* Find max sector size */
-	for (i = 0; i < common.info->cfi.regsCount; ++i) {
-		sz = CFI_SIZE_SECTION(common.info->cfi.regs[i].size);
-		if (sz > maxSz)
-			maxSz = sz;
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
+
+		TEST_ASSERT_EQUAL(-EINVAL, strg->dev->blk->ops->write(strg, 0, NULL, 0x1000));
 	}
-
-	/* Sample offset in nor flash memory */
-	offs = 20 * maxSz;
-
-	/* Data size might not be equaled sector size, using flashdrv_sync data should be flashed */
-	test_writeSyncVerify(offs, sz);
 }
 
 
-TEST(test_flashdrv, write_smallChunks)
+TEST(test_flashblk, write_flashSync)
+{
+	rbnode_t *node;
+	storage_t *strg;
+
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
+
+		/* Data size and offset are not aligned to typicall values */
+		test_writeSyncVerify(strg, 417, 373);
+	}
+}
+
+
+TEST(test_flashblk, write_flashNonSync)
+{
+	addr_t offs = 317;
+	size_t sz = 47;
+
+	rbnode_t *node;
+	storage_t *strg;
+
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
+
+		/* Prepare sample data to write */
+		test_initBuffs(sz);
+
+		/* Data size is not equal sector size, without sync data should not be flashed */
+		TEST_ASSERT_EQUAL(sz, strg->dev->blk->ops->write(strg, offs, common.txBuff, sz));
+		TEST_ASSERT_EQUAL(sz, strg->dev->blk->ops->read(strg, offs, common.rxBuff, sz));
+		TEST_ASSERT_EQUAL(-EINVAL, memcmp(common.rxBuff, common.txBuff, sz) != 0 ? -EINVAL : 0);
+	}
+}
+
+
+TEST(test_flashblk, write_smallSectorSz)
+{
+	addr_t offs;
+	rbnode_t *node;
+	storage_t *strg;
+	static const size_t sz = 0x1000; /* The smallest sector size for NOR flash memories */
+
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
+
+		/* Sample offset in nor flash memory */
+		offs = 10 * sz;
+
+		/* Data size might not be equaled sector size, using flashdrv_sync data should be flashed */
+		test_writeSyncVerify(strg, offs, sz);
+	}
+}
+
+
+TEST(test_flashblk, write_bigSectorSz)
+{
+	addr_t offs;
+	rbnode_t *node;
+	storage_t *strg;
+	static const size_t sz = 0x10000;
+
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
+
+		/* Sample offset in nor flash memory */
+		offs = 7 * sz;
+		/* Skip small regions */
+		if (offs > strg->size)
+			continue;
+
+		/* Data size might not be equaled sector size, using flashdrv_sync data should be flashed */
+		test_writeSyncVerify(strg, offs, sz);
+	}
+}
+
+
+TEST(test_flashblk, write_smallChunks)
 {
 	int i;
 	static const int offs = 0x100;
 	static const size_t sz = 0x20;
 
-	/* Check different length of input buffer to verify correct interpretation of dummy bytes */
-	for (i = 1; i < sz; i++)
-		test_writeSyncVerify(offs, i);
-}
+	rbnode_t *node;
+	storage_t *strg;
 
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
 
-TEST(test_flashdrv, write_bigChunk)
-{
-	size_t flashSz = CFI_SIZE_FLASH(common.info->cfi.chipSize);
-	addr_t offs = flashSz / 4;
-
-	/* Test SIZE_DEFAULT_BUFF data length */
-	test_writeSyncVerify(offs, SIZE_DEFAULT_BUFF);
-}
-
-
-TEST(test_flashdrv, write_pageAtBegin)
-{
-	/* Write and verify page size at the beginning of memory */
-	test_writeSyncVerify(0, CFI_SIZE_PAGE(common.info->cfi.pageSize));
-}
-
-
-TEST(test_flashdrv, write_atEnd)
-{
-	static const size_t sz = 0x1000;
-	addr_t offs = CFI_SIZE_FLASH(common.info->cfi.chipSize) - sz;
-
-	/* Write and verify page size at the end of memory */
-	test_writeSyncVerify(offs, sz);
-}
-
-
-TEST(test_flashdrv, write_betweenSectors)
-{
-	size_t sz = CFI_SIZE_SECTION(common.info->cfi.regs[0].size);
-	addr_t offs = sz * 2 + sz / 2;
-
-	test_writeSyncVerify(offs, sz);
-}
-
-
-TEST(test_flashdrv, write_betweenRegions)
-{
-	addr_t offs;
-	size_t sz;
-
-	/* Verify writing data between regions */
-	if (common.info->cfi.regsCount != 1) {
-		sz = CFI_SIZE_SECTION(common.info->cfi.regs[0].size);
-		offs = CFI_SIZE_REGION(common.info->cfi.regs[0].size, common.info->cfi.regs[0].count) - (sz / 2);
-
-		test_writeSyncVerify(offs, sz);
+		/* Check different length of input buffer to verify correct interpretation of dummy bytes */
+		for (i = 1; i < sz; i++)
+			test_writeSyncVerify(strg, offs, i);
 	}
 }
 
 
-TEST_GROUP_RUNNER(test_flashdrv)
+TEST(test_flashblk, write_bigChunk)
 {
-	RUN_TEST_CASE(test_flashdrv, info_validate);
+	addr_t offs;
+	rbnode_t *node;
+	storage_t *strg;
 
-	RUN_TEST_CASE(test_flashdrv, read_toInvalBuff);
-	RUN_TEST_CASE(test_flashdrv, read_fromInvalOffs);
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
+		offs = strg->size / 4;
 
-	RUN_TEST_CASE(test_flashdrv, erase_invalOffs);
-	RUN_TEST_CASE(test_flashdrv, erase_outOfMem);
-	RUN_TEST_CASE(test_flashdrv, erase_sector);
-	RUN_TEST_CASE(test_flashdrv, erase_chip);
+		/* Test SIZE_DEFAULT_BUFF data length */
+		test_writeSyncVerify(strg, offs, SIZE_DEFAULT_BUFF);
+	}
+}
 
-	RUN_TEST_CASE(test_flashdrv, write_outOfRange);
-	RUN_TEST_CASE(test_flashdrv, write_fromInvalBuff);
-	RUN_TEST_CASE(test_flashdrv, write_flashSync);
-	RUN_TEST_CASE(test_flashdrv, write_flashNonSync);
-	RUN_TEST_CASE(test_flashdrv, write_smallSectorSz);
-	RUN_TEST_CASE(test_flashdrv, write_bigSectorSz);
-	RUN_TEST_CASE(test_flashdrv, write_smallChunks);
-	RUN_TEST_CASE(test_flashdrv, write_bigChunk);
-	RUN_TEST_CASE(test_flashdrv, write_pageAtBegin);
-	RUN_TEST_CASE(test_flashdrv, write_atEnd);
-	RUN_TEST_CASE(test_flashdrv, write_betweenSectors);
-	RUN_TEST_CASE(test_flashdrv, write_betweenRegions);
+
+TEST(test_flashblk, write_pageAtBegin)
+{
+	rbnode_t *node;
+	storage_t *strg;
+
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
+
+		/* Write and verify page size at the beginning of memory */
+		test_writeSyncVerify(strg, 0, 0x200);
+	}
+}
+
+
+TEST(test_flashblk, write_atEnd)
+{
+	addr_t offs;
+	rbnode_t *node;
+	storage_t *strg;
+	static const size_t sz = 0x1000;
+
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
+		offs = strg->size - sz;
+
+		/* Write and verify page size at the end of memory */
+		test_writeSyncVerify(strg, offs, sz);
+	}
+}
+
+
+TEST(test_flashblk, write_betweenSectors)
+{
+	size_t sz;
+	rbnode_t *node;
+	storage_t *strg;
+
+	for (node = lib_rbMinimum(common.strgs.root); node != NULL; node = lib_rbNext(node)) {
+		strg = lib_treeof(storage_t, node, node);
+
+		sz = 0x1000;
+		test_writeSyncVerify(strg, sz / 2, sz);
+
+		sz = 0x10000;
+		test_writeSyncVerify(strg, sz / 2, sz);
+	}
+}
+
+
+TEST_GROUP_RUNNER(test_flashblk)
+{
+	RUN_TEST_CASE(test_flashblk, info_blk);
+
+	RUN_TEST_CASE(test_flashblk, read_toInvalBuff);
+	RUN_TEST_CASE(test_flashblk, read_fromInvalOffs);
+
+	RUN_TEST_CASE(test_flashblk, write_outOfRange);
+	RUN_TEST_CASE(test_flashblk, write_fromInvalBuff);
+	RUN_TEST_CASE(test_flashblk, write_flashSync);
+	RUN_TEST_CASE(test_flashblk, write_flashNonSync);
+	RUN_TEST_CASE(test_flashblk, write_smallSectorSz);
+	RUN_TEST_CASE(test_flashblk, write_bigSectorSz);
+	RUN_TEST_CASE(test_flashblk, write_smallChunks);
+	RUN_TEST_CASE(test_flashblk, write_bigChunk);
+	RUN_TEST_CASE(test_flashblk, write_pageAtBegin);
+	RUN_TEST_CASE(test_flashblk, write_atEnd);
+	RUN_TEST_CASE(test_flashblk, write_betweenSectors);
 }
 
 
 void runner(void)
 {
-	RUN_TEST_GROUP(test_flashdrv);
+	RUN_TEST_GROUP(test_flashblk);
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- change default sector size for Micron n25q128 to run jffs2,
- add MTD and block device interface for flash driver,
- update tests after changes in flash driver.

More detailed information is provided in commit message.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (zedboard, zynq7000-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-build/pull/109).
- [x] I will merge this PR by myself when appropriate.
