### PR TITLE
libtty: add baudrate parameter to initialization function

### DIFF
--- a/multi/imxrt-multi/uart.c
+++ b/multi/imxrt-multi/uart.c
@@ -719,7 +719,7 @@ int uart_init(void)
 		callbacks.set_cflag = set_cflag;
 		callbacks.signal_txready = signal_txready;
 
-		if (libtty_init(&uart->tty_common, &callbacks, BUFSIZE) < 0)
+		if (libtty_init(&uart->tty_common, &callbacks, BUFSIZE, libtty_int_to_baudrate(default_baud[dev])) < 0)
 			return -1;
 
 		/* Wait for kernel to stop sending data over uart */

--- a/multi/stm32l4-multi/tty.c
+++ b/multi/stm32l4-multi/tty.c
@@ -397,6 +397,7 @@ int tty_init(void)
 #if TTY_CNT != 0
 	unsigned int uart, i;
 	char fname[] = "uartx";
+	speed_t baudrate = B115200;
 	oid_t oid;
 	libtty_callbacks_t callbacks;
 	tty_ctx_t *ctx;
@@ -428,7 +429,7 @@ int tty_init(void)
 		callbacks.set_cflag = tty_setCflag;
 		callbacks.signal_txready = tty_signalTxReady;
 
-		if (libtty_init(&ctx->tty_common, &callbacks, 512) < 0)
+		if (libtty_init(&ctx->tty_common, &callbacks, 512, baudrate) < 0)
 			return -1;
 
 		mutexCreate(&ctx->irqlock);
@@ -443,7 +444,7 @@ int tty_init(void)
 
 		/* Set up UART to 9600,8,n,1 16-bit oversampling */
 		_tty_configure(ctx, 8, tty_parnone, 1);
-		tty_setBaudrate(ctx, B115200);
+		tty_setBaudrate(ctx, baudrate);
 
 		interrupt(info[uart - usart1].irq, tty_irqHandler, (void *)ctx, ctx->cond, NULL);
 

--- a/tty/imx6ull-uart/imx6ull-uart.c
+++ b/tty/imx6ull-uart/imx6ull-uart.c
@@ -577,7 +577,7 @@ int main(int argc, char **argv)
 		.signal_txready = &signal_txready,
 	};
 
-	if (libtty_init(&uart.tty_common, &callbacks, BUFSIZE) < 0)
+	if (libtty_init(&uart.tty_common, &callbacks, BUFSIZE, baud) < 0)
 		return -1;
 
 	if (argc == 1) {

--- a/tty/libtty/Makefile
+++ b/tty/libtty/Makefile
@@ -6,5 +6,5 @@
 
 NAME := libtty
 LOCAL_SRCS := libtty.c libtty_disc.c
-LOCAL_HEADERS := libtty.h libtty-lf-fifo.h
+LOCAL_HEADERS := libtty.h libtty-lf-fifo.h ttydefaults.h
 include $(static-lib.mk)

--- a/tty/libtty/libtty.c
+++ b/tty/libtty/libtty.c
@@ -90,7 +90,7 @@ static void termios_optimize(libtty_common_t* tty)
 	}
 }
 
-static void termios_init(struct termios* term)
+static void termios_init(struct termios *term, speed_t speed)
 {
 	memset(term, 0, sizeof(*term));
 
@@ -99,8 +99,8 @@ static void termios_init(struct termios* term)
 	term->c_lflag = TTYDEF_LFLAG & TTYSUP_LFLAG;
 	term->c_cflag = TTYDEF_CFLAG;
 
-	term->c_ispeed = TTYDEF_SPEED;
-	term->c_ospeed = TTYDEF_SPEED;
+	term->c_ispeed = speed;
+	term->c_ospeed = speed;
 
 	memcpy(term->c_cc, ttydefchars, sizeof(ttydefchars));
 }
@@ -202,7 +202,7 @@ void libtty_wake_writer(libtty_common_t *tty)
 }
 
 
-int libtty_init(libtty_common_t* tty, libtty_callbacks_t* callbacks, unsigned int bufsize)
+int libtty_init(libtty_common_t *tty, libtty_callbacks_t *callbacks, unsigned int bufsize, speed_t speed)
 {
 	memset(tty, 0, sizeof(*tty));
 	tty->cb = *callbacks;
@@ -230,7 +230,7 @@ int libtty_init(libtty_common_t* tty, libtty_callbacks_t* callbacks, unsigned in
 	fifo_init(tty->tx_fifo, bufsize);
 	fifo_init(tty->rx_fifo, bufsize);
 
-	termios_init(&tty->term);
+	termios_init(&tty->term, speed);
 	termios_optimize(tty);
 
 	tty->ws.ws_row = 25;

--- a/tty/libtty/libtty.h
+++ b/tty/libtty/libtty.h
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <termios.h>
 
+#include "ttydefaults.h"
+
 typedef struct libtty_common_s libtty_common_t;
 typedef struct libtty_callbacks_s libtty_callbacks_t;
 typedef struct fifo_s fifo_t;
@@ -77,7 +79,7 @@ static inline void libtty_read_state_init(libtty_read_state_t *st) {
 
 
 /* bufsize: TX/RX buffer size - has to be power of 2 ! */
-int libtty_init(libtty_common_t* tty, libtty_callbacks_t* callbacks, unsigned int bufsize);
+int libtty_init(libtty_common_t *tty, libtty_callbacks_t *callbacks, unsigned int bufsize, speed_t speed);
 int libtty_destroy(libtty_common_t* tty);
 int libtty_close(libtty_common_t* tty);
 

--- a/tty/pc-tty/ttypc_vt.c
+++ b/tty/pc-tty/ttypc_vt.c
@@ -703,7 +703,7 @@ int ttypc_vt_init(ttypc_t *ttypc, unsigned int ttybuffsz, ttypc_vt_t *vt)
 		}
 	}
 
-	if ((err = libtty_init(&vt->tty, &cb, ttybuffsz)) < 0) {
+	if ((err = libtty_init(&vt->tty, &cb, ttybuffsz, TTYDEF_SPEED)) < 0) {
 		resourceDestroy(vt->lock);
 		munmap(vt->mem, _PAGE_SIZE);
 		if (SCRB_PAGES) {

--- a/tty/spike-tty/spike-tty.c
+++ b/tty/spike-tty/spike-tty.c
@@ -172,7 +172,7 @@ static int _spiketty_init(spiketty_t *spiketty, unsigned int port, unsigned int 
 	callbacks.set_cflag = set_cflag;
 	callbacks.signal_txready = signal_txready;
 
-	if ((err = libtty_init(&spiketty->tty, &callbacks, _PAGE_SIZE)) < 0)
+	if ((err = libtty_init(&spiketty->tty, &callbacks, _PAGE_SIZE, TTYDEF_SPEED)) < 0)
 		return err;
 
 	spiketty->active = 1;

--- a/tty/uart16550/uart16550.c
+++ b/tty/uart16550/uart16550.c
@@ -259,7 +259,7 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed)
 	callbacks.set_cflag = set_cflag;
 	callbacks.signal_txready = signal_txready;
 
-	err = libtty_init(&uart->tty, &callbacks, _PAGE_SIZE);
+	err = libtty_init(&uart->tty, &callbacks, _PAGE_SIZE, libtty_int_to_baudrate(speed));
 	if (err < 0) {
 		return err;
 	}

--- a/tty/zynq7000-uart/zynq7000-uart.c
+++ b/tty/zynq7000-uart/zynq7000-uart.c
@@ -394,7 +394,7 @@ static int uart_init(unsigned int n, speed_t baud, int raw)
 	callbacks.set_baudrate = uart_setBaudrate;
 	callbacks.signal_txready = uart_signalTXReady;
 
-	if (libtty_init(&uart->tty, &callbacks, _PAGE_SIZE) < 0) {
+	if (libtty_init(&uart->tty, &callbacks, _PAGE_SIZE, baud) < 0) {
 		munmap((void *)uart->base, _PAGE_SIZE);
 		return -ENOENT;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
RTOS-259

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the initial baudrate differs from `B115200`, there is no chance to change it using ioctl to `B115200`. 

Invocation of `libtty_init` has been changed in the whole repository.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-posixsrv/pull/16).
- [ ] I will merge this PR by myself when appropriate.
