### PR TITLE
stm32l4-multi: fix bugs in otp handling

### DIFF
--- a/multi/stm32l4-multi/flash.c
+++ b/multi/stm32l4-multi/flash.c
@@ -143,13 +143,12 @@ size_t flash_readData(uint32_t offset, char *buff, size_t size)
 }
 
 
-size_t flash_readOtp(uint32_t offset, char *buff, size_t size)
+ssize_t flash_readOtp(uint32_t offset, char *buff, size_t size)
 {
 	size_t ret;
 
-	ret = otp_isValidAddress(offset + OTP_ADDR, size);
-	if (!ret) {
-		return -1;
+	if (otp_isValidAddress(offset + OTP_ADDR, size) == 0) {
+		return -EINVAL;
 	}
 
 	mutexLock(flash_common.lock);
@@ -276,13 +275,12 @@ size_t flash_writeData(uint32_t offset, const char *buff, size_t size)
 }
 
 
-size_t flash_writeOtp(uint32_t offset, const char *buff, size_t size)
+ssize_t flash_writeOtp(uint32_t offset, const char *buff, size_t size)
 {
 	int ret;
 	uint32_t *ptr = (void *)(offset + OTP_ADDR);
 
-	ret = otp_isValidAddress((uint32_t)ptr, size);
-	if (!ret) {
+	if (otp_isValidAddress((uint32_t)ptr, size) == 0) {
 		return -EINVAL;
 	}
 

--- a/multi/stm32l4-multi/flash.h
+++ b/multi/stm32l4-multi/flash.h
@@ -65,10 +65,10 @@ extern size_t flash_readData(uint32_t offset, char *buff, size_t size);
 extern size_t flash_writeData(uint32_t offset, const char *buff, size_t size);
 
 
-extern size_t flash_readOtp(uint32_t offset, char *buff, size_t size);
+extern ssize_t flash_readOtp(uint32_t offset, char *buff, size_t size);
 
 
-extern size_t flash_writeOtp(uint32_t offset, const char *buff, size_t size);
+extern ssize_t flash_writeOtp(uint32_t offset, const char *buff, size_t size);
 
 
 extern int flash_switchBanks(void);


### PR DESCRIPTION
Add -EINVAL returning in case of unaligment address or size when read from otp.
Fix returning value from otp functions to be signed type.

JIRA: SKAL-527

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4x).