### PR TITLE
imxrt-flash: priority set was too late

### DIFF
--- a/storage/imxrt-flash/flashsrv.c
+++ b/storage/imxrt-flash/flashsrv.c
@@ -4,7 +4,7 @@
  * i.MX RT Flash server
  *
  * Copyright 2019-2022 Phoenix Systems
- * Author: Hubert Buczynski
+ * Author: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -841,6 +841,8 @@ int main(void)
 		return EXIT_FAILURE;
 	}
 
+	priority(IMXRT_FLASH_PRIO);
+
 	if (flashsrv_flashMemoriesInit() != EOK) {
 		LOG_ERROR("imxrt-flashsrv: flash memories were not initialized correctly.\n");
 		return EXIT_FAILURE;
@@ -850,8 +852,6 @@ int main(void)
 		LOG_ERROR("imxrt-flashsrv: partitions were not initialized correctly.\n");
 		return EXIT_FAILURE;
 	}
-
-	priority(IMXRT_FLASH_PRIO);
 
 	printf("imxrt-flashsrv: initialized.\n");
 

--- a/storage/imxrt-flash/fspi.c
+++ b/storage/imxrt-flash/fspi.c
@@ -19,6 +19,15 @@
 #include <unistd.h>
 #include "fspi.h"
 
+
+/*
+ * NOTICE: FlexSPI driver in user space depends on phoenix-rtos-loader (plo) configuration set during
+ * flash probing, all settings (clocks, bus setup, command lookup-table, etc) are done in plo not in
+ * user space (as imxrt-flash/flashsrv), this driver when used without `plo/devices/flash-flexspi`
+ * will not work properly.
+ */
+
+
 /* clang-format off */
 
 enum { mcr0 = 0, mcr1, mcr2, ahbcr, inten, intr, lutkey, lutcr, ahbrxbuf0cr0, ahbrxbuf1cr0, ahbrxbuf2cr0, ahbrxbuf3cr0,
@@ -29,7 +38,6 @@ enum { mcr0 = 0, mcr1, mcr2, ahbcr, inten, intr, lutkey, lutcr, ahbrxbuf0cr0, ah
     hmstr3cr, hmstr4cr, hmstr5cr, hmstr6cr, hmstr7cr, haddrstart, haddrend, haddroffset };
 
 /* clang-format on */
-
 
 void flexspi_swreset(flexspi_t *fspi)
 {


### PR DESCRIPTION
JIRA: RTOS-220

Priority of main thread was set too late.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176, imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
