### PR TITLE
libtty: add termios c_cflag field initialization in termios_init()

### DIFF
--- a/tty/libtty/libtty.c
+++ b/tty/libtty/libtty.c
@@ -97,6 +97,7 @@ static void termios_init(struct termios* term)
 	term->c_iflag = TTYDEF_IFLAG & TTYSUP_IFLAG;
 	term->c_oflag = TTYDEF_OFLAG & TTYSUP_OFLAG;
 	term->c_lflag = TTYDEF_LFLAG & TTYSUP_LFLAG;
+	term->c_cflag = TTYDEF_CFLAG;
 
 	term->c_ispeed = TTYDEF_SPEED;
 	term->c_ospeed = TTYDEF_SPEED;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
`libtty` didn't initialize this field causing issues, e.g. here:
https://github.com/phoenix-rtos/phoenix-rtos-devices/blob/802f6d762c11ae58882963526ee682539684f138/tty/zynq7000-uart/zynq7000-uart.c#L395

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: PP-41](https://jira.phoenix-rtos.com/browse/PP-41)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a9-zynq7000-zedboard

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
