### PR TITLE
tty/imx6ull-uart: Fix warning when building with KLOG_ENABLE set to 0

### DIFF
--- a/tty/imx6ull-uart/imx6ull-uart.c
+++ b/tty/imx6ull-uart/imx6ull-uart.c
@@ -550,10 +550,12 @@ static void print_usage(const char *progname)
 }
 
 
+#if KLOG_ENABLE
 static void libklog_clbk(const char *data, size_t size)
 {
 	libtty_write(&uart.tty_common, data, size, 0);
 }
+#endif /* KLOG_ENABLE */
 
 
 int main(int argc, char **argv)
@@ -704,6 +706,8 @@ int main(int argc, char **argv)
 		create_dev(&dev, _PATH_CONSOLE);
 
 	libklog_init(libklog_clbk);
+#else
+	(void)is_console;
 #endif /* KLOG_ENABLE */
 
 	uart_thr((void *)port);


### PR DESCRIPTION
JIRA: RTOS-258

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
