### PR TITLE
sensors: fix makefile rule for installing headers

### DIFF
--- a/sensors/Makefile
+++ b/sensors/Makefile
@@ -11,6 +11,7 @@ include $(static-lib.mk)
 # Sensors SPI interface
 NAME := libsensors-spi
 LOCAL_HEADERS := sensors-spi.h
+LOCAL_HEADERS_DIR := nothing  # do not reinstall libsensors.h
 LOCAL_SRCS := libsensors-spi.c
 DEPS := libzynq7000-gpio-msg libspi-msg
 include $(static-lib.mk)


### PR DESCRIPTION
JIRA: RTOS-242

<!--- Provide a general summary of your changes in the Title above -->

## Description
Quick fix for:
![image](https://user-images.githubusercontent.com/3939983/187966309-3432039b-3346-4b90-9620-b0c6eec7e1eb.png)


IMHO libsensors-spi could be a separate component with separate Makefile (or maybe the API should be?).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
