### PR TITLE
imxrt-flash: use mem mapped pointer for directWrite devctl

### DIFF
--- a/storage/imxrt-flash/flashdrv.c
+++ b/storage/imxrt-flash/flashdrv.c
@@ -280,7 +280,7 @@ int flash_init(flash_context_t *ctx)
 		return res;
 	}
 
-	LOG_INFO("imxrt-flash: detected %s %s (0x%x)", ctx->properties.pVendor, pInfo->name, pInfo->jedecId);
+	LOG_INFO("detected %s %s (0x%x)", ctx->properties.pVendor, pInfo->name, pInfo->jedecId);
 
 	buff = malloc(pInfo->sectorSz);
 	if (buff == NULL) {

--- a/storage/imxrt-flash/flashsrv.c
+++ b/storage/imxrt-flash/flashsrv.c
@@ -310,14 +310,14 @@ static void flashsrv_devCtl(flash_memory_t *memory, msg_t *msg)
 
 		case flashsrv_devctl_directWrite:
 			TRACE("imxrt-flashsrv: flashsrv_devctl_directWrite, addr: %u, size: %u, id: %u, port: %u.",
-				idevctl->write.addr, idevctl->write.size, idevctl->oid.id, idevctl->oid.port);
+				idevctl->write.addr, msg->i.size, idevctl->oid.id, idevctl->oid.port);
 
 			if (idevctl->write.addr >= memory->ctx.properties.size) {
 				odevctl->err = -EINVAL;
 				break;
 			}
 
-			odevctl->err = flashsrv_directWrite(memory->fOid.id, idevctl->write.addr, idevctl->write.buff, idevctl->write.size);
+			odevctl->err = flashsrv_directWrite(memory->fOid.id, idevctl->write.addr, msg->i.data, msg->i.size);
 			break;
 
 		default:
@@ -392,14 +392,14 @@ static void flashsrv_rawCtl(flash_memory_t *memory, msg_t *msg)
 
 		case flashsrv_devctl_directWrite:
 			TRACE("imxrt-flashsrv: flashsrv_devctl_directWrite, addr: %u, size: %u, id: %u, port: %u.",
-				idevctl->write.addr + memory->parts[partID].pHeader->offset, idevctl->write.size, idevctl->oid.id, idevctl->oid.port);
+				idevctl->write.addr + memory->parts[partID].pHeader->offset, msg->i.size, idevctl->oid.id, idevctl->oid.port);
 
 			if (idevctl->write.addr > memory->parts[idevctl->oid.id].pHeader->size) {
 				odevctl->err = -EINVAL;
 				break;
 			}
 
-			odevctl->err = flashsrv_directWrite(memory->fOid.id, memory->parts[partID].pHeader->offset + idevctl->write.addr, idevctl->write.buff, idevctl->write.size);
+			odevctl->err = flashsrv_directWrite(memory->fOid.id, memory->parts[partID].pHeader->offset + idevctl->write.addr, msg->i.data, msg->i.size);
 			break;
 
 		default:

--- a/storage/imxrt-flash/flashsrv.c
+++ b/storage/imxrt-flash/flashsrv.c
@@ -293,12 +293,12 @@ static void flashsrv_devCtl(flash_memory_t *memory, msg_t *msg)
 			break;
 
 		case flashsrv_devctl_eraseSector:
-			TRACE("imxrt-flashsrv: flashsrv_devctl_eraseSector - addr: %u, id: %u, port: %u.", idevctl->erase.addr, idevctl->oid.id, idevctl->oid.port);
-			if (idevctl->erase.addr >= memory->ctx.properties.size) {
+			TRACE("imxrt-flashsrv: flashsrv_devctl_eraseSector - addr: %u, id: %u, port: %u.", idevctl->addr, idevctl->oid.id, idevctl->oid.port);
+			if (idevctl->addr >= memory->ctx.properties.size) {
 				odevctl->err = -EINVAL;
 				break;
 			}
-			flashsrv_eraseSector(memory->fOid.id, idevctl->erase.addr);
+			flashsrv_eraseSector(memory->fOid.id, idevctl->addr);
 			odevctl->err = EOK;
 			break;
 
@@ -310,14 +310,14 @@ static void flashsrv_devCtl(flash_memory_t *memory, msg_t *msg)
 
 		case flashsrv_devctl_directWrite:
 			TRACE("imxrt-flashsrv: flashsrv_devctl_directWrite, addr: %u, size: %u, id: %u, port: %u.",
-				idevctl->write.addr, msg->i.size, idevctl->oid.id, idevctl->oid.port);
+				idevctl->addr, msg->i.size, idevctl->oid.id, idevctl->oid.port);
 
-			if (idevctl->write.addr >= memory->ctx.properties.size) {
+			if (idevctl->addr >= memory->ctx.properties.size) {
 				odevctl->err = -EINVAL;
 				break;
 			}
 
-			odevctl->err = flashsrv_directWrite(memory->fOid.id, idevctl->write.addr, msg->i.data, msg->i.size);
+			odevctl->err = flashsrv_directWrite(memory->fOid.id, idevctl->addr, msg->i.data, msg->i.size);
 			break;
 
 		default:
@@ -368,14 +368,14 @@ static void flashsrv_rawCtl(flash_memory_t *memory, msg_t *msg)
 
 		case flashsrv_devctl_eraseSector:
 			TRACE("imxrt-flashsrv: flashsrv_devctl_eraseSector - addr: %u, id: %u, port: %u.",
-				idevctl->erase.addr + memory->parts[partID].pHeader->offset, partID, idevctl->oid.port);
+				idevctl->addr + memory->parts[partID].pHeader->offset, partID, idevctl->oid.port);
 
-			if (idevctl->erase.addr > memory->parts[idevctl->oid.id].pHeader->size) {
+			if (idevctl->addr > memory->parts[idevctl->oid.id].pHeader->size) {
 				odevctl->err = -EINVAL;
 				break;
 			}
 
-			flashsrv_eraseSector(memory->fOid.id, memory->parts[partID].pHeader->offset + idevctl->erase.addr);
+			flashsrv_eraseSector(memory->fOid.id, memory->parts[partID].pHeader->offset + idevctl->addr);
 			odevctl->err = EOK;
 			break;
 
@@ -392,14 +392,14 @@ static void flashsrv_rawCtl(flash_memory_t *memory, msg_t *msg)
 
 		case flashsrv_devctl_directWrite:
 			TRACE("imxrt-flashsrv: flashsrv_devctl_directWrite, addr: %u, size: %u, id: %u, port: %u.",
-				idevctl->write.addr + memory->parts[partID].pHeader->offset, msg->i.size, idevctl->oid.id, idevctl->oid.port);
+				idevctl->addr + memory->parts[partID].pHeader->offset, msg->i.size, idevctl->oid.id, idevctl->oid.port);
 
-			if (idevctl->write.addr > memory->parts[idevctl->oid.id].pHeader->size) {
+			if (idevctl->addr > memory->parts[idevctl->oid.id].pHeader->size) {
 				odevctl->err = -EINVAL;
 				break;
 			}
 
-			odevctl->err = flashsrv_directWrite(memory->fOid.id, memory->parts[partID].pHeader->offset + idevctl->write.addr, msg->i.data, msg->i.size);
+			odevctl->err = flashsrv_directWrite(memory->fOid.id, memory->parts[partID].pHeader->offset + idevctl->addr, msg->i.data, msg->i.size);
 			break;
 
 		default:

--- a/storage/imxrt-flash/imxrt-flashsrv.h
+++ b/storage/imxrt-flash/imxrt-flashsrv.h
@@ -32,8 +32,6 @@ typedef struct {
 
 	struct {
 		uint32_t addr;
-		const void *buff;
-		size_t size;
 	} write;
 
 } __attribute__((packed)) flash_i_devctl_t;

--- a/storage/imxrt-flash/imxrt-flashsrv.h
+++ b/storage/imxrt-flash/imxrt-flashsrv.h
@@ -25,15 +25,7 @@ enum { flashsrv_devctl_properties = 0, flashsrv_devctl_sync, flashsrv_devctl_era
 typedef struct {
 	int type;
 	oid_t oid;
-
-	struct {
-		uint32_t addr;
-	} erase;
-
-	struct {
-		uint32_t addr;
-	} write;
-
+	uint32_t addr;
 } __attribute__((packed)) flash_i_devctl_t;
 
 

--- a/storage/imxrt-flash/tests/flashsrv_raw_tests.c
+++ b/storage/imxrt-flash/tests/flashsrv_raw_tests.c
@@ -118,7 +118,7 @@ static int eraseSector(oid_t oid, uint32_t addr)
 	idevctl = (flash_i_devctl_t *)msg.i.raw;
 	idevctl->type = flashsrv_devctl_eraseSector;
 	idevctl->oid = oid;
-	idevctl->erase.addr = addr;
+	idevctl->addr = addr;
 
 	odevctl = (flash_o_devctl_t *)msg.o.raw;
 


### PR DESCRIPTION
## Description
Fixes the passed pointer to the buffer of directWrite devctl by using a mapped pointer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176, imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
