### PR TITLE
storage: adapt to changed mtMount message handling

### DIFF
--- a/storage/imx6ull-flash/flashsrv.c
+++ b/storage/imx6ull-flash/flashsrv.c
@@ -448,7 +448,8 @@ static void flashsrv_devCtrl(msg_t *msg)
 
 static void flashsrv_msgHandler(void *arg, msg_t *msg)
 {
-	mount_msg_t *mnt;
+	mount_i_msg_t *imnt;
+	mount_o_msg_t *omnt;
 
 	switch (msg->type) {
 		case mtOpen:
@@ -469,9 +470,10 @@ static void flashsrv_msgHandler(void *arg, msg_t *msg)
 			break;
 
 		case mtMount:
-			mnt = (mount_msg_t *)msg->i.raw;
-			TRACE("DEV mount - fs: %s", mnt->fstype);
-			storage_mountfs(storage_get(mnt->id), mnt->fstype, NULL, 0, (oid_t *)msg->o.raw);
+			imnt = (mount_i_msg_t *)msg->i.raw;
+			omnt = (mount_o_msg_t *)msg->o.raw;
+			TRACE("DEV mount - fs: %s", imnt->fstype);
+			omnt->err = storage_mountfs(storage_get(imnt->id), imnt->fstype, msg->i.data, imnt->mode, &omnt->root);
 			break;
 
 		case mtGetAttr:

--- a/storage/imx6ull-flashnor/flashnor.c
+++ b/storage/imx6ull-flashnor/flashnor.c
@@ -89,12 +89,14 @@ static void meterfs_handler(void *arg, msg_t *msg)
 
 static void flashnor_msgloop(void *arg, msg_t *msg)
 {
-	mount_msg_t *mnt;
+	mount_i_msg_t *imnt;
+	mount_o_msg_t *omnt;
 
 	switch (msg->type) {
 		case mtMount:
-			mnt = (mount_msg_t *)msg->i.raw;
-			storage_mountfs(storage_get(mnt->id), mnt->fstype, NULL, 0, (oid_t *)msg->o.raw);
+			imnt = (mount_i_msg_t *)msg->i.raw;
+			omnt = (mount_o_msg_t *)msg->o.raw;
+			omnt->err = storage_mountfs(storage_get(imnt->id), imnt->fstype, msg->i.data, imnt->mode, &omnt->root);
 			break;
 
 		default:

--- a/storage/pc-ata/atasrv.c
+++ b/storage/pc-ata/atasrv.c
@@ -448,7 +448,8 @@ static void atasrv_msgloop(void *arg)
 {
 	unsigned long rid;
 	unsigned port = *(unsigned int *)arg;
-	mount_msg_t *mnt;
+	mount_i_msg_t *imnt;
+	mount_o_msg_t *omnt;
 	msg_t msg;
 
 	for (;;) {
@@ -457,8 +458,9 @@ static void atasrv_msgloop(void *arg)
 
 		switch (msg.type) {
 		case mtMount:
-			mnt = (mount_msg_t *)msg.i.raw;
-			atasrv_mount(mnt->id, mnt->fstype, (oid_t *)msg.o.raw);
+			imnt = (mount_i_msg_t *)msg.i.raw;
+			omnt = (mount_o_msg_t *)msg.o.raw;
+			omnt->err = atasrv_mount(imnt->id, imnt->fstype, &omnt->root);
 			break;
 
 		case mtOpen:

--- a/storage/zynq7000-flash/zynq7000-flash.c
+++ b/storage/zynq7000-flash/zynq7000-flash.c
@@ -163,7 +163,8 @@ static int flash_devCtl(oid_t *oid)
 static void flash_msgHandler(void *arg, msg_t *msg)
 {
 	storage_t *strg;
-	mount_msg_t *mnt;
+	mount_i_msg_t *imnt;
+	mount_o_msg_t *omnt;
 
 	switch (msg->type) {
 		case mtOpen:
@@ -189,8 +190,9 @@ static void flash_msgHandler(void *arg, msg_t *msg)
 			break;
 
 		case mtMount:
-			mnt = (mount_msg_t *)msg->i.raw;
-			storage_mountfs(storage_get(GET_STORAGE_ID(mnt->id)), mnt->fstype, NULL, 0, (oid_t *)msg->o.raw);
+			imnt = (mount_i_msg_t *)msg->i.raw;
+			omnt = (mount_o_msg_t *)msg->o.raw;
+			omnt->err = storage_mountfs(storage_get(GET_STORAGE_ID(imnt->id)), imnt->fstype, msg->i.data, imnt->mode, &omnt->root);
 			break;
 
 		case mtDevCtl:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Adapted new `mtMount` message handling.
Added correct passing of mount `mode` and `data` parameters to the mounting function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: RTOS-290](https://jira.phoenix-rtos.com/browse/RTOS-290)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
https://github.com/phoenix-rtos/phoenix-rtos-project/pull/557
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/libphoenix/pull/220
- [ ] I will merge this PR by myself when appropriate.
