### PR TITLE
imx6ull-flash: add temporary fix for reading broken metadata

### DIFF
--- a/storage/imx6ull-flash/flashdev.c
+++ b/storage/imx6ull-flash/flashdev.c
@@ -397,7 +397,12 @@ static int flashmtd_metaRead(struct _storage_t *strg, off_t offs, void *data, si
 		err = _flashmtd_checkECC(strg, paddr, 1);
 		if (err == -EBADMSG) {
 			/* Continue reading, let the client handle -EBADMSG */
-			ret = -EBADMSG;
+			/* ret = -EBADMSG; */
+
+			/* TODO: temporary fix for broken metadata */
+			/* To be removed once proper fix is in place */
+			memset(meta->metadata, 0xff, strg->dev->mtd->oobSize);
+			ret = -EUCLEAN;
 		}
 		else if (err == -EUCLEAN && ret != -EBADMSG) {
 			/* Not a critical error, continue reading, return -EUCLEAN, but don't overwrite -EBADMSG */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Ignore broken metadata. Assume clean metadata instead (0xff only).
Temporary fix for jffs2 not being able to mount partition with broken metadata.
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-371](https://jira.phoenix-rtos.com/browse/DTR-371)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
