### PR TITLE
libsensors-spi: put writeDir() before writePort() + naming change

### DIFF
--- a/sensors/baro/lps25xx.c
+++ b/sensors/baro/lps25xx.c
@@ -203,7 +203,7 @@ static int lps25xx_alloc(sensor_info_t *info, const char *args)
 	}
 
 	/* initialize SPI device communication */
-	err = sensorsspi_initDev(args, ss, &ctx->spiCtx.oid, &ctx->spiSS);
+	err = sensorsspi_open(args, ss, &ctx->spiCtx.oid, &ctx->spiSS);
 	if (err < 0) {
 		printf("lps25xx: Can`t initialize SPI device\n");
 		free(ctx);

--- a/sensors/imu/lsm9dsxx.c
+++ b/sensors/imu/lsm9dsxx.c
@@ -261,7 +261,7 @@ static int lsm9dsxx_alloc(sensor_info_t *info, const char *args)
 	}
 
 	/* initialize SPI device communication */
-	err = sensorsspi_initDev(args, ss, &ctx->spiCtx.oid, &ctx->spiSS);
+	err = sensorsspi_open(args, ss, &ctx->spiCtx.oid, &ctx->spiSS);
 	if (err < 0) {
 		printf("lsm9dsxx: Can`t initialize SPI device\n");
 		free(ctx);

--- a/sensors/mag/lsm9dsxx.c
+++ b/sensors/mag/lsm9dsxx.c
@@ -217,7 +217,7 @@ static int lsm9dsxx_alloc(sensor_info_t *info, const char *args)
 	}
 
 	/* initialize SPI device communication */
-	err = sensorsspi_initDev(args, ss, &ctx->spiCtx.oid, &ctx->spiSS);
+	err = sensorsspi_open(args, ss, &ctx->spiCtx.oid, &ctx->spiSS);
 	if (err < 0) {
 		printf("lps25xx: Can`t initialize SPI device\n");
 		free(ctx);

--- a/sensors/sensors-spi.h
+++ b/sensors/sensors-spi.h
@@ -23,7 +23,7 @@ extern int sensorsspi_xfer(const spimsg_ctx_t *ctx, oid_t *ss, const void *out, 
 
 
 /* Initializes SPI sensor device communication */
-extern int sensorsspi_initDev(const char *devSPI, const char *devSS, oid_t *spi, oid_t *ss);
+extern int sensorsspi_open(const char *devSPI, const char *devSS, oid_t *spi, oid_t *ss);
 
 
 /* Initializes SPI sensors communication */


### PR DESCRIPTION
JIRA: PP-44

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - change order of gpiomsg_writeDir() and gpiomsg_writePort()
 - changed function name `sensorsspi_initDev()`->`sensorsspi_open`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
