### PR TITLE
imx6ull-flash/flashdev: remove error checking from _flashmtd_errRead

### DIFF
--- a/storage/imx6ull-flash/flashdev.c
+++ b/storage/imx6ull-flash/flashdev.c
@@ -110,13 +110,13 @@ static int flashmtd_erase(struct _storage_t *strg, off_t offs, size_t size)
 
 		res = flashdrv_isbad(strg->dev->ctx->dma, pageID);
 		if (res != 0) {
-			printf("flashmtd_erase: skipping bad block: %lld\n", eb);
+			printf("flashmtd_erase: skipping bad block: %u\n", eb);
 			continue;
 		}
 
 		res = flashdrv_erase(strg->dev->ctx->dma, pageID);
 		if (res < 0) {
-			printf("flashmtd_erase: error while erasing block: %lld - marking as badblock", eb);
+			printf("flashmtd_erase: error while erasing block: %u - marking as badblock", eb);
 			res = flashdrv_markbad(strg->dev->ctx->dma, pageID);
 			if (res < 0) {
 				mutexUnlock(strg->dev->ctx->lock);
@@ -227,9 +227,7 @@ static ssize_t flashmtd_metaRead(struct _storage_t *strg, off_t offs, void *data
 		/* TODO: should we skip badblocks ? */
 		res = flashdrv_read(strg->dev->ctx->dma, offs / strg->dev->mtd->writesz, NULL, strg->dev->ctx->metabuf);
 		err = _flashmtd_errRead(res, strg->dev->ctx->metabuf, err, strg->dev->ctx->databuf);
-		if (err < 0) {
-			break;
-		}
+		/* TODO: handle error from _flashmtd_errRead */
 
 		chunksz = len > strg->dev->mtd->oobSize ? strg->dev->mtd->oobSize : len;
 		memcpy((unsigned char *)data + tempsz, strg->dev->ctx->metabuf, chunksz);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
additional:
 - fixing logs

DTR-102

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
