### PR TITLE
sensors: add GPS driver to sensor manager

### DIFF
--- a/_targets/Makefile.armv7a7-imx6ull
+++ b/_targets/Makefile.armv7a7-imx6ull
@@ -14,3 +14,4 @@ DEFAULT_COMPONENTS += imx6ull-uart imx6ull-otp
 DEFAULT_COMPONENTS += imx6ull-wdg imx6ull-i2c
 
 DEFAULT_COMPONENTS += libusbehci umass usbacm
+DEFAULT_COMPONENTS += libsensors sensors

--- a/sensors/Makefile
+++ b/sensors/Makefile
@@ -15,5 +15,7 @@ LOCAL_HEADERS_DIR := nothing
 LOCAL_SRCS := sensors.c
 LOCAL_SRCS += imu/lsm9dsxx.c
 LOCAL_SRCS += baro/lps25xx.c
+LOCAL_SRCS += gps/pa6h.c gps/nmea.c
+LOCAL_HEADERS += gps/nmea.h
 DEP_LIBS := libsensors libspi-msg
 include $(binary.mk)

--- a/sensors/gps/nmea.c
+++ b/sensors/gps/nmea.c
@@ -1,0 +1,369 @@
+/*
+ * Phoenix-RTOS
+ *
+ * NMEA
+ *
+ * Copyright 2022 Phoenix Systems
+ * Author: Damian Loewnau, Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <math.h>
+
+#include "nmea.h"
+
+
+/* Moves pointer to the n-th comma character in str (excluding the first character).
+ * Returns the pointer with the new value or NULL if search failed */
+static char *nmea_nField(char *str, int n)
+{
+	int i;
+
+	for (i = 0; i < n && str != NULL; i++) {
+		str = strchr(str + 1, ',');
+	}
+
+	return str;
+}
+
+
+static int nmea_parsegsa(char *str, nmea_t *out)
+{
+	char *p = str;
+	nmea_gsa_t in;
+
+	p = nmea_nField(p, field_gsa_fix);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* if failed, gsa_fix_notavailable will be assigned */
+	in.fix = strtoul(p + 1, NULL, 10);
+	if (in.fix < gsa_fix_notavailable || in.fix > gsa_fix_3d) {
+		in.fix = gsa_fix_notavailable;
+	}
+
+	p = nmea_nField(p, field_gsa_pdop - field_gsa_fix);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.pdop = strtod(p + 1, NULL);
+
+	p = nmea_nField(p, field_gsa_hdop - field_gsa_pdop);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.hdop = strtod(p + 1, NULL);
+
+	p = nmea_nField(p, field_gsa_vdop - field_gsa_hdop);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.vdop = strtod(p + 1, NULL);
+
+	out->msg.gsa = in;
+	out->type = nmea_gsa;
+
+	return nmea_gsa;
+}
+
+
+static int nmea_parsevtg(char *str, nmea_t *out)
+{
+	char *p = str;
+	nmea_vtg_t in;
+
+	p = nmea_nField(p, field_vtg_track);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.track = strtod(p + 1, NULL);
+
+	p = nmea_nField(p, field_vtg_speedknots - field_vtg_track);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.speed_knots = strtod(p + 1, NULL);
+
+	p = nmea_nField(p, field_vtg_speedkmh - field_vtg_speedknots);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.speed_kmh = strtod(p + 1, NULL);
+
+	out->msg.vtg = in;
+	out->type = nmea_vtg;
+
+	return nmea_vtg;
+}
+
+
+static int nmea_parsegga(char *str, nmea_t *out)
+{
+	char *p = str, *sign;
+	nmea_gga_t in;
+
+	/* latitude read */
+	p = nmea_nField(p, field_gga_lat);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	sign = nmea_nField(p, 1);
+	if (sign == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.lat = strtod(p + 1, NULL);
+	/* conversion from ddmm.mmmm to dd.dddd */
+	in.lat = ((int)in.lat / 100) + (in.lat - ((int)in.lat / 100) * 100) / 60;
+	in.lat = (sign[1] == 'S') ? -in.lat : in.lat;
+
+	/* longitude read */
+	p = nmea_nField(p, field_gga_lon - field_gga_lat);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	sign = nmea_nField(p, 1);
+	if (sign == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.lon = strtod(p + 1, NULL);
+	/* conversion from ddmm.mmmm to dd.dddd */
+	in.lon = ((int)in.lon / 100) + (in.lon - ((int)in.lon / 100) * 100) / 60;
+	in.lon = (sign[1] == 'W') ? -in.lon : in.lon;
+
+	/* GPS Quality indicator read */
+	p = nmea_nField(p, field_gga_fix - field_gga_lon);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+
+	in.fix = strtoul(p + 1, NULL, 10);
+	if (in.fix > gga_fix_simulation) {
+		in.fix = gga_fix_invalid;
+	}
+
+	/* number of satellites in use read */
+	p = nmea_nField(p, field_gga_sats - field_gga_fix);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.sats = strtoul(p + 1, NULL, 10);
+
+	/* horizontal dilution of precision read */
+	p = nmea_nField(p, field_gga_hdop - field_gga_sats);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.hdop = strtod(p + 1, NULL);
+
+	/* Antenna altitude above mean-sea-level read */
+	p = nmea_nField(p, field_gga_h_asl - field_gga_hdop);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.h_asl = strtod(p + 1, NULL);
+
+	/* Geoidal separation read */
+	p = nmea_nField(p, field_gga_h_wgs - field_gga_h_asl);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.h_wgs = strtod(p + 1, NULL);
+
+	out->msg.gga = in;
+	out->type = nmea_gga;
+
+	return nmea_gga;
+}
+
+
+static int nmea_parsermc(char *str, nmea_t *out)
+{
+	char *p = str, *sign;
+	nmea_rmc_t in;
+
+	/* latitude read */
+	p = nmea_nField(p, field_rmc_lat);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	sign = nmea_nField(p, 1);
+	if (sign == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.lat = strtod(p + 1, NULL);
+	in.lat = ((int)in.lat / 100) + (in.lat - ((int)in.lat / 100) * 100) / 60; /* conversion from ddmm.mmmm to dd.dddd */
+	in.lat = (sign[1] == 'S') ? -in.lat : in.lat;
+
+	/* longitude read */
+	p = nmea_nField(p, field_rmc_lon - field_rmc_lat);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	sign = nmea_nField(p, 1);
+	if (sign == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.lon = strtod(p + 1, NULL);
+	in.lon = ((int)in.lon / 100) + (in.lon - ((int)in.lon / 100) * 100) / 60; /* conversion from ddmm.mmmm to dd.dddd */
+	in.lon = (sign[1] == 'W') ? -in.lon : in.lon;
+
+	/* speed in knots read */
+	p = nmea_nField(p, field_rmc_speedknots - field_rmc_lon);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.speed = strtod(p + 1, NULL);
+
+	/* course read */
+	p = nmea_nField(p, field_rmc_course - field_rmc_speedknots);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.course = strtod(p + 1, NULL);
+
+	/* magnetic variation read */
+	p = nmea_nField(p, field_rmc_magvar - field_rmc_course);
+	if (p == NULL) {
+		return nmea_broken;
+	}
+	/* when error occurred 0 is assigned */
+	in.magvar = strtod(p + 1, NULL);
+
+	out->msg.rmc = in;
+	out->type = nmea_rmc;
+
+	return nmea_rmc;
+}
+
+
+int nmea_interpreter(char *str, nmea_t *out)
+{
+	int ret;
+
+	if (strncmp(str, "$GPGSA", 6) == 0) {
+		ret = nmea_parsegsa(str, out);
+	}
+	else if (strncmp(str, "$GPVTG", 6) == 0) {
+		ret = nmea_parsevtg(str, out);
+	}
+	else if (strncmp(str, "$GPGGA", 6) == 0) {
+		ret = nmea_parsegga(str, out);
+	}
+	else if (strncmp(str, "$GPRMC", 6) == 0) {
+		ret = nmea_parsermc(str, out);
+	}
+	else {
+		ret = nmea_unknown;
+	}
+
+	return ret;
+}
+
+
+int nmea_countlines(char *buf)
+{
+	int n = 0;
+	char *curr;
+
+	curr = strchr(buf, '$');
+
+	while (curr != NULL) {
+		/* assert that '*' and checksum characters are available */
+		curr = strchr(curr, '*');
+		if (curr != NULL) {
+			if ((curr[1] != '\0') && (curr[2] != '\0')) {
+				n++;
+			}
+			curr = strchr(curr, '$');
+		}
+	}
+
+	return n;
+}
+
+
+char **nmea_getlines(char *buf, int n)
+{
+	char **lines;
+	char *curr, *start;
+	int i;
+
+	curr = buf;
+
+	lines = malloc(sizeof(char *) * n);
+
+	if (lines == NULL) {
+		return NULL;
+	}
+
+	for (i = 0; i < n; i++) {
+		start = strchr(curr, '$');
+		if (start == NULL) {
+			break;
+		}
+
+		curr = strchr(start, '*');
+		if (curr == NULL) {
+			break;
+		}
+
+		curr[3] = '\0';
+		curr += 4;
+
+		lines[i] = start;
+	}
+
+	/* something went wrong - aborting */
+	if (i < n) {
+		free(lines);
+		return NULL;
+	}
+	else {
+		return lines;
+	}
+}
+
+
+int nmea_assertChecksum(const char *line)
+{
+	char countedChecksum;
+	unsigned int readChecksum;
+	int i, len;
+
+	countedChecksum = 0;
+	readChecksum = 0;
+
+	/* example message: `$GPVTG,9.75,T,,M,0.02,N,0.04,K,A*30` */
+	/* `*30` is the value of checksum, it has to be skipped when counting */
+	len = strlen(line) - 3;
+
+	for (i = 1; i < len; i++) {
+		countedChecksum ^= line[i];
+	}
+	sscanf(&line[i + 1], "%x", &readChecksum);
+
+	return (countedChecksum == (char)readChecksum) ? EOK : -1;
+}

--- a/sensors/gps/nmea.h
+++ b/sensors/gps/nmea.h
@@ -1,0 +1,111 @@
+/*
+ * Phoenix-RTOS
+ *
+ * NMEA
+ *
+ * Copyright 2022 Phoenix Systems
+ * Author: Damian Loewnau, Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _NMEA_H_
+#define _NMEA_H_
+
+
+/* types of messages interpreted, together with unknown, and broken message */
+enum nmea_type { nmea_gga, nmea_gsa, nmea_rmc, nmea_vtg, nmea_unknown, nmea_broken };
+
+/* GPGSA nmea type definitions: GPS DOP and active satellites */
+typedef struct {
+	unsigned int fix;
+	float pdop;
+	float hdop;
+	float vdop;
+} nmea_gsa_t;
+
+
+enum nmea_gsa_fix { gsa_fix_notavailable = 1, gsa_fix_2d, gsa_fix_3d };
+
+
+enum nmea_fields_gsa { field_gsa_fix = 2, field_gsa_pdop = 15, field_gsa_hdop = 16, field_gsa_vdop = 17 };
+
+
+/* GPRMC nmea type definitions: Recommended minimum specific GPS/Transit data */
+typedef struct {
+	float lat;
+	float lon;
+	float speed;
+	float course;
+	float magvar;
+} nmea_rmc_t;
+
+
+enum nmea_fields_rmc { field_rmc_lat = 3, field_rmc_lon = 5, field_rmc_speedknots = 7, field_rmc_course = 8,
+	field_rmc_magvar = 10 };
+
+
+/* GPVTG nmea type definitions: Track Made Good and Ground Speed. */
+typedef struct {
+	float track;
+	char track_type;
+	float speed_knots;
+	float speed_kmh;
+} nmea_vtg_t;
+
+
+enum nmea_fields_vtg { field_vtg_track = 1, field_vtg_tracktype = 2, field_vtg_speedknots = 5, field_vtg_speedkmh = 7 };
+
+
+/* GPGGA nmea type definitions: Global Positioning System Fix Data  */
+typedef struct {
+	float lat;
+	float lon;
+	unsigned int fix;
+	unsigned int sats;
+	float hdop;
+	float h_asl;
+	float h_wgs;
+} nmea_gga_t;
+
+
+enum nmea_gga_fix { gga_fix_invalid, gga_fix_gnss, gga_fix_dpgs, gga_fix_pps, gga_fix_rtkinematic,
+	gga_fix_estimated = 6,gga_fix_maninput, gga_fix_simulation };
+
+
+enum nmea_fields_gga { field_gga_lat = 2, field_gga_lon = 4, field_gga_fix = 6, field_gga_sats = 7,
+	field_gga_hdop = 8, field_gga_h_asl = 9, field_gga_h_wgs = 11 };
+
+
+/* incoming message storage */
+typedef struct {
+	int type;
+	union {
+		nmea_gsa_t gsa;
+		nmea_rmc_t rmc;
+		nmea_vtg_t vtg;
+		nmea_gga_t gga;
+	} msg;
+
+} nmea_t;
+
+
+/* interpret one line of gps output into nmea message, if known */
+extern int nmea_interpreter(char *str, nmea_t *out);
+
+
+/* Returns the number of nmea lines with checksums occurring buffer */
+extern int nmea_countlines(char *buf);
+
+
+/* Splits gps input buffer to an array with n separate nmea strings */
+/* NULL will be returned if cannot allocate memory for the array or there is wrong input buffer */
+extern char **nmea_getlines(char *buf, int n);
+
+
+/* Returns 0 if counted and read checksum are the same */
+extern int nmea_assertChecksum(const char *line);
+
+#endif

--- a/sensors/gps/pa6h.c
+++ b/sensors/gps/pa6h.c
@@ -1,0 +1,207 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Driver for GPS module PA6H
+ *
+ * Copyright 2022 Phoenix Systems
+ * Author: Damian Loewnau, Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <math.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <sys/threads.h>
+
+#include "../sensors.h"
+#include "nmea.h"
+
+
+/* Specified by the module's documentation */
+#define UPDATE_RATE_MS 1000
+
+#define DEG2RAD     0.0174532925
+#define DEG2MILIRAD 17.4532925 /* 1 degree -> 1 milliradian conversion parameter */
+#define KMH2MMS     277.7778   /* 1 km/h -> mm/s conversion parameter */
+
+
+typedef struct {
+	sensor_event_t evtGps;
+	int filedes;
+	char buff[1024];
+	char stack[512] __attribute__((aligned(8)));
+} pa6h_ctx_t;
+
+
+int pa6h_update(nmea_t *message, pa6h_ctx_t *ctx)
+{
+	switch (message->type) {
+		case nmea_gga:
+			ctx->evtGps.gps.lat = message->msg.gga.lat * 1e7;
+			ctx->evtGps.gps.lon = message->msg.gga.lon * 1e7;
+			ctx->evtGps.gps.hdop = (unsigned int)(message->msg.gga.hdop * 1e2);
+			ctx->evtGps.gps.fix = message->msg.gga.fix;
+			ctx->evtGps.gps.alt = message->msg.gga.h_asl * 1e3;
+			ctx->evtGps.gps.altEllipsoid = message->msg.gga.h_wgs * 1e3;
+			ctx->evtGps.gps.satsNb = message->msg.gga.sats;
+			break;
+
+		case nmea_gsa:
+			ctx->evtGps.gps.hdop = (unsigned int)(message->msg.gsa.hdop * 1e2);
+			ctx->evtGps.gps.vdop = (unsigned int)(message->msg.gsa.vdop * 1e2);
+			break;
+
+		case nmea_rmc:
+			break;
+
+		case nmea_vtg:
+			ctx->evtGps.gps.heading = message->msg.vtg.track * DEG2MILIRAD;     /* degrees -> milliradians */
+			ctx->evtGps.gps.groundSpeed = message->msg.vtg.speed_kmh * KMH2MMS; /* kmh->mm/s */
+			ctx->evtGps.gps.velNorth = cos(message->msg.vtg.track * DEG2RAD) * ctx->evtGps.gps.groundSpeed;
+			ctx->evtGps.gps.velEast = sin(message->msg.vtg.track * DEG2RAD) * ctx->evtGps.gps.groundSpeed;
+			break;
+
+		default:
+			break;
+	}
+	gettime(&(ctx->evtGps.timestamp), NULL);
+
+	return 0;
+}
+
+
+static void pa6h_threadPublish(void *data)
+{
+	sensor_info_t *info = (sensor_info_t *)data;
+	pa6h_ctx_t *ctx = info->ctx;
+	nmea_t message;
+	char **lines;
+	int i, nlines = 0, nbytes = 0, ret = 0;
+	unsigned char doUpdate = 0;
+
+	while (1) {
+		memset(ctx->buff, 0, sizeof(ctx->buff));
+		usleep(1000 * UPDATE_RATE_MS);
+
+		nbytes = read(ctx->filedes, ctx->buff, sizeof(ctx->buff) - 1);
+		if (nbytes <= 0) {
+			continue;
+		}
+
+		nlines = nmea_countlines(ctx->buff);
+		lines = nmea_getlines(ctx->buff, nlines);
+		if (lines == NULL) {
+			continue;
+		}
+
+		for (i = 0; i < nlines; i++) {
+			if (nmea_assertChecksum(lines[i]) == EOK) {
+				ret = nmea_interpreter(lines[i], &message);
+				if (ret != nmea_broken && ret != nmea_unknown) {
+					pa6h_update(&message, ctx);
+					doUpdate = 1;
+				}
+			}
+		}
+		if (doUpdate == 1) {
+			sensors_publish(info->id, &ctx->evtGps);
+			doUpdate = 0;
+		}
+	}
+	free(lines);
+}
+
+
+static int pa6h_start(sensor_info_t *info)
+{
+	int err;
+	pa6h_ctx_t *ctx = info->ctx;
+
+	ctx->evtGps.type = SENSOR_TYPE_GPS;
+	ctx->evtGps.gps.devId = info->id;
+
+	err = beginthread(pa6h_threadPublish, 4, ctx->stack, sizeof(ctx->stack), info);
+	if (err < 0) {
+		free(ctx);
+	}
+	else {
+		printf("pa6h: launched sensor\n");
+	}
+
+	return err;
+}
+
+
+static int pa6h_parse(const char *args, const char **path)
+{
+	int err = EOK;
+
+	if (!(args == NULL || strchr(args, ':'))) {
+		*path = args;
+	}
+	else {
+		fprintf(stderr, "pa6h: Wrong arguments\n"
+						"Please specify the path to source device instance, for example: /dev/uart0\n");
+		err = -EINVAL;
+	}
+
+	return err;
+}
+
+
+static int pa6h_alloc(sensor_info_t *info, const char *args)
+{
+	int cnt = 0, err;
+	const char *path;
+	pa6h_ctx_t *ctx;
+
+	ctx = malloc(sizeof(pa6h_ctx_t));
+	if (ctx == NULL) {
+		return -ENOMEM;
+	}
+
+	info->types = SENSOR_TYPE_GPS;
+
+	err = pa6h_parse(args, &path);
+	if (err != EOK) {
+		free(ctx);
+		return err;
+	}
+
+	ctx->filedes = open(path, O_RDONLY | O_NOCTTY | O_NONBLOCK);
+	while (ctx->filedes < 0) {
+		usleep(10 * 1000);
+		cnt++;
+
+		if (cnt > 10000) {
+			fprintf(stderr, "pa6h: Can't open %s: %s\n", path, strerror(errno));
+			err = -errno;
+			free(ctx);
+			return err;
+		}
+		ctx->filedes = open(path, O_RDONLY | O_NOCTTY | O_NONBLOCK);
+	}
+	info->ctx = ctx;
+
+	return EOK;
+}
+
+
+void __attribute__((constructor)) pa6h_register(void)
+{
+	static sensor_drv_t sensor = {
+		.name = "pa6h",
+		.alloc = pa6h_alloc,
+		.start = pa6h_start
+	};
+
+	sensors_register(&sensor);
+}

--- a/sensors/include/libsensors.h
+++ b/sensors/include/libsensors.h
@@ -66,7 +66,7 @@ typedef struct {
 	int16_t headingOffs;   /* value in [mrad] */
 	uint16_t headingAccur; /* value in [mrad] */
 	uint8_t satsNb;        /* number of used satellites */
-	uint8_t reserved;
+	uint8_t fix;           /* fix quality */
 } gps_data_t;
 
 
@@ -99,7 +99,7 @@ typedef struct {
 /* Event data gets from sensor manager */
 typedef struct {
 	sensor_type_t type;
-	uint64_t timestamp;
+	time_t timestamp;
 
 	union {
 		accel_data_t accels;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- _targets: imx6ull: add sensor manager to default components
- sensors: gps: add implementation for pa6h module


- Client example (specific uart instance with 9600 br should be available in /dev/ directory):
 ```c
#include <stdio.h>
#include <stdlib.h>
#include <fcntl.h>
#include <unistd.h>
#include <sys/ioctl.h>

#include <libsensors.h>


int main(int argc, char **argv)
{
	int fd;
	sensors_data_t *data;
	unsigned char buff[0x400];
	sensor_type_t types;
	sensors_ops_t ops = {0};
	fd = open("/dev/sensors", O_RDWR);
	if (fd < 0) {
		return EXIT_FAILURE;
	}
	/* Get available sensor types */
	ioctl(fd, SMIOC_SENSORSAVAIL, &types);

	/* Define sensor types request */
	ops.types = (types & SENSOR_TYPE_GPS) | (types & SENSOR_TYPE_ACCEL) | (types & SENSOR_TYPE_GYRO) \
		| (types & SENSOR_TYPE_GPS);
	ioctl(fd, SMIOC_SENSORSSET, &ops);
	if ((ops.evtSz * sizeof(sensor_event_t) + sizeof(((sensors_data_t *)0)->size)) > sizeof(buff)) {
		fprintf(stderr, "Buff is too small\n");
		return EXIT_FAILURE;
	}
	for (int i = 0; i < 15; ++i) {
		sleep(1);
		read(fd, buff, 0x400);

		data = (sensors_data_t *)buff;
		printf("Sz: %d\n", data->size);

		for (int j = 0; j < data->size; ++j) {
			switch (data->events[j].type) {
			case SENSOR_TYPE_ACCEL:
				printf("Accel, timestamp: %lld\n", data->events[j].timestamp);
				printf("acce - x: %d, y: %d, z: %d\n", data->events[j].accels.accelX, data->events[j].accels.accelY, data->events[j].accels.accelZ);
				break;

			case SENSOR_TYPE_BARO:
				printf("Baro, timestamp: %llu\n", data->events[j].timestamp);
				printf("baro - pressure: %u\n", data->events[j].baro.pressure);
				break;

			case SENSOR_TYPE_GYRO:
				printf("Gyro, timestamp: %lld\n", data->events[j].timestamp);
				printf("gyro - x: %d, y: %d, z: %d\n", data->events[j].gyro.gyroX, data->events[j].gyro.gyroY, data->events[j].gyro.gyroZ);
				break;
			case SENSOR_TYPE_GPS:
				printf("Gps, timestamp: %llu\n", data->events[j].timestamp);
				printf("lat/lon | hdop:\t%d/%d | %d\n", data->events[j].gps.lat, data->events[j].gps.lon, data->events[j].gps.hdop);
				printf("asl/wgs | vdop:\t%d/%d | %d\n", data->events[j].gps.alt, data->events[j].gps.altEllipsoid, data->events[j].gps.vdop);
				printf("kmh/kmhN/kmhE:\t%d/%d/%d\n", data->events[j].gps.groundSpeed, data->events[j].gps.velNorth, data->events[j].gps.velEast);
				printf("hdop/vdop/sats:\t%d/%d/%d\n", data->events[j].gps.hdop, data->events[j].gps.vdop, data->events[j].gps.satsNb);
				printf("\n");
				break;
			default:
				break;
			}
		}
	}

	close(fd);

	return EXIT_SUCCESS;
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Required for Phoenix-Pilot

JIRA: PP-36

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7a9-zynq7000-zturn board and PmodGPS module).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
