### PR TITLE
storage/nandflashdrv: add new fields to flashdrv_info_t

### DIFF
--- a/storage/imx6ull-flash/flashdrv.c
+++ b/storage/imx6ull-flash/flashdrv.c
@@ -1006,6 +1006,8 @@ static void setup_flash_info(void)
 		flashdrv_common.info.writesz = 4096u;
 		flashdrv_common.info.metasz = 256u;
 		flashdrv_common.info.erasesz = 4096u * 64;
+		flashdrv_common.info.oobsz = 16;
+		flashdrv_common.info.oobavail = 16;
 	}
 	else if (flash_id->manufacturerid == 0x2c && flash_id->deviceid == 0xd3) {
 		flashdrv_common.info.name = "Micron MT29F8G 8Gbit NAND";
@@ -1013,6 +1015,8 @@ static void setup_flash_info(void)
 		flashdrv_common.info.writesz = 4096u;
 		flashdrv_common.info.metasz = 224u;
 		flashdrv_common.info.erasesz = 4096u * 64;
+		flashdrv_common.info.oobsz = 16;
+		flashdrv_common.info.oobavail = 16;
 	}
 	else {
 		/* use sane defaults */
@@ -1021,6 +1025,8 @@ static void setup_flash_info(void)
 		flashdrv_common.info.writesz = 4096u;
 		flashdrv_common.info.metasz = 224u;
 		flashdrv_common.info.erasesz = 4096u * 64;
+		flashdrv_common.info.oobsz = 16;
+		flashdrv_common.info.oobavail = 16;
 	}
 
 	flashdrv_dmadestroy(dma);

--- a/storage/imx6ull-flash/imx6ull-flashdrv.h
+++ b/storage/imx6ull-flash/imx6ull-flashdrv.h
@@ -52,10 +52,12 @@ typedef struct {
 /* information about NAND flash configuration */
 typedef struct {
 	const char *name;
-	uint64_t size;    /* total NAND size in bytes */
-	uint32_t writesz; /* write page DATA size in bytes */
-	uint32_t metasz;  /* write page METADATA size in bytes */
-	uint32_t erasesz; /* erase block size in bytes (multiply of writesize) */
+	uint64_t size;     /* total NAND size in bytes */
+	uint32_t writesz;  /* write page DATA size in bytes */
+	uint32_t metasz;   /* write page METADATA size in bytes */
+	uint32_t erasesz;  /* erase block size in bytes (multiply of writesize) */
+	uint32_t oobsz;    /* out-of-bound (oob) data size */
+	uint32_t oobavail; /* available out-of-bound (oob) data size */
 } flashdrv_info_t;
 
 /* paddr: page address, so NAND address / writesz */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - out-of-bound (oob) size & available size are needed for MTD interface

DTR-102

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
