### PR TITLE
zynq7000: add recipe for libspi-msg in target Makefile

### DIFF
--- a/_targets/Makefile.armv7a9-zynq7000
+++ b/_targets/Makefile.armv7a9-zynq7000
@@ -7,5 +7,5 @@
 #
 
 DEFAULT_COMPONENTS := zynq7000-uart zynq7000-pwm zynq7000-xgpio zynq7000-spi
-DEFAULT_COMPONENTS += libflashdrv-zynq zynq7000-flash test_flashdrv
+DEFAULT_COMPONENTS += libflashdrv-zynq zynq7000-flash test_flashdrv libspi-msg
 DEFAULT_COMPONENTS += libsensors sensors


### PR DESCRIPTION
JIRA: PP-6

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added _libspi-msg_ to zynq7000 target components

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is impossible to compile applications that use indirect method of spi usage via driver

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zynq7000 zturn board.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
