### PR TITLE
imxrt-flash sync improvements

### DIFF
--- a/storage/imxrt-flash/flashdrv.c
+++ b/storage/imxrt-flash/flashdrv.c
@@ -94,6 +94,11 @@ static ssize_t bufferSync(flash_context_t *ctx, uint32_t dstAddr, int isLast)
 			return res;
 		}
 
+		if (ctx->properties.sector_size <= dstAddr) {
+			ctx->prevAddr = (uint32_t)-1;
+			ctx->syncAddr = (uint32_t)-1;
+		}
+
 		if (isLast != 0) {
 			return res;
 		}

--- a/storage/imxrt-flash/flashsrv.c
+++ b/storage/imxrt-flash/flashsrv.c
@@ -545,8 +545,16 @@ static void flashsrv_rawThread(void *arg)
 				break;
 
 			case mtOpen:
-			case mtClose:
 				msg.o.io.err = EOK;
+				break;
+
+			case mtClose:
+				(void)flash_sync(&memory->ctx);
+				msg.o.io.err = EOK;
+				break;
+
+			case mtSync:
+				msg.o.io.err = flash_sync(&memory->ctx);
 				break;
 
 			default:


### PR DESCRIPTION
Quick fixes for imxrt-flash:

RTOS-224: Synchronize cached writes on close (raw partition)
BES-226: Invalidate sync buffer if it's out of range

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176, imxrt1064-bes).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
