### PR TITLE
imx6ull-flash: adjust GPMI configuration, enable EDO mode (DLL)

### DIFF
--- a/storage/imx6ull-flash/flashdrv.c
+++ b/storage/imx6ull-flash/flashdrv.c
@@ -1065,8 +1065,8 @@ void flashdrv_init(void)
 	*(flashdrv_common.bch + bch_ctrl_clr) = (1 << 31);
 	*(flashdrv_common.bch + bch_ctrl_clr) = (1 << 30);
 
-	/* set address setup = 4 (20ns), data hold = 2 (10ns), data setup = 3 (15ns) */
-	*(flashdrv_common.gpmi + gpmi_timing0) = (4 << 16) | (2 << 8) | (3 << 0);
+	/* GPMI clock = 198 MHz (~5ns period), address setup = 3 (~15ns), data hold = 2 (~10ns), data setup = 3 (~15ns) */
+	*(flashdrv_common.gpmi + gpmi_timing0) = (3 << 16) | (2 << 8) | (3 << 0);
 	/* Set wait for ready timeout */
 	*(flashdrv_common.gpmi + gpmi_timing1) = 0xffff << 16;
 
@@ -1082,8 +1082,10 @@ void flashdrv_init(void)
 		*(flashdrv_common.mux + i + 94) = 0;
 	}
 
-	/* set #R/B busy-low, WP */
-	*(flashdrv_common.gpmi + gpmi_ctrl1) |= (1 << 2) | (1 << 3) | (1 << 18);
+	/* Set DECOUPLE_CS, WRN no delay, GANGED_RDYBUSY, BCH, RDN_DELAY, WP, #R/B busy-low */
+	*(flashdrv_common.gpmi + gpmi_ctrl1) = (1 << 24) | (3 << 22) | (1 << 19) | (1 << 18) | (14 << 12) | (1 << 3) | (1 << 2);
+	/* Enable DLL */
+	*(flashdrv_common.gpmi + gpmi_ctrl1_set) = (1 << 17);
 
 	interrupt(32 + 13, dma_irqHandler, NULL, flashdrv_common.dma_cond, &flashdrv_common.intdma);
 	interrupt(32 + 16, gpmi_irqHandler, NULL, 0, &flashdrv_common.intgpmi);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Adjusted GPMI timings and configuration. Applied timings were checked against supported Micron and Kioxia chips.
Clock on the NAND chip pins above 33 MHz (in our case it's ~40 MHz - GPMI clock divided by data setup and data hold cycles so 198 / (3 + 2)) allows for enabling EDO mode which slightly improves NAND read speed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-169](https://jira.phoenix-rtos.com/browse/DTR-169)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.