### PR TITLE
pa6h: more error calculations

### DIFF
--- a/sensors/gps/nmea.c
+++ b/sensors/gps/nmea.c
@@ -34,14 +34,16 @@ static char *nmea_nField(char *str, int n)
 }
 
 
-static int nmea_parsegsa(char *str, nmea_t *out)
+static void nmea_parsegsa(char *str, nmea_t *out)
 {
 	char *p = str;
 	nmea_gsa_t in;
 
+	out->type = nmea_broken;
+
 	p = nmea_nField(p, field_gsa_fix);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* if failed, gsa_fix_notavailable will be assigned */
 	in.fix = strtoul(p + 1, NULL, 10);
@@ -51,78 +53,78 @@ static int nmea_parsegsa(char *str, nmea_t *out)
 
 	p = nmea_nField(p, field_gsa_pdop - field_gsa_fix);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.pdop = strtod(p + 1, NULL);
 
 	p = nmea_nField(p, field_gsa_hdop - field_gsa_pdop);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.hdop = strtod(p + 1, NULL);
 
 	p = nmea_nField(p, field_gsa_vdop - field_gsa_hdop);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.vdop = strtod(p + 1, NULL);
 
 	out->msg.gsa = in;
 	out->type = nmea_gsa;
-
-	return nmea_gsa;
 }
 
 
-static int nmea_parsevtg(char *str, nmea_t *out)
+static void nmea_parsevtg(char *str, nmea_t *out)
 {
 	char *p = str;
 	nmea_vtg_t in;
 
+	out->type = nmea_broken;
+
 	p = nmea_nField(p, field_vtg_track);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.track = strtod(p + 1, NULL);
 
 	p = nmea_nField(p, field_vtg_speedknots - field_vtg_track);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.speed_knots = strtod(p + 1, NULL);
 
 	p = nmea_nField(p, field_vtg_speedkmh - field_vtg_speedknots);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.speed_kmh = strtod(p + 1, NULL);
 
 	out->msg.vtg = in;
 	out->type = nmea_vtg;
-
-	return nmea_vtg;
 }
 
 
-static int nmea_parsegga(char *str, nmea_t *out)
+static void nmea_parsegga(char *str, nmea_t *out)
 {
 	char *p = str, *sign;
 	nmea_gga_t in;
 
+	out->type = nmea_broken;
+
 	/* latitude read */
 	p = nmea_nField(p, field_gga_lat);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	sign = nmea_nField(p, 1);
 	if (sign == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.lat = strtod(p + 1, NULL);
@@ -133,11 +135,11 @@ static int nmea_parsegga(char *str, nmea_t *out)
 	/* longitude read */
 	p = nmea_nField(p, field_gga_lon - field_gga_lat);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	sign = nmea_nField(p, 1);
 	if (sign == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.lon = strtod(p + 1, NULL);
@@ -148,7 +150,7 @@ static int nmea_parsegga(char *str, nmea_t *out)
 	/* GPS Quality indicator read */
 	p = nmea_nField(p, field_gga_fix - field_gga_lon);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 
 	in.fix = strtoul(p + 1, NULL, 10);
@@ -159,7 +161,7 @@ static int nmea_parsegga(char *str, nmea_t *out)
 	/* number of satellites in use read */
 	p = nmea_nField(p, field_gga_sats - field_gga_fix);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.sats = strtoul(p + 1, NULL, 10);
@@ -167,7 +169,7 @@ static int nmea_parsegga(char *str, nmea_t *out)
 	/* horizontal dilution of precision read */
 	p = nmea_nField(p, field_gga_hdop - field_gga_sats);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.hdop = strtod(p + 1, NULL);
@@ -175,7 +177,7 @@ static int nmea_parsegga(char *str, nmea_t *out)
 	/* Antenna altitude above mean-sea-level read */
 	p = nmea_nField(p, field_gga_h_asl - field_gga_hdop);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.h_asl = strtod(p + 1, NULL);
@@ -183,31 +185,31 @@ static int nmea_parsegga(char *str, nmea_t *out)
 	/* Geoidal separation read */
 	p = nmea_nField(p, field_gga_h_wgs - field_gga_h_asl);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.h_wgs = strtod(p + 1, NULL);
 
 	out->msg.gga = in;
 	out->type = nmea_gga;
-
-	return nmea_gga;
 }
 
 
-static int nmea_parsermc(char *str, nmea_t *out)
+static void nmea_parsermc(char *str, nmea_t *out)
 {
 	char *p = str, *sign;
 	nmea_rmc_t in;
 
+	out->type = nmea_broken;
+
 	/* latitude read */
 	p = nmea_nField(p, field_rmc_lat);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	sign = nmea_nField(p, 1);
 	if (sign == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.lat = strtod(p + 1, NULL);
@@ -217,11 +219,11 @@ static int nmea_parsermc(char *str, nmea_t *out)
 	/* longitude read */
 	p = nmea_nField(p, field_rmc_lon - field_rmc_lat);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	sign = nmea_nField(p, 1);
 	if (sign == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.lon = strtod(p + 1, NULL);
@@ -231,7 +233,7 @@ static int nmea_parsermc(char *str, nmea_t *out)
 	/* speed in knots read */
 	p = nmea_nField(p, field_rmc_speedknots - field_rmc_lon);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.speed = strtod(p + 1, NULL);
@@ -239,7 +241,7 @@ static int nmea_parsermc(char *str, nmea_t *out)
 	/* course read */
 	p = nmea_nField(p, field_rmc_course - field_rmc_speedknots);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.course = strtod(p + 1, NULL);
@@ -247,37 +249,31 @@ static int nmea_parsermc(char *str, nmea_t *out)
 	/* magnetic variation read */
 	p = nmea_nField(p, field_rmc_magvar - field_rmc_course);
 	if (p == NULL) {
-		return nmea_broken;
+		return;
 	}
 	/* when error occurred 0 is assigned */
 	in.magvar = strtod(p + 1, NULL);
 
 	out->msg.rmc = in;
 	out->type = nmea_rmc;
-
-	return nmea_rmc;
 }
 
 
-int nmea_interpreter(char *str, nmea_t *out)
+void nmea_interpreter(char *str, nmea_t *out)
 {
-	int ret;
-
 	if (strncmp(str, "$GPGSA", 6) == 0) {
-		ret = nmea_parsegsa(str, out);
+		nmea_parsegsa(str, out);
 	}
 	else if (strncmp(str, "$GPVTG", 6) == 0) {
-		ret = nmea_parsevtg(str, out);
+		nmea_parsevtg(str, out);
 	}
 	else if (strncmp(str, "$GPGGA", 6) == 0) {
-		ret = nmea_parsegga(str, out);
+		nmea_parsegga(str, out);
 	}
 	else if (strncmp(str, "$GPRMC", 6) == 0) {
-		ret = nmea_parsermc(str, out);
+		nmea_parsermc(str, out);
 	}
 	else {
-		ret = nmea_unknown;
+		out->type = nmea_unknown;
 	}
-
-	return ret;
 }

--- a/sensors/gps/nmea.h
+++ b/sensors/gps/nmea.h
@@ -91,7 +91,7 @@ typedef struct {
 } nmea_t;
 
 
-/* interpret one line of gps output into nmea message, if known */
-extern int nmea_interpreter(char *str, nmea_t *out);
+/* interpret one line of gps output into nmea message */
+extern void nmea_interpreter(char *str, nmea_t *out);
 
 #endif

--- a/sensors/include/libsensors.h
+++ b/sensors/include/libsensors.h
@@ -60,8 +60,9 @@ typedef struct {
 	int32_t velNorth;      /* GPS North velocity, [mm/s] */
 	int32_t velEast;       /* GPS East velocity, [mm/s] */
 	int32_t velDown;       /* GPS Down velocity, [mm/s] */
-	uint32_t eph;          /* GPS horizontal position accuracy 1E-3 [m] (millimetres)*/
-	uint32_t epv;          /* GPS vertical position accuracy 1E-3 [m] (millimetres)*/
+	uint32_t eph;          /* GPS horizontal position accuracy 1E-3 [m] (millimetres) */
+	uint32_t epv;          /* GPS vertical position accuracy 1E-3 [m] (millimetres) */
+	uint32_t evel;         /* GPS velocity accuracy 1E-3 [m] (millimetres) */
 	uint16_t heading;      /* value in [mrad] */
 	int16_t headingOffs;   /* value in [mrad] */
 	uint16_t headingAccur; /* value in [mrad] */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 1) Addition of velocity error field to gps data structure
 2) Remove some of redundancies in parsing/interpreting nmea messages
    - nmea parsers do not return message type. They store it inside message structure passed to them
    - interpreter does not return message type.
    - pa6h_update returns information about the need of publishing new data

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 - hdop/vdop values are insufficient by itself to calculate error in position in SI units. For this an arbitrary value of base (minimum) error in position/velocity is needed which is device specific. Therefore calculation of such error must be done  in the driver module
 - update logic was corrected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
