### PR TITLE
stm32l4-multi: Extend API with IV and key (derived or not) retrieval

### DIFF
--- a/multi/stm32l4-multi/libmulti/include/libmulti/libaes.h
+++ b/multi/stm32l4-multi/libmulti/include/libmulti/libaes.h
@@ -26,7 +26,16 @@ enum { aes_encrypt = 0, aes_decrypt = 2 };
 void libaes_setKey(const unsigned char *key, int keylen);
 
 
+void libaes_getKey(unsigned char *key, int keylen);
+
+
 void libaes_setIv(const unsigned char *iv);
+
+
+void libaes_getIv(unsigned char *iv);
+
+
+void libaes_deriveDecryptionKey(void);
 
 
 void libaes_prepare(int mode, int dir);


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

Initialization Vector and key can now be retrieved from the AES peripheral. This makes it possible to perform encryption/decryption on non-contiguous data - IV and key can be stored in a software context for later use.

Decryption key can be generated on-demand instead of forcing the operation every time some buffer is to be decrypted. The key can then be stored in a software context and reused without the need to generate it again.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: stm32l4.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
