### PR TITLE
Introduce global timeout to imx6ull-sdma, change ad7779 init procedure

### DIFF
--- a/adc/ad7779/ad7779-driver.c
+++ b/adc/ad7779/ad7779-driver.c
@@ -313,6 +313,20 @@ static int init(void)
 		return res;
 	}
 
+	if ((res = spi_init()) < 0) {
+		log_error("failed to initialize spi");
+		sai_free();
+		dma_free();
+		return res;
+	}
+
+	if ((res = ad7779_gpio_init()) < 0) {
+		log_error("failed to initialize gpio");
+		sai_free();
+		dma_free();
+		return res;
+	}
+
 	if ((res = ad7779_init(0)) < 0) {
 		log_error("failed to initialize ad7779 (%d)", res);
 		sai_free();

--- a/adc/ad7779/ad7779.c
+++ b/adc/ad7779/ad7779.c
@@ -570,12 +570,6 @@ int ad7779_init(int hard)
 {
 	int res;
 
-	if ((res = spi_init()) < 0)
-		return res;
-
-	if ((res = ad7779_gpio_init()) < 0)
-		return res;
-
 	if ((res = ad7779_reset(hard)) < 0)
 		return res;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Move SPI and GPIO configuration to main init method of ad7779
2. Introduce global timeout for DMA read method

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull, not tested on imxrt1064.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
