### PR TITLE
stm32l4-multi: Fix SPI deinitialization procedure

### DIFF
--- a/multi/stm32l4-multi/libmulti/libdma.c
+++ b/multi/stm32l4-multi/libmulti/libdma.c
@@ -107,6 +107,7 @@ static void _prepare_transfer(volatile unsigned int *channel_base, void *maddr, 
 {
 	*(channel_base + cmar) = (unsigned int) maddr;
 	*(channel_base + cndtr) = len;
+	dataBarier();
 
 	if (tcie)
 		/* Enable Transfer Complete interrupt, enable channel */
@@ -114,13 +115,17 @@ static void _prepare_transfer(volatile unsigned int *channel_base, void *maddr, 
 	else
 		/* Enable channel */
 		*(channel_base + ccr) |= 0x1;
+
+	dataBarier();
 }
 
 
 static void _unprepare_transfer(volatile unsigned int *channel_base)
 {
+	dataBarier();
 	/* Disable Transfer Complete interrupt, disable channel */
 	*(channel_base + ccr) &= ~((1 << 1) | 0x1);
+	dataBarier();
 }
 
 


### PR DESCRIPTION

## Description
<!--- Describe your changes shortly -->

SPI peripheral was not deinitialized properly and consistently in all modes of operation (read, write, readwrite, with or without DMA), thus potentially leaving unprocessed data in FIFOs. This change makes the peripheral enabled only for the time of a transaction and deinitializes it afterwards. Also, a few missing data barriers were added for SPI and DMA.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: stm32l4.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
