### PR TITLE
sensorhub: decrease magnetometer base sampling freq. from 80Hz to 64Hz

### DIFF
--- a/sensors/mag/lsm9dsxx.c
+++ b/sensors/mag/lsm9dsxx.c
@@ -158,7 +158,7 @@ static void lsm9dsxx_threadPublish(void *data)
 	uint8_t obuf;
 
 	while (1) {
-		usleep(12500); /* 80Hz sampling period */
+		usleep(1000 * 1000 / 64);
 
 		obuf = REG_DATA_OUT | SPI_READ_BIT | SPI_AUTOADDRINCR_BIT;
 		err = sensorsspi_xfer(&ctx->spiCtx, &ctx->spiSS, &obuf, sizeof(obuf), ibuf, sizeof(ibuf), sizeof(obuf));


### PR DESCRIPTION
JIRA: PP-51

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Longer wait is needed for magnetometer thread to not truncate data when sampling the sensor without uisng DRDY (data ready) register check. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We skip DRDY check as it is not important for us to achieve absolute maximum magnetometer data sampling performance. It comes out, that precise 80Hz sampling causes data loss on some axis. Thus the closest and possibly round value of 64 Hz was chosen as sampling frequency. Tested on zturn drone this fixes the problem. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: lsm9dsxx with zturn.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
