### PR TITLE
stm32l4-multi: set oid.port when creating uart devices

### DIFF
--- a/multi/stm32l4-multi/tty.c
+++ b/multi/stm32l4-multi/tty.c
@@ -413,6 +413,7 @@ int tty_init(void)
 	};
 
 	portCreate(&uart_common.port);
+	oid.port = uart_common.port;
 
 	for (uart = usart1; uart <= uart5; ++uart) {
 		if (!uartConfig[uart])


### PR DESCRIPTION
This fixes problem introduced in:
2d20738 stm32l4-multi: Support klog

JIRA: ISC-193

## Motivation and Context
Without this fix operations on /dev/uart* fail as device is initialized with invalid port number.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: stm32l4
