### PR TITLE
edma: add support for multiple EDMA drivers

### DIFF
--- a/adc/ad7779/imxrt/dma.c
+++ b/adc/ad7779/imxrt/dma.c
@@ -41,8 +41,12 @@ static struct {
 static int edma_error_handler(unsigned int n, void *arg)
 {
 	/* TODO: Store some info for debugging? Notify about it somehow? */
-	sai_rx_disable();
-	edma_clear_error(SAI1_RX_DMA_CHANNEL);
+	const uint32_t mask = 1U << SAI1_RX_DMA_CHANNEL;
+
+	if (edma_error_channel() & mask) {
+		sai_rx_disable();
+		edma_clear_error(SAI1_RX_DMA_CHANNEL);
+	}
 
 	return 0;
 }

--- a/adc/ade7913/ade7913-driver.c
+++ b/adc/ade7913/ade7913-driver.c
@@ -221,7 +221,11 @@ static int edma_spi_rcv_irq_handler(unsigned int n, void *arg)
 
 static int edma_error_handler(unsigned int n, void *arg)
 {
-	edma_clear_error(DREADY_DMA_CHANNEL);
+	const uint32_t mask = 1U << DREADY_DMA_CHANNEL;
+
+	if (edma_error_channel() & mask) {
+		edma_clear_error(DREADY_DMA_CHANNEL);
+	}
 
 	return EOK;
 }


### PR DESCRIPTION
EDMA may be used by multiple drivers at the same time so channel number must be checked inside error ISR to make sure it's our error. EDMA initialization is done by first driver calling edma_init().

JIRA: BES-239

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt-1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
