### PR TITLE
uart16550: Fix HW clk not being used in set_baudrate

### DIFF
--- a/tty/uart16550/uart16550.c
+++ b/tty/uart16550/uart16550.c
@@ -33,6 +33,8 @@
 typedef struct {
 	uint8_t hwctx[64];
 
+	unsigned int clk;
+
 	handle_t mutex;
 	handle_t intcond;
 	handle_t inth;
@@ -75,7 +77,7 @@ static void set_baudrate(void *_uart, speed_t baud)
 	}
 
 	/* Baud divisor */
-	baud_rate = 115200 / baud_rate;
+	baud_rate = uart->clk / (16 * baud_rate);
 
 	reg = uarthw_read(uart->hwctx, REG_LCR);
 
@@ -245,12 +247,12 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed)
 	unsigned int divisor;
 	libtty_callbacks_t callbacks;
 
-	int err = uarthw_init(uartn, uart->hwctx, sizeof(uart->hwctx), &divisor);
+	int err = uarthw_init(uartn, uart->hwctx, sizeof(uart->hwctx), &uart->clk);
 	if (err < 0) {
 		return err;
 	}
 
-	divisor /= 16 * speed;
+	divisor = uart->clk / (16 * speed);
 
 	callbacks.arg = uart;
 	callbacks.set_baudrate = set_baudrate;


### PR DESCRIPTION
JIRA: PP-86

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
