### PR TITLE
imx6ull-flashnor: add driver initialization info

### DIFF
--- a/storage/imx6ull-flashnor/flashnor-ecspi.h
+++ b/storage/imx6ull-flashnor/flashnor-ecspi.h
@@ -22,7 +22,7 @@
 extern ssize_t flashnor_ecspiRead(unsigned int addr, void *buff, size_t bufflen);
 
 
-extern ssize_t flashnor_ecspiWrite(unsigned int addr, void *buff, size_t bufflen);
+extern ssize_t flashnor_ecspiWrite(unsigned int addr, const void *buff, size_t bufflen);
 
 
 extern int flashnor_ecspiEraseSector(unsigned int addr);

--- a/storage/imx6ull-flashnor/flashnor.c
+++ b/storage/imx6ull-flashnor/flashnor.c
@@ -291,6 +291,8 @@ int main(int argc, char *argv[])
 	}
 
 	kill(getppid(), SIGUSR1);
+	printf("imx6ull-flashnor: initialized\n");
+
 	storage_run(1, 4 * 4096);
 
 	return EOK;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added printing NOR device info (JEDEC ID, chip name and size).
![norinfo](https://user-images.githubusercontent.com/8835317/167161123-eb4d3ebf-c0e1-4618-8c75-27b136771b50.png)

Added missing `const` qualifier for `buff` parameter in `flashnor_ecspiWrite()`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-302](https://jira.phoenix-rtos.com/browse/DTR-302)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
