### PR TITLE
ad7779: apply a sync pulse after configuration

### DIFF
--- a/adc/ad7779/ad7779-driver.c
+++ b/adc/ad7779/ad7779-driver.c
@@ -138,6 +138,12 @@ static int dev_ctl(msg_t *msg)
 				return -EINVAL;
 			if (res != AD7779_OK)
 				return -EIO;
+			/* NOTE: Here SYNC_IN is not required by the docs, but sometimes after
+			 * turning on/off channels we encounter unexpected ADC hang-ups (SPI
+			 * works but we don't get DRDY). Applying SYNC solves the issue. */
+			res = ad7779_pulse_sync();
+			if (res != AD7779_OK)
+				return -EIO;
 			return EOK;
 
 		case adc_dev_ctl__get_config:
@@ -175,6 +181,9 @@ static int dev_ctl(msg_t *msg)
 			res = ad7779_set_channel_mode(dev_ctl.ch_config.channel, mode);
 			if (res == AD7779_ARG_ERROR)
 				return -EINVAL;
+			if (res != AD7779_OK)
+				return -EIO;
+			res = ad7779_pulse_sync();
 			if (res != AD7779_OK)
 				return -EIO;
 			return EOK;
@@ -215,6 +224,9 @@ static int dev_ctl(msg_t *msg)
 				return -EINVAL;
 			if (res != AD7779_OK)
 				return -EIO;
+			res = ad7779_pulse_sync();
+			if (res != AD7779_OK)
+				return -EIO;
 			return EOK;
 
 		case adc_dev_ctl__get_channel_gain:
@@ -235,6 +247,9 @@ static int dev_ctl(msg_t *msg)
 			res = ad7779_set_channel_gain_correction(dev_ctl.calib.channel, dev_ctl.calib.gain);
 			if (res == AD7779_ARG_ERROR)
 				return -EINVAL;
+			if (res != AD7779_OK)
+				return -EIO;
+			res = ad7779_pulse_sync();
 			if (res != AD7779_OK)
 				return -EIO;
 			return EOK;

--- a/adc/ad7779/ad7779.c
+++ b/adc/ad7779/ad7779.c
@@ -76,6 +76,13 @@
 
 #define AD7779_READ_BIT		 (0x80)
 
+/* AD7779_STATUS_REG_3 */
+#define INIT_COMPLETE_BIT (1 << 4)
+
+/* AD7779_GEN_ERR_REG_2 */
+#define RESET_DETECTED_BIT (1 << 5)
+
+
 static int ad7779_read(uint8_t addr, uint8_t *data, uint8_t len)
 {
 	uint8_t buff[len + 1];
@@ -181,6 +188,27 @@ int ad7779_get_mode(ad7779_mode_t *mode)
 	return AD7779_OK;
 }
 
+int ad7779_pulse_sync(void)
+{
+	int res;
+
+	log_debug("resetting internal logic");
+	res = ad7779_gpio(start, 0);
+	if (res != 0) {
+		log_error("failed to set start GPIO to 0");
+		return AD7779_GPIO_IO_ERROR;
+	}
+
+	usleep(2);
+	res = ad7779_gpio(start, 1);
+	if (res != 0) {
+		log_error("failed to set start GPIO to 1");
+		return AD7779_GPIO_IO_ERROR;
+	}
+
+	return AD7779_OK;
+}
+
 int ad7779_set_mode(ad7779_mode_t mode)
 {
 	if (mode == ad7779_mode__high_resolution)
@@ -265,13 +293,6 @@ int ad7779_set_sampling_rate(uint32_t fs)
 	/* Trigger ODR update (by setting SRC_LOAD_UPDATE bit) */
 	log_debug("triggering ODR update by setting SRC_LOAD_UPDATE_BIT");
 	if ((res = ad7779_set_clear_bits(AD7779_SRC_UPDATE, SRC_LOAD_UPDATE_BIT, 0)) < 0)
-		return res;
-
-	/* Reset internal logic */
-	log_debug("reseting internal logic");
-	if ((res = ad7779_set_clear_bits(AD7779_GENERAL_USER_CONFIG_2, 0, SPI_SYNC)) < 0)
-		return res;
-	if ((res = ad7779_set_clear_bits(AD7779_GENERAL_USER_CONFIG_2, SPI_SYNC, 0)) < 0)
 		return res;
 
 	return AD7779_OK;
@@ -543,25 +564,34 @@ static int ad7779_reset(int hard)
 	}
 
 	/* Software reset */
-	ad7779_gpio(start, 0);
-	usleep(10000);
 	ad7779_gpio(reset, 0);
-	usleep(200000);
-	ad7779_gpio(start, 1);
-	usleep(100000);
+	usleep(2);
 	ad7779_gpio(reset, 1);
+	usleep(300);
 
 	memset(status, 0, sizeof(status));
 
 	for (i = 0; i < 4; ++i) {
-		if (!ad7779_get_status(status)) {
-			if (status[16] & 0x10)
-				return AD7779_OK;
+		if (ad7779_get_status(status) != AD7779_OK) {
+			usleep(100 * 1000);
+			continue;
 		}
 
-		usleep(100000);
+		if ((status[16] & INIT_COMPLETE_BIT) && (status[13] & RESET_DETECTED_BIT)) {
+			return AD7779_OK;
+		}
+		else {
+			if (!(status[16] & INIT_COMPLETE_BIT)) {
+				log_error("init bit not detected");
+			}
+			if (!(status[13] & RESET_DETECTED_BIT)) {
+				log_error("reset bit not detected");
+			}
+			break;
+		}
 	}
 
+	log_error("failed to read status after the device restart");
 	return AD7779_CTRL_IO_ERROR;
 }
 
@@ -596,6 +626,10 @@ int ad7779_init(int hard)
 
 	log_debug("switching to high resolution mode");
 	if ((res = ad7779_set_mode(ad7779_mode__high_resolution)) < 0)
+		return res;
+
+	/* Toggle START (to generate SYNC_IN) after mode change */
+	if ((res = ad7779_pulse_sync()) < 0)
 		return res;
 
 	/* Use one DOUTx line; DCLK_CLK_DIV = 1 */

--- a/adc/ad7779/ad7779.h
+++ b/adc/ad7779/ad7779.h
@@ -89,6 +89,8 @@ int ad7779_set_channel_gain_correction(uint8_t channel, uint32_t gain);
 
 int ad7779_get_status(uint8_t *status_buf);
 
+int ad7779_pulse_sync(void);
+
 /* For debugging purposes */
 int ad7779_print_status(void);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Use a START pulse to generate an internal SYNC_IN pulse after each configuration. Additionaly, I removed the START pulse and long sleeps after device reboot. I have tested this on imx6ull and imxrt based architectures and it seems to work well. Hang-ups do not occur.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull, imxrt106x.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
