### PR TITLE
zynq7000-flash: add strg->start to flash server in ops invocations

### DIFF
--- a/storage/zynq7000-flash/flashdrv.c
+++ b/storage/zynq7000-flash/flashdrv.c
@@ -39,6 +39,7 @@ typedef struct {
 	uint8_t cmdTx[MAX_SIZE_CMD];
 
 	handle_t lock;
+	off_t start;
 } flash_reg_t;
 
 
@@ -359,7 +360,7 @@ static ssize_t _flashdrv_read(unsigned int id, addr_t offs, void *buff, size_t l
 
 /* Block device interface */
 
-static int _flashdrv_sync(unsigned int id, size_t regStart)
+static int _flashdrv_sync(unsigned int id)
 {
 	uint8_t *src;
 	addr_t dst;
@@ -378,7 +379,7 @@ static int _flashdrv_sync(unsigned int id, size_t regStart)
 	pgNb = sectSz / pageSz;
 
 	for (i = 0; i < pgNb; ++i) {
-		dst = regStart + fdrv_common.regs[id].sectID * sectSz + i * pageSz;
+		dst = fdrv_common.regs[id].start + fdrv_common.regs[id].sectID * sectSz + i * pageSz;
 		src = fdrv_common.regs[id].buff + i * pageSz;
 
 		res = _flashdrv_pageProgram(id, dst, src, pageSz);
@@ -398,12 +399,8 @@ static ssize_t flashdrv_blkRead(struct _storage_t *strg, off_t start, void *data
 {
 	ssize_t res;
 
-	if ((start + size) > strg->size) {
-		return -EINVAL;
-	}
-
 	mutexLock(fdrv_common.regs[strg->dev->ctx->id].lock);
-	res = _flashdrv_read(strg->dev->ctx->id, start + strg->start, data, size);
+	res = _flashdrv_read(strg->dev->ctx->id, start, data, size);
 	mutexUnlock(fdrv_common.regs[strg->dev->ctx->id].lock);
 
 	return res;
@@ -414,47 +411,46 @@ static ssize_t flashdrv_blkWrite(struct _storage_t *strg, off_t start, const voi
 {
 	ssize_t res;
 	size_t sectSz;
+	off_t regOffs;
 	unsigned int sectID, regID;
 
 	size_t chunkSz = 0, freeSz = 0, saveSz = 0;
-
-	if (strg == NULL || strg->dev == NULL || (start + size) > strg->size || data == NULL) {
-		return -EINVAL;
-	}
 
 	if (size == 0) {
 		return 0;
 	}
 
 	regID = strg->dev->ctx->id;
+
+	regOffs = start - fdrv_common.regs[regID].start;
 	sectSz = CFI_SIZE_SECTION(fdrv_common.info.cfi.regs[regID].size);
 
 	mutexLock(fdrv_common.regs[regID].lock);
 	while (saveSz < size) {
-		start += chunkSz;
-		sectID = start / sectSz;
+		regOffs += chunkSz;
+		sectID = regOffs / sectSz;
 
 		if (sectID != fdrv_common.regs[regID].sectID) {
-			res = _flashdrv_sync(regID, strg->start);
+			res = _flashdrv_sync(regID);
 			if (res < 0) {
 				mutexUnlock(fdrv_common.regs[regID].lock);
 				return res;
 			}
 
-			res = _flashdrv_read(regID, strg->start + (sectSz * sectID), fdrv_common.regs[regID].buff, sectSz);
+			res = _flashdrv_read(regID, fdrv_common.regs[regID].start + (sectSz * sectID), fdrv_common.regs[regID].buff, sectSz);
 			if (res < 0) {
 				mutexUnlock(fdrv_common.regs[regID].lock);
 				return res;
 			}
 
-			res = _flashdrv_sectorErase(regID, strg->start + (sectSz * sectID));
+			res = _flashdrv_sectorErase(regID, fdrv_common.regs[regID].start + (sectSz * sectID));
 			if (res < 0) {
 				mutexUnlock(fdrv_common.regs[regID].lock);
 				return res;
 			}
 
 			fdrv_common.regs[regID].sectID = sectID;
-			fdrv_common.regs[regID].buffPos = start - (sectID * sectSz);
+			fdrv_common.regs[regID].buffPos = regOffs - (sectID * sectSz);
 		}
 
 		freeSz = sectSz - fdrv_common.regs[regID].buffPos;
@@ -468,7 +464,7 @@ static ssize_t flashdrv_blkWrite(struct _storage_t *strg, off_t start, const voi
 			continue;
 		}
 
-		res = _flashdrv_sync(regID, strg->start);
+		res = _flashdrv_sync(regID);
 		if (res < 0) {
 			mutexUnlock(fdrv_common.regs[regID].lock);
 			return res;
@@ -489,7 +485,7 @@ static int flashdrv_blkSync(struct _storage_t *strg)
 	}
 
 	mutexLock(fdrv_common.regs[strg->dev->ctx->id].lock);
-	res = _flashdrv_sync(strg->dev->ctx->id, strg->start);
+	res = _flashdrv_sync(strg->dev->ctx->id);
 	mutexUnlock(fdrv_common.regs[strg->dev->ctx->id].lock);
 
 	return res;
@@ -671,6 +667,7 @@ int flashdrv_devInit(storage_t *strg)
 	reg->buffPos = 0;
 	reg->sectID = (uint32_t)-1;
 	reg->buff = malloc(secSz);
+	reg->start = flashdrv_regStart(id);
 	if (reg->buff == NULL) {
 		resourceDestroy(reg->lock);
 		return -ENOMEM;
@@ -694,7 +691,7 @@ int flashdrv_devInit(storage_t *strg)
 
 	/* Initialize storage device properties */
 	strg->parent = NULL;
-	strg->start = flashdrv_regStart(id);
+	strg->start = reg->start;
 	strg->size = CFI_SIZE_REGION(info->cfi.regs[id].size, info->cfi.regs[id].count);
 
 	/* NOR flash driver supports MTD interface */

--- a/storage/zynq7000-flash/zynq7000-flash.c
+++ b/storage/zynq7000-flash/zynq7000-flash.c
@@ -43,14 +43,14 @@ static ssize_t flash_read(oid_t *oid, offs_t offs, void *buff, size_t len)
 	ssize_t res = -ENOSYS;
 	storage_t *strg = storage_get(GET_STORAGE_ID(oid->id));
 
-	if (strg == NULL || strg->dev == NULL) {
+	if (strg == NULL || strg->dev == NULL || (offs + len) >= strg->size) {
 		res = -EINVAL;
 	}
 	else if (strg->dev->mtd != NULL && strg->dev->mtd->ops != NULL && strg->dev->mtd->ops->read != NULL && GET_MTD_TYPE(oid->id) == MTD_CHAR) {
-		res = strg->dev->mtd->ops->read(strg, offs, buff, len);
+		res = strg->dev->mtd->ops->read(strg, strg->start + offs, buff, len);
 	}
 	else if (strg->dev->blk != NULL && strg->dev->blk->ops != NULL && strg->dev->blk->ops->read != NULL && GET_MTD_TYPE(oid->id) == MTD_BLOCK) {
-		res = strg->dev->blk->ops->read(strg, offs, buff, len);
+		res = strg->dev->blk->ops->read(strg, strg->start + offs, buff, len);
 	}
 	else {
 		res = -EINVAL;
@@ -65,14 +65,14 @@ static ssize_t flash_write(oid_t *oid, offs_t offs, const void *buff, size_t len
 	ssize_t res = -ENOSYS;
 	storage_t *strg = storage_get(GET_STORAGE_ID(oid->id));
 
-	if (strg == NULL || strg->dev == NULL) {
+	if (strg == NULL || strg->dev == NULL || (offs + len) >= strg->size) {
 		res = -EINVAL;
 	}
 	else if (strg->dev->mtd != NULL && strg->dev->mtd->ops != NULL && strg->dev->mtd->ops->write != NULL && GET_MTD_TYPE(oid->id) == MTD_CHAR) {
-		res = strg->dev->mtd->ops->write(strg, offs, buff, len);
+		res = strg->dev->mtd->ops->write(strg, strg->start + offs, buff, len);
 	}
 	else if (strg->dev->blk != NULL && strg->dev->blk->ops != NULL && strg->dev->blk->ops->write != NULL && GET_MTD_TYPE(oid->id) == MTD_BLOCK) {
-		res = strg->dev->blk->ops->write(strg, offs, buff, len);
+		res = strg->dev->blk->ops->write(strg, strg->start + offs, buff, len);
 	}
 	else {
 		res = -EINVAL;

--- a/storage/zynq7000-flash/zynq7000-flash.c
+++ b/storage/zynq7000-flash/zynq7000-flash.c
@@ -328,7 +328,7 @@ static int flash_partAdd(const char *parentPath, off_t start, size_t size)
 		return err;
 	}
 
-	strg->start = start;
+	strg->start = parent->start + start;
 	strg->size = size;
 	strg->parent = parent;
 	strg->dev = parent->dev;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- flash drv does not longer relies on strg->start which can be different than region's start
- add a parent's storage offset to the partition start

PD-216

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
