### PR TITLE
Fix: USB PHY on `imxrt117x` does not set platformctl `lpcg.op` field in `setClock()`

### DIFF
--- a/usb/ehci/phy-imxrt117x.c
+++ b/usb/ehci/phy-imxrt117x.c
@@ -63,6 +63,7 @@ static int setClock(int dev, unsigned int state)
 
 	pctl.action = pctl_set;
 	pctl.type = pctl_lpcg;
+	pctl.lpcg.op = pctl_lpcg_op_direct;
 	pctl.lpcg.dev = dev;
 	pctl.lpcg.state = (state != 0);
 


### PR DESCRIPTION
JIRA: RTOS-268

Fixes: USB PHY on `imxrt117x` does not set platformctl `lpcg.op` field in `setClock()`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1179-nil).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
