### PR TITLE
Fixes for uart16550 driver.

### DIFF
--- a/tty/uart16550/uart16550.h
+++ b/tty/uart16550/uart16550.h
@@ -3,7 +3,7 @@
  *
  * UART 16550 device driver
  *
- * Copyright 2012-2015, 2020 Phoenix Systems
+ * Copyright 2012-2015, 2020-2022 Phoenix Systems
  * Copyright 2001, 2005, 2008 Pawel Pisarczyk
  * Author: Pawel Pisarczyk, Pawel Kolodziej
  *

--- a/tty/uart16550/uarthw-pc.c
+++ b/tty/uart16550/uarthw-pc.c
@@ -5,7 +5,7 @@
  *
  * Hardware abstracion layer (ia32-generic)
  *
- * Copyright 2020 Phoenix Systems
+ * Copyright 2020-2022 Phoenix Systems
  * Author: Julia Kosowska, Pawel Pisarczyk
  *
  * This file is part of Phoenix-RTOS.
@@ -58,18 +58,21 @@ int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz)
 		unsigned int irq;
 	} uarts[] = { { (void *)0x3f8, 4 }, { (void *)0x2f8, 3 }, { (void *)0x3e8, 4 }, { (void *)0x2e8, 3 } };
 
-	if (hwctxsz < sizeof(uarthw_ctx_t))
+	if (hwctxsz < sizeof(uarthw_ctx_t)) {
 		return -EINVAL;
+	}
 
-	if (uartn >= 4)
+	if (uartn >= 4) {
 		return -ENODEV;
+	}
 
 	((uarthw_ctx_t *)hwctx)->base = uarts[uartn].base;
 	((uarthw_ctx_t *)hwctx)->irq = uarts[uartn].irq;
 
 	/* Detect device presence */
-	if (uarthw_read(hwctx, REG_IIR) == 0xff)
+	if (uarthw_read(hwctx, REG_IIR) == 0xff) {
 		return -ENODEV;
+	}
 
 	return EOK;
 }

--- a/tty/uart16550/uarthw-riscv.c
+++ b/tty/uart16550/uarthw-riscv.c
@@ -64,7 +64,7 @@ int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz)
 	if (uartn >= 1)
 		return -ENODEV;
 
-	if ((((uarthw_ctx_t *)hwctx)->base = (uintptr_t)mmap(NULL, _PAGE_SIZE, PROT_WRITE | PROT_READ, MAP_DEVICE, OID_PHYSMEM, (offs_t)0x10000000)) == (uintptr_t)NULL)
+	if ((((uarthw_ctx_t *)hwctx)->base = (uintptr_t)mmap(NULL, _PAGE_SIZE, PROT_WRITE | PROT_READ, MAP_DEVICE, OID_PHYSMEM, (offs_t)0x10000000)) == (uintptr_t)MAP_FAILED)
 		return -ENOMEM;
 
 	((uarthw_ctx_t *)hwctx)->irq = 0xa;

--- a/tty/uart16550/uarthw.h
+++ b/tty/uart16550/uarthw.h
@@ -5,7 +5,7 @@
  *
  * Hardware abstracion layer interface
  *
- * Copyright 2020 Phoenix Systems
+ * Copyright 2020-2022 Phoenix Systems
  * Author: Pawel Pisarczyk
  *
  * This file is part of Phoenix-RTOS.


### PR DESCRIPTION
JIRA: RTOS-195 & JIRA-196

## Description

- **For JIRA RTOS-195:**

The `uart16550` device driver should create the `/dev/ttyS[0-3]` devices when it detects the presence of a device, but it did not created anything, so it was impossible to communicate with the driver.

I've assigned four serial devices in qemu (` -serial stdio -serial pty -serial pty -serial pty`), the first is on std/io the others are created as `/dev/pts/*` devices which can be nicely used in screen or tmux or to connect with `pppd` + `pppou`.

It was:
![ia32_uart16550_no_devices](https://user-images.githubusercontent.com/141153/171996223-d67fe6c9-7bda-46e5-bf8d-04edf56c4ed9.png)

With fix
![ia32_uart16550_works](https://user-images.githubusercontent.com/141153/171996369-13fa23bd-389b-4e8a-abcd-f17826d2c15e.png)

> &nbsp;
> &nbsp;

In sepparate commit the code was refactored to meet changes in coding style (MISRA rules).


- **For JIRA RTOS-196:**

The callbacks `set_baudrate()` and `set_cflags()` were implemented and tested on QEMU and real PC ISA IO card (with 16C550A chip by EXAR, now MaxLinear using standard 1.8432 MHz XTAL).
Adding link to 16550 fully compatible chip datasheet which I used for tests ([ST16C550](https://www.maxlinear.com/ds/st16c550_501_040605.pdf))

> &nbsp;
> &nbsp;
> &nbsp;
> &nbsp;

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic (4 serial ports), real pentium2 BX440 board with ISA card (using ST16C550 chip by EXAR)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x]  I will merge this PR by myself when appropriate.
