### PR TITLE
stm32l4-multi/tty: add RX fifo buffer written in IRQ

### DIFF
--- a/tty/imx6ull-uart/imx6ull-uart.c
+++ b/tty/imx6ull-uart/imx6ull-uart.c
@@ -13,9 +13,6 @@
  * %LICENSE%
  */
 
-#include "lf_fifo.h"
-#include "../libtty/fifo.h"
-
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -36,6 +33,7 @@
 #include <syslog.h>
 
 #include <libtty.h>
+#include <libtty-lf-fifo.h>
 #include <libklog.h>
 
 #include <phoenix/arch/imx6ull.h>

--- a/tty/libtty/Makefile
+++ b/tty/libtty/Makefile
@@ -6,5 +6,5 @@
 
 NAME := libtty
 LOCAL_SRCS := libtty.c libtty_disc.c
-LOCAL_HEADERS := libtty.h
+LOCAL_HEADERS := libtty.h libtty-lf-fifo.h
 include $(static-lib.mk)

--- a/tty/libtty/libtty-lf-fifo.h
+++ b/tty/libtty/libtty-lf-fifo.h
@@ -13,10 +13,13 @@
  * %LICENSE%
  */
 
-#ifndef _LF_FIFO_H
-#define _LF_FIFO_H
+#ifndef LIBTTY_LF_FIFO_H
+#define LIBTTY_LF_FIFO_H
 
 #include <stdint.h>
+
+/* TODO: consider merging with libtty/fifo.h */
+/* TODO: move into corelibs */
 
 typedef struct lf_fifo_s lf_fifo_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
16 byte FIFO is added between RX interrupt and tty processing thread.

## Motivation and Context
Without this change TTY driver occasionally looses RX bytes. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: stm32l4

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
