### PR TITLE
stm32l4-multi: Fix unstable writes to internal flash

### DIFF
--- a/multi/stm32l4-multi/flash.c
+++ b/multi/stm32l4-multi/flash.c
@@ -83,6 +83,7 @@ static inline void _program_lock(void)
 {
 	*(flash_common.flash + flash_cr) |= 1ul << 31;
 	dataBarier();
+	keepidle(0);
 }
 
 
@@ -90,6 +91,7 @@ static void _program_unlock(void)
 {
 	/* We'll get hardfault if we do this wrong... */
 
+	keepidle(1);
 	*(flash_common.flash + flash_keyr) = 0x45670123;
 	dataBarier();
 	*(flash_common.flash + flash_keyr) = 0xcdef89ab;


### PR DESCRIPTION
Added keepidle during operations on flash so as to avoid random delays and possible write failures

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: stm32l4.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
