### PR TITLE
imx6ull-uart: add wait for root before create_dev()

### DIFF
--- a/tty/imx6ull-uart/imx6ull-uart.c
+++ b/tty/imx6ull-uart/imx6ull-uart.c
@@ -560,7 +560,7 @@ int main(int argc, char **argv)
 {
 	uint32_t port;
 	char uartn[sizeof("uartx") + 1];
-	oid_t dev;
+	oid_t dev, dir;
 	int err;
 	speed_t baud = B115200;
 	int parity = 0;
@@ -695,6 +695,10 @@ int main(int argc, char **argv)
 
 	dev.port = port;
 	dev.id = 0;
+
+	while (lookup("/", NULL, &dir) < 0) {
+		usleep(10000);
+	}
 
 	if ((err = create_dev(&dev, uartn)))
 		debug("imx6ull-uart: Could not create device file\n");


### PR DESCRIPTION
JIRA: PP-7

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add wait for root before create_dev() in imx6ull uart.

## Motivation and Context
When working on imx6ull devkit no /dev/ appeared without this change, thus making working with devices impossible.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
