### PR TITLE
imx6ull: NOR flash driver over QSPI

### DIFF
--- a/_targets/Makefile.armv7a7-imx6ull
+++ b/_targets/Makefile.armv7a7-imx6ull
@@ -9,7 +9,6 @@
 DEFAULT_COMPONENTS := imx6ull-sdma imx6ull-gpio libimx6ull-ecspi libimx6ull-qspi
 DEFAULT_COMPONENTS += imx6ull-flash
 DEFAULT_COMPONENTS += imx6ull-flashnor
-DEFAULT_COMPONENTS += flashnor-test
 DEFAULT_COMPONENTS += libusbclient cdc-demo
 DEFAULT_COMPONENTS += imx6ull-uart imx6ull-otp
 DEFAULT_COMPONENTS += imx6ull-wdg imx6ull-i2c imx6ull-sdio

--- a/_targets/Makefile.armv7a7-imx6ull
+++ b/_targets/Makefile.armv7a7-imx6ull
@@ -6,9 +6,10 @@
 # Copyright 2019 Phoenix Systems
 #
 
-DEFAULT_COMPONENTS := imx6ull-sdma imx6ull-gpio libimx6ull-ecspi
+DEFAULT_COMPONENTS := imx6ull-sdma imx6ull-gpio libimx6ull-ecspi libimx6ull-qspi
 DEFAULT_COMPONENTS += imx6ull-flash
 DEFAULT_COMPONENTS += imx6ull-flashnor
+DEFAULT_COMPONENTS += flashnor-test
 DEFAULT_COMPONENTS += libusbclient cdc-demo
 DEFAULT_COMPONENTS += imx6ull-uart imx6ull-otp
 DEFAULT_COMPONENTS += imx6ull-wdg imx6ull-i2c imx6ull-sdio

--- a/spi/imx6ull-qspi/Makefile
+++ b/spi/imx6ull-qspi/Makefile
@@ -1,0 +1,10 @@
+#
+# Makefile for Phoenix-RTOS imx6ull-qspi driver
+#
+# Copyright 2023 Phoenix Systems
+#
+
+NAME := libimx6ull-qspi
+LOCAL_SRCS := qspi.c
+LOCAL_HEADERS := qspi.h
+include $(static-lib.mk)

--- a/spi/imx6ull-qspi/qspi.c
+++ b/spi/imx6ull-qspi/qspi.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <phoenix/arch/imx6ull.h>
 #include <board_config.h>
+#include <unistd.h>
 
 #include "qspi.h"
 
@@ -120,7 +121,7 @@ struct {
 /* TODO find clock frequency - ~50Mhz */
 
 
-static int wait_cmd_done_busy()
+static int wait_cmd_done_busy(void)
 {
 	int max_iter;
 
@@ -220,7 +221,7 @@ void qspi_setTCSS(uint8_t cycles)
 
 int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size)
 {
-	uint8_t to_read, byte, i;
+	uint8_t byte, i;
 	uint16_t len = 0;
 	uint32_t reg;
 	int max_iter;

--- a/spi/imx6ull-qspi/qspi.c
+++ b/spi/imx6ull-qspi/qspi.c
@@ -198,7 +198,7 @@ void qspi_setTCSS(uint8_t cycles)
 	*QSPI_FLSHCR_ADDR = (*QSPI_FLSHCR_ADDR & ~(0x0F)) | cycles;
 }
 
-int _qspi_read(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size)
+int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size)
 {
 	uint8_t to_read, byte, i;
 	uint16_t len = 0;

--- a/spi/imx6ull-qspi/qspi.c
+++ b/spi/imx6ull-qspi/qspi.c
@@ -91,27 +91,8 @@
 
 #define NUM_LUT_SEQ 16
 
-struct {
-	int mux;
-	char val;
-	char sion;
-} qspi_pctl_mux[2][8] = {
-	{ { pctl_mux_nand_d7, 2, 0 }, { pctl_mux_nand_ale, 2, 0 }, { pctl_mux_nand_wp, 2, 0 }, { pctl_mux_nand_rdy, 2, 0 }, { pctl_mux_nand_ce0, 2, 0 }, { pctl_mux_nand_ce1, 2, 0 }, { pctl_mux_nand_cle, 2, 0 }, { pctl_mux_nand_dqs, 2, 0 } },
-	{ { pctl_mux_nand_re, 2, 0 }, { pctl_mux_nand_we, 2, 0 }, { pctl_mux_nand_d0, 2, 0 }, { pctl_mux_nand_d1, 2, 0 }, { pctl_mux_nand_d2, 2, 0 }, { pctl_mux_nand_d3, 2, 0 }, { pctl_mux_nand_d4, 2, 0 }, { pctl_mux_nand_d5, 2, 0 } },
-};
 
-struct {
-	int pad;
-	char speed;
-	char dse;
-	char sre;
-} qspi_pctl_pad[2][8] = {
-	{ { pctl_pad_nand_d7, 1, 4, 0 }, { pctl_pad_nand_ale, 1, 4, 0 }, { pctl_pad_nand_wp, 1, 4, 0 }, { pctl_pad_nand_rdy, 1, 4, 0 }, { pctl_pad_nand_ce0, 1, 4, 0 }, { pctl_pad_nand_ce1, 1, 4, 0 }, { pctl_pad_nand_cle, 1, 4, 0 }, { pctl_pad_nand_dqs, 1, 4, 0 } },
-	{ { pctl_pad_nand_re, 1, 4, 0 }, { pctl_pad_nand_we, 1, 4, 0 }, { pctl_pad_nand_d0, 1, 4, 0 }, { pctl_pad_nand_d1, 1, 4, 0 }, { pctl_pad_nand_d2, 1, 4, 0 }, { pctl_pad_nand_d3, 1, 4, 0 }, { pctl_pad_nand_d4, 1, 4, 0 }, { pctl_pad_nand_d5, 1, 4, 0 } },
-};
-
-
-struct {
+static struct {
 	volatile uint32_t *base;
 	uint32_t flash_base_addr[2];
 	int init;
@@ -123,15 +104,15 @@ struct {
 
 static int wait_cmd_done_busy(void)
 {
-	int max_iter;
+	int maxIter;
 
-	for (max_iter = 1000; max_iter > 0; max_iter--) {
+	for (maxIter = 1000; maxIter > 0; maxIter--) {
 		if ((*(qspi_common.base + QSPI_SR) & QSPI_SR_BUSY) == 0) {
 			return EOK;
 		}
 		usleep(100);
 	}
-	printf("WAIT BUSY TIMEOUT\n");
+	printf("imx6ull-qspi: busy wait timeout\n");
 	return -ETIME;
 }
 
@@ -140,6 +121,23 @@ static void set_mux(qspi_dev_t dev_no)
 {
 	platformctl_t ctl;
 	int i;
+	static const struct {
+		int mux;
+		char val;
+		char sion;
+	} qspi_pctl_mux[2][8] = {
+		{ { pctl_mux_nand_d7, 2, 0 }, { pctl_mux_nand_ale, 2, 0 }, { pctl_mux_nand_wp, 2, 0 }, { pctl_mux_nand_rdy, 2, 0 }, { pctl_mux_nand_ce0, 2, 0 }, { pctl_mux_nand_ce1, 2, 0 }, { pctl_mux_nand_cle, 2, 0 }, { pctl_mux_nand_dqs, 2, 0 } },
+		{ { pctl_mux_nand_re, 2, 0 }, { pctl_mux_nand_we, 2, 0 }, { pctl_mux_nand_d0, 2, 0 }, { pctl_mux_nand_d1, 2, 0 }, { pctl_mux_nand_d2, 2, 0 }, { pctl_mux_nand_d3, 2, 0 }, { pctl_mux_nand_d4, 2, 0 }, { pctl_mux_nand_d5, 2, 0 } },
+	};
+	static const struct {
+		int pad;
+		char speed;
+		char dse;
+		char sre;
+	} qspi_pctl_pad[2][8] = {
+		{ { pctl_pad_nand_d7, 1, 4, 0 }, { pctl_pad_nand_ale, 1, 4, 0 }, { pctl_pad_nand_wp, 1, 4, 0 }, { pctl_pad_nand_rdy, 1, 4, 0 }, { pctl_pad_nand_ce0, 1, 4, 0 }, { pctl_pad_nand_ce1, 1, 4, 0 }, { pctl_pad_nand_cle, 1, 4, 0 }, { pctl_pad_nand_dqs, 1, 4, 0 } },
+		{ { pctl_pad_nand_re, 1, 4, 0 }, { pctl_pad_nand_we, 1, 4, 0 }, { pctl_pad_nand_d0, 1, 4, 0 }, { pctl_pad_nand_d1, 1, 4, 0 }, { pctl_pad_nand_d2, 1, 4, 0 }, { pctl_pad_nand_d3, 1, 4, 0 }, { pctl_pad_nand_d4, 1, 4, 0 }, { pctl_pad_nand_d5, 1, 4, 0 } },
+	};
 
 	ctl.action = pctl_set;
 	ctl.type = pctl_iomux;
@@ -176,7 +174,7 @@ static void set_clk(void)
 }
 
 
-int qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq)
+int _qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq)
 {
 	int i;
 
@@ -209,13 +207,13 @@ static void set_IPCR(int seq_num, size_t idatsz)
 }
 
 
-void qspi_setTCSH(uint8_t cycles)
+void _qspi_setTCSH(uint8_t cycles)
 {
 	*(qspi_common.base + QSPI_FLSHCR) = (*(qspi_common.base + QSPI_FLSHCR) & ~(0x0f << 8)) | (cycles << 8);
 }
 
 
-void qspi_setTCSS(uint8_t cycles)
+void _qspi_setTCSS(uint8_t cycles)
 {
 	*(qspi_common.base + QSPI_FLSHCR) = (*(qspi_common.base + QSPI_FLSHCR) & ~(0x0f)) | cycles;
 }
@@ -223,10 +221,10 @@ void qspi_setTCSS(uint8_t cycles)
 
 int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size)
 {
-	uint8_t byte, i;
-	uint16_t len = 0;
+	uint8_t i;
+	size_t byte, len = 0;
 	uint32_t reg;
-	int max_iter;
+	int maxIter;
 
 	if ((dev != qspi_flash_a) && (dev != qspi_flash_b)) {
 		return -ENODEV;
@@ -242,19 +240,19 @@ int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *bu
 	set_IPCR(lut_seq, size);
 
 	while (len < size) {
-		for (max_iter = 1000; max_iter > 0; max_iter--) {
+		for (maxIter = 1000; maxIter > 0; maxIter--) {
 			reg = *(qspi_common.base + QSPI_SR);
 			if (((reg & QSPI_SR_RXWE) != 0) || ((reg & QSPI_SR_BUSY) == 0)) {
 				break;
 			}
 			usleep(100);
 		}
-		if (max_iter == 0) {
-			printf("READ TIMEOUT\n");
+		if (maxIter == 0) {
+			printf("imx6ull-qspi: read timeout\n");
 			return -ETIME;
 		}
 
-		for (i = 0; (i < WATERMARK + 1) && (len < size); i++) {
+		for (i = 0; (i <= WATERMARK) && (len < size); i++) {
 			reg = *(qspi_common.base + QSPI_RBDRn(i));
 			for (byte = 0; (byte < 4) && (len + byte < size); byte++) {
 				((uint8_t *)buf)[len + byte] = reg & 0xff;
@@ -290,7 +288,7 @@ static size_t write_tx(const void *data, size_t size)
 int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void *data, size_t size)
 {
 	size_t sent = 0;
-	int max_iter;
+	int maxIter;
 
 	if ((dev != qspi_flash_a) && (dev != qspi_flash_b)) {
 		return -ENODEV;
@@ -299,8 +297,9 @@ int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void 
 		return -EINVAL;
 	}
 
-	if (*(qspi_common.base + QSPI_SR) & QSPI_SR_TXEDA) /* Check if TX buffer is not empty. */
+	if (((*(qspi_common.base + QSPI_SR)) & QSPI_SR_TXEDA) != 0) { /* Check if TX buffer is not empty. */
 		*(qspi_common.base + QSPI_MCR) |= QSPI_MCR_CLR_TXF;
+	}
 
 	*(qspi_common.base + QSPI_SFAR) = qspi_common.flash_base_addr[dev] + addr;
 
@@ -309,14 +308,18 @@ int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void 
 	set_IPCR(lut_seq, size);
 
 	if (sent < size) {
-		for (max_iter = 1000; max_iter > 0; max_iter--) {
+		maxIter = 1000;
+		while (maxIter > 0) {
 			sent += write_tx(data + sent, size - sent);
 			if (sent >= size) {
 				break;
 			}
+			if (sent == 0) {
+				maxIter--;
+			}
 			usleep(100);
 		}
-		if (max_iter == 0) {
+		if (maxIter == 0) {
 			printf("WRITE TIMEOUT\n");
 			return -ETIME;
 		}

--- a/spi/imx6ull-qspi/qspi.c
+++ b/spi/imx6ull-qspi/qspi.c
@@ -19,8 +19,9 @@
 #include <stdbool.h>
 #include <string.h>
 #include <phoenix/arch/imx6ull.h>
-#include "qspi.h"
 #include <board_config.h>
+
+#include "qspi.h"
 
 /* Default values for not configured boards */
 #ifndef QSPI_FLASH_A1_SIZE
@@ -38,21 +39,21 @@
 
 #define QSPI_MMAP_BASE 0x60000000
 
-#define QSPI_BASE ((uint32_t *)0x21E0000)
+#define QSPI_BASE ((void *)0x21e0000)
 
 #define QSPI_LCKCR_ADDR   (qspi_common.base + 0x304 / sizeof(uint32_t))
 #define QSPI_LCKCR_LOCK   0x01
 #define QSPI_LCKCR_UNLOCK 0x02
 
 #define QSPI_LUT_KEY_ADDR (qspi_common.base + 0x300 / sizeof(uint32_t))
-#define QSPI_LUT_KEY      0x5AF05AF0
+#define QSPI_LUT_KEY      0x5af05af0
 
 #define QSPI_LUTn_ADDR(n)      (qspi_common.base + (0x310 + 4 * (n)) / sizeof(uint32_t))
 #define QSPI_SEQ_START_REGN(n) (4 * (n))
 
 #define QSPI_IPCR_ADDR                    (qspi_common.base + 0x08 / sizeof(uint32_t))
-#define QSPI_IPCR_SET_SEQID(reg, seqid)   ((reg) & ~(0x0F << 24)) | ((seqid & 0x0F) << 24)
-#define QSPI_IPCR_SET_IDATSZ(reg, idatsz) ((reg) & ~(0xFFFF)) | (idatsz)
+#define QSPI_IPCR_SET_SEQID(reg, seqid)   ((reg) & ~(0x0f << 24)) | ((seqid & 0x0f) << 24)
+#define QSPI_IPCR_SET_IDATSZ(reg, idatsz) ((reg) & ~(0xffff)) | (idatsz)
 
 #define QSPI_FLSHCR_ADDR (qspi_common.base + 0x0C / sizeof(uint32_t))
 
@@ -63,7 +64,7 @@
 
 #define QSPI_BFGENCR_ADDR (qspi_common.base + 0x20 / sizeof(uint32_t))
 
-#define QSPI_SR_ADDR   (qspi_common.base + 0x15C / sizeof(uint32_t))
+#define QSPI_SR_ADDR   (qspi_common.base + 0x15c / sizeof(uint32_t))
 #define QSPI_SR_BUSY   (0x01)
 #define QSPI_SR_RXWE   (0x01 << 16)
 #define QSPI_SR_TXEDA  (0x01 << 24)
@@ -71,8 +72,8 @@
 
 #define QSPI_RBDRn_ADRR(n) (qspi_common.base + (0x200 + 4 * (n)) / sizeof(uint32_t))
 
-#define QSPI_RBSR_ADRR    (qspi_common.base + 0x10C / sizeof(uint32_t))
-#define QSPI_RBSR_TO_READ (((*QSPI_RBSR_ADRR) >> 8) & 0x3F)
+#define QSPI_RBSR_ADRR    (qspi_common.base + 0x10c / sizeof(uint32_t))
+#define QSPI_RBSR_TO_READ (((*QSPI_RBSR_ADRR) >> 8) & 0x3f)
 
 #define QSPI_SFAR_ADDR (qspi_common.base + 0x100 / sizeof(uint32_t))
 
@@ -87,7 +88,7 @@
 #define QSPI_SFA1AD (qspi_common.base + 0x180 / sizeof(uint32_t))
 #define QSPI_SFA2AD (qspi_common.base + 0x184 / sizeof(uint32_t))
 #define QSPI_SFB1AD (qspi_common.base + 0x188 / sizeof(uint32_t))
-#define QSPI_SFB2AD (qspi_common.base + 0x18C / sizeof(uint32_t))
+#define QSPI_SFB2AD (qspi_common.base + 0x18c / sizeof(uint32_t))
 
 #define WATERMARK 16
 
@@ -185,17 +186,17 @@ int qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq)
 
 static void set_IPCR(int seq_num, size_t idatsz)
 {
-	*QSPI_IPCR_ADDR = QSPI_IPCR_SET_IDATSZ(QSPI_IPCR_SET_SEQID(*QSPI_IPCR_ADDR, seq_num), idatsz & 0xFFFF);
+	*QSPI_IPCR_ADDR = QSPI_IPCR_SET_IDATSZ(QSPI_IPCR_SET_SEQID(*QSPI_IPCR_ADDR, seq_num), idatsz & 0xffff);
 }
 
 void qspi_setTCSH(uint8_t cycles)
 {
-	*QSPI_FLSHCR_ADDR = (*QSPI_FLSHCR_ADDR & ~(0x0F << 8)) | (cycles << 8);
+	*QSPI_FLSHCR_ADDR = (*QSPI_FLSHCR_ADDR & ~(0x0f << 8)) | (cycles << 8);
 }
 
 void qspi_setTCSS(uint8_t cycles)
 {
-	*QSPI_FLSHCR_ADDR = (*QSPI_FLSHCR_ADDR & ~(0x0F)) | cycles;
+	*QSPI_FLSHCR_ADDR = (*QSPI_FLSHCR_ADDR & ~(0x0f)) | cycles;
 }
 
 int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size)
@@ -213,7 +214,7 @@ int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *bu
 		return -1;
 	}
 
-	*QSPI_RBCT_ADDR = (*QSPI_RBCT_ADDR & ~(0x1F) | WATERMARK);
+	*QSPI_RBCT_ADDR = (*QSPI_RBCT_ADDR & ~(0x1f) | WATERMARK);
 
 	*QSPI_SFAR_ADDR = qspi_common.flash_base_addr[dev] + addr;
 
@@ -229,7 +230,7 @@ int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *bu
 		for (i = 0; i < WATERMARK + 1 && len < size; i++) {
 			reg = *QSPI_RBDRn_ADRR(i);
 			for (byte = 0; byte < 4 && len + byte < size; byte++) {
-				((uint8_t *)buf)[len + byte] = reg & 0xFF;
+				((uint8_t *)buf)[len + byte] = reg & 0xff;
 				reg >>= 8;
 			}
 			len += byte;

--- a/spi/imx6ull-qspi/qspi.c
+++ b/spi/imx6ull-qspi/qspi.c
@@ -341,7 +341,7 @@ int _qspi_init(qspi_dev_t dev)
 
 	set_mux(dev);
 
-	if (!qspi_common.init) {
+	if (qspi_common.init == 0) {
 		/* Enable module */
 		*(qspi_common.base + QSPI_MCR) &= ~QSPI_MCR_CLR_MDIS;
 		/* Set write to RXBR buffer */

--- a/spi/imx6ull-qspi/qspi.c
+++ b/spi/imx6ull-qspi/qspi.c
@@ -1,0 +1,341 @@
+/*
+ * Phoenix-RTOS
+ *
+ * i.MX 6ULL QSPI lib
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Hubert Badocha
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <stddef.h>
+#include <sys/interrupt.h>
+#include <sys/mman.h>
+#include <errno.h>
+#include <sys/platform.h>
+#include <sys/threads.h>
+#include <stdbool.h>
+#include <string.h>
+#include <phoenix/arch/imx6ull.h>
+#include "qspi.h"
+#include <board_config.h>
+
+/* Default values for not configured boards */
+#ifndef QSPI_FLASH_A1_SIZE
+#define QSPI_FLASH_A1_SIZE (256 * 1024 * 1024)
+#endif
+#ifndef QSPI_FLASH_A2_SIZE
+#define QSPI_FLASH_A2_SIZE (0)
+#endif
+#ifndef QSPI_FLASH_B1_SIZE
+#define QSPI_FLASH_B1_SIZE (0)
+#endif
+#ifndef QSPI_FLASH_B2_SIZE
+#define QSPI_FLASH_B2_SIZE (0)
+#endif
+
+#define QSPI_MMAP_BASE 0x60000000
+
+#define QSPI_BASE ((uint32_t *)0x21E0000)
+
+#define QSPI_LCKCR_ADDR   (qspi_common.base + 0x304 / sizeof(uint32_t))
+#define QSPI_LCKCR_LOCK   0x01
+#define QSPI_LCKCR_UNLOCK 0x02
+
+#define QSPI_LUT_KEY_ADDR (qspi_common.base + 0x300 / sizeof(uint32_t))
+#define QSPI_LUT_KEY      0x5AF05AF0
+
+#define QSPI_LUTn_ADDR(n)      (qspi_common.base + (0x310 + 4 * (n)) / sizeof(uint32_t))
+#define QSPI_SEQ_START_REGN(n) (4 * (n))
+
+#define QSPI_IPCR_ADDR                    (qspi_common.base + 0x08 / sizeof(uint32_t))
+#define QSPI_IPCR_SET_SEQID(reg, seqid)   ((reg) & ~(0x0F << 24)) | ((seqid & 0x0F) << 24)
+#define QSPI_IPCR_SET_IDATSZ(reg, idatsz) ((reg) & ~(0xFFFF)) | (idatsz)
+
+#define QSPI_FLSHCR_ADDR (qspi_common.base + 0x0C / sizeof(uint32_t))
+
+#define QSPI_MCR_ADDR     (qspi_common.base)
+#define QSPI_MCR_CLR_TXF  (0x01 << 11)
+#define QSPI_MCR_CLR_RXF  (0x01 << 10)
+#define QSPI_MCR_CLR_MDIS (0x01 << 14)
+
+#define QSPI_BFGENCR_ADDR (qspi_common.base + 0x20 / sizeof(uint32_t))
+
+#define QSPI_SR_ADDR   (qspi_common.base + 0x15C / sizeof(uint32_t))
+#define QSPI_SR_BUSY   (0x01)
+#define QSPI_SR_RXWE   (0x01 << 16)
+#define QSPI_SR_TXEDA  (0x01 << 24)
+#define QSPI_SR_TXFULL (0x01 << 27)
+
+#define QSPI_RBDRn_ADRR(n) (qspi_common.base + (0x200 + 4 * (n)) / sizeof(uint32_t))
+
+#define QSPI_RBSR_ADRR    (qspi_common.base + 0x10C / sizeof(uint32_t))
+#define QSPI_RBSR_TO_READ (((*QSPI_RBSR_ADRR) >> 8) & 0x3F)
+
+#define QSPI_SFAR_ADDR (qspi_common.base + 0x100 / sizeof(uint32_t))
+
+#define QSPI_RBCT_ADDR  (qspi_common.base + 0x110 / sizeof(uint32_t))
+#define QSPI_RBCT_RXBRD (0x01 << 8)
+
+#define QSPI_FR_ADDR (qspi_common.base + 0x160 / sizeof(uint32_t))
+#define QSPI_FR_RBDF (0x01 << 16)
+
+#define QSPI_TBDR_ADDR (qspi_common.base + 0x154 / sizeof(uint32_t))
+
+#define QSPI_SFA1AD (qspi_common.base + 0x180 / sizeof(uint32_t))
+#define QSPI_SFA2AD (qspi_common.base + 0x184 / sizeof(uint32_t))
+#define QSPI_SFB1AD (qspi_common.base + 0x188 / sizeof(uint32_t))
+#define QSPI_SFB2AD (qspi_common.base + 0x18C / sizeof(uint32_t))
+
+#define WATERMARK 16
+
+#define NUM_LUT_SEQ 16
+
+typedef struct {
+	int mux;
+	char val;
+	char sion;
+} qspi_pctl_mux_t;
+
+typedef struct {
+	int pad;
+	char speed;
+	char dse;
+	char sre;
+} qspi_pctl_pad_t;
+
+qspi_pctl_mux_t qspi_pctl_mux[2][8] = {
+	{ { pctl_mux_nand_d7, 2, 0 }, { pctl_mux_nand_ale, 2, 0 }, { pctl_mux_nand_wp, 2, 0 }, { pctl_mux_nand_rdy, 2, 0 }, { pctl_mux_nand_ce0, 2, 0 }, { pctl_mux_nand_ce1, 2, 0 }, { pctl_mux_nand_cle, 2, 0 }, { pctl_mux_nand_dqs, 2, 0 } },
+	{ { pctl_mux_nand_re, 2, 0 }, { pctl_mux_nand_we, 2, 0 }, { pctl_mux_nand_d0, 2, 0 }, { pctl_mux_nand_d1, 2, 0 }, { pctl_mux_nand_d2, 2, 0 }, { pctl_mux_nand_d3, 2, 0 }, { pctl_mux_nand_d4, 2, 0 }, { pctl_mux_nand_d5, 2, 0 } },
+};
+
+qspi_pctl_pad_t qspi_pctl_pad[2][8] = {
+	{ { pctl_pad_nand_d7, 1, 4, 0 }, { pctl_pad_nand_ale, 1, 4, 0 }, { pctl_pad_nand_wp, 1, 4, 0 }, { pctl_pad_nand_rdy, 1, 4, 0 }, { pctl_pad_nand_ce0, 1, 4, 0 }, { pctl_pad_nand_ce1, 1, 4, 0 }, { pctl_pad_nand_cle, 1, 4, 0 }, { pctl_pad_nand_dqs, 1, 4, 0 } },
+	{ { pctl_pad_nand_re, 1, 4, 0 }, { pctl_pad_nand_we, 1, 4, 0 }, { pctl_pad_nand_d0, 1, 4, 0 }, { pctl_pad_nand_d1, 1, 4, 0 }, { pctl_pad_nand_d2, 1, 4, 0 }, { pctl_pad_nand_d3, 1, 4, 0 }, { pctl_pad_nand_d4, 1, 4, 0 }, { pctl_pad_nand_d5, 1, 4, 0 } },
+};
+
+
+struct {
+	volatile uint32_t *base;
+	uint32_t flash_base_addr[2];
+	bool init;
+} qspi_common = { .base = NULL, .init = false, .flash_base_addr = { QSPI_MMAP_BASE, QSPI_MMAP_BASE + QSPI_FLASH_A1_SIZE + QSPI_FLASH_A2_SIZE } };
+
+// TODO ustawić ile ohmów w rejestrze na flashu.
+// TODO find clock frequency - ~50Mhz
+
+static void set_mux(qspi_dev_t dev_no)
+{
+	platformctl_t ctl;
+	int i;
+
+	ctl.action = pctl_set;
+	ctl.type = pctl_iomux;
+
+	for (i = 0; i < 8; i++) {
+		ctl.iomux.mux = qspi_pctl_mux[dev_no][i].mux;
+		ctl.iomux.mode = qspi_pctl_mux[dev_no][i].val;
+		ctl.iomux.sion = qspi_pctl_mux[dev_no][i].sion;
+		platformctl(&ctl);
+	}
+
+	ctl.action = pctl_set;
+	ctl.type = pctl_iopad;
+
+	for (i = 0; i < 8; i++) {
+		ctl.iopad.pad = qspi_pctl_pad[dev_no][i].pad;
+		ctl.iopad.speed = qspi_pctl_pad[dev_no][i].speed;
+		ctl.iopad.dse = qspi_pctl_pad[dev_no][i].dse;
+		ctl.iopad.sre = qspi_pctl_pad[dev_no][i].sre;
+		platformctl(&ctl);
+	}
+}
+
+static void set_clk()
+{
+	platformctl_t ctl;
+
+	ctl.action = pctl_set;
+	ctl.type = pctl_devclock;
+	ctl.devclock.dev = pctl_clk_qspi;
+	ctl.devclock.state = 0x03;
+
+	platformctl(&ctl);
+}
+
+int qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq)
+{
+	if (lut_seq >= NUM_LUT_SEQ) {
+		return -1;
+	}
+	if (*QSPI_LCKCR_ADDR & QSPI_LCKCR_LOCK) {
+		*QSPI_LUT_KEY_ADDR = QSPI_LUT_KEY;
+		*QSPI_LCKCR_ADDR = (*QSPI_LCKCR_ADDR & ~(QSPI_LCKCR_UNLOCK | QSPI_LCKCR_LOCK)) | QSPI_LCKCR_UNLOCK;
+	}
+
+	for (int i = 0; i < 4; i++) {
+		*QSPI_LUTn_ADDR(QSPI_SEQ_START_REGN(lut_seq) + i) = (((uint32_t)lut->instrs[2 * i + 1]) << 16) | lut->instrs[2 * i];
+	}
+
+	*QSPI_LUT_KEY_ADDR = QSPI_LUT_KEY;
+	*QSPI_LCKCR_ADDR = (*QSPI_LCKCR_ADDR & ~(QSPI_LCKCR_UNLOCK | QSPI_LCKCR_LOCK)) | QSPI_LCKCR_LOCK;
+}
+
+static void set_IPCR(int seq_num, size_t idatsz)
+{
+	*QSPI_IPCR_ADDR = QSPI_IPCR_SET_IDATSZ(QSPI_IPCR_SET_SEQID(*QSPI_IPCR_ADDR, seq_num), idatsz & 0xFFFF);
+}
+
+void qspi_setTCSH(uint8_t cycles)
+{
+	*QSPI_FLSHCR_ADDR = (*QSPI_FLSHCR_ADDR & ~(0x0F << 8)) | (cycles << 8);
+}
+
+void qspi_setTCSS(uint8_t cycles)
+{
+	*QSPI_FLSHCR_ADDR = (*QSPI_FLSHCR_ADDR & ~(0x0F)) | cycles;
+}
+
+int _qspi_read(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size)
+{
+	uint8_t to_read, byte, i;
+	uint16_t len = 0;
+	uint32_t reg;
+	int err;
+
+
+	if (dev != qspi_flash_a && dev != qspi_flash_b) {
+		return -ENODEV;
+	}
+	if (lut_seq >= NUM_LUT_SEQ || size > MAX_READ_LEN) {
+		return -1;
+	}
+
+	*QSPI_RBCT_ADDR = (*QSPI_RBCT_ADDR & ~(0x1F) | WATERMARK);
+
+	printf("RBCT: %#x\n", *QSPI_RBCT_ADDR);
+
+	*QSPI_SFAR_ADDR = qspi_common.flash_base_addr[dev] + addr;
+
+	*QSPI_MCR_ADDR |= QSPI_MCR_CLR_RXF;
+
+	printf("RXWE: %#x\n", *QSPI_SR_ADDR & QSPI_SR_RXWE);
+	reg = *QSPI_RBDRn_ADRR(0);
+	printf("PRE DR: %#x\n", reg);
+	set_IPCR(lut_seq, size);
+
+	printf("RXWE: %#x\n", *QSPI_SR_ADDR & QSPI_SR_RXWE);
+	while (len < size) {
+		printf("RXWE: %#x\n", *QSPI_SR_ADDR & QSPI_SR_RXWE);
+		while (((*QSPI_SR_ADDR & QSPI_SR_RXWE) ^ QSPI_SR_BUSY) == 0) /* Wait for data ready */
+			;
+
+		printf("RXWE: %#x\n", *QSPI_SR_ADDR & QSPI_SR_RXWE);
+
+		for (i = 0; i < WATERMARK + 1 && len < size; i++) {
+			reg = *QSPI_RBDRn_ADRR(i);
+			printf("DR: %#x\n", reg);
+			for (byte = 0; byte < 4 && len + byte < size; byte++) {
+				((uint8_t *)buf)[len + byte] = reg & 0xFF;
+				reg >>= 8;
+			}
+			len += byte;
+		}
+		printf("POP\n");
+		*QSPI_FR_ADDR |= QSPI_FR_RBDF; /* Buffer pop. */
+	}
+
+	while (*QSPI_SR_ADDR & QSPI_SR_BUSY)
+		;
+	*QSPI_MCR_ADDR |= QSPI_MCR_CLR_RXF;
+
+	return EOK;
+}
+
+static size_t write_tx(const void *data, size_t size)
+{
+	size_t byte, sent = 0;
+	uint32_t reg;
+
+	while ((*QSPI_SR_ADDR & QSPI_SR_TXFULL) == 0 && sent < size) {
+		reg = 0;
+		for (byte = 0; byte < 4 && sent + byte < size; byte++) {
+			reg |= ((uint8_t *)data)[sent + byte] << (8 * byte);
+		}
+		*QSPI_TBDR_ADDR = reg;
+		sent += byte;
+	}
+
+	return sent;
+}
+
+int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void *data, size_t size)
+{
+	size_t sent = 0;
+	int err;
+	if (dev != qspi_flash_a && dev != qspi_flash_b) {
+		return -ENODEV;
+	}
+	if (lut_seq >= NUM_LUT_SEQ || size > MAX_READ_LEN) {
+		return -1;
+	}
+
+	if (*QSPI_SR_ADDR & QSPI_SR_TXEDA) /* Check if TX buffer is not empty. */
+		*QSPI_MCR_ADDR |= QSPI_MCR_CLR_TXF;
+
+	*QSPI_SFAR_ADDR = qspi_common.flash_base_addr[dev] + addr;
+
+	sent += write_tx(data, size);
+	printf("SENT: %d, BUSY: %#x \n", sent, *QSPI_SR_ADDR & QSPI_SR_BUSY);
+	printf("SIZE: %d\n", size);
+
+	set_IPCR(lut_seq, size);
+	printf("SENT: %d, BUSY: %#x \n", sent, *QSPI_SR_ADDR & QSPI_SR_BUSY);
+
+	while (sent < size) {
+		sent += write_tx(data + sent, size - sent);
+		printf("SENT: %d, BUSY: %#x \n", sent, *QSPI_SR_ADDR & QSPI_SR_BUSY);
+	}
+
+	printf("WAITING\n");
+	while (*QSPI_SR_ADDR & QSPI_SR_BUSY)
+		;
+
+	return EOK;
+}
+
+int _qspi_init(qspi_dev_t dev)
+{
+	int err;
+	if (dev != qspi_flash_a && dev != qspi_flash_b) {
+		printf("qspi: invalid device %d.\n", dev);
+		return -ENODEV;
+	}
+
+	if (!qspi_common.init) {
+		if ((qspi_common.base = mmap(NULL, 0x4000, PROT_READ | PROT_WRITE, MAP_DEVICE, OID_PHYSMEM, QSPI_BASE)) == MAP_FAILED) {
+			printf("qspi: could not map qspi paddr %p.\n", QSPI_BASE);
+			return -ENOMEM;
+		}
+		set_clk();
+	}
+
+	set_mux(dev);
+
+	if (!qspi_common.init) {
+		/* Enable module */
+		*QSPI_MCR_ADDR &= ~QSPI_MCR_CLR_MDIS;
+		/* Set write to RXBR buffer */
+		*QSPI_RBCT_ADDR |= QSPI_RBCT_RXBRD;
+		/* Set flash sizes */
+		*QSPI_SFA1AD = (*QSPI_SFA1AD & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_A1_SIZE) & ~(0x3ff));
+		*QSPI_SFA2AD = (*QSPI_SFA2AD & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_A2_SIZE) & ~(0x3ff));
+		*QSPI_SFB1AD = (*QSPI_SFB1AD & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_B1_SIZE) & ~(0x3ff));
+		*QSPI_SFB2AD = (*QSPI_SFB2AD & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_B2_SIZE) & ~(0x3ff));
+	}
+	qspi_common.init = true;
+
+	return EOK;
+}

--- a/spi/imx6ull-qspi/qspi.c
+++ b/spi/imx6ull-qspi/qspi.c
@@ -50,9 +50,7 @@
 #define QSPI_LUTn(n)           ((0x310 + 4 * (n)) / sizeof(uint32_t))
 #define QSPI_SEQ_START_REGN(n) (4 * (n))
 
-#define QSPI_IPCR                         (0x08 / sizeof(uint32_t))
-#define QSPI_IPCR_SET_SEQID(reg, seqid)   ((reg) & ~(0x0f << 24)) | ((seqid & 0x0f) << 24)
-#define QSPI_IPCR_SET_IDATSZ(reg, idatsz) ((reg) & ~(0xffff)) | (idatsz)
+#define QSPI_IPCR (0x08 / sizeof(uint32_t))
 
 #define QSPI_FLSHCR (0x0C / sizeof(uint32_t))
 
@@ -71,8 +69,7 @@
 
 #define QSPI_RBDRn(n) ((0x200 + 4 * (n)) / sizeof(uint32_t))
 
-#define QSPI_RBSR         (0x10c / sizeof(uint32_t))
-#define QSPI_RBSR_TO_READ (((*QSPI_RBSR_ADRR) >> 8) & 0x3f)
+#define QSPI_RBSR (0x10c / sizeof(uint32_t))
 
 #define QSPI_SFAR (0x100 / sizeof(uint32_t))
 
@@ -201,7 +198,11 @@ int qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq)
 
 static void set_IPCR(int seq_num, size_t idatsz)
 {
-	*(qspi_common.base + QSPI_IPCR) = QSPI_IPCR_SET_IDATSZ(QSPI_IPCR_SET_SEQID(*(qspi_common.base + QSPI_IPCR), seq_num), idatsz & 0xffff);
+	uint32_t reg = *(qspi_common.base + QSPI_IPCR);
+
+	reg = (reg & ~(0x0f << 24)) | ((seq_num & 0x0f) << 24);
+	reg = (reg & ~(0xffff)) | (idatsz & 0xffff);
+	*(qspi_common.base + QSPI_IPCR) = reg;
 }
 
 

--- a/spi/imx6ull-qspi/qspi.c
+++ b/spi/imx6ull-qspi/qspi.c
@@ -16,7 +16,6 @@
 #include <errno.h>
 #include <sys/platform.h>
 #include <sys/threads.h>
-#include <stdbool.h>
 #include <string.h>
 #include <phoenix/arch/imx6ull.h>
 #include <board_config.h>
@@ -117,8 +116,8 @@ struct {
 struct {
 	volatile uint32_t *base;
 	uint32_t flash_base_addr[2];
-	bool init;
-} qspi_common = { .base = NULL, .init = false, .flash_base_addr = { QSPI_MMAP_BASE, QSPI_MMAP_BASE + QSPI_FLASH_A1_SIZE + QSPI_FLASH_A2_SIZE } };
+	int init;
+} qspi_common = { .base = NULL, .init = 0, .flash_base_addr = { QSPI_MMAP_BASE, QSPI_MMAP_BASE + QSPI_FLASH_A1_SIZE + QSPI_FLASH_A2_SIZE } };
 
 /* TODO set ohm value in the flash register */
 /* TODO find clock frequency - ~50Mhz */
@@ -316,7 +315,7 @@ int _qspi_init(qspi_dev_t dev)
 		*(qspi_common.base + QSPI_SFB1AD) = (*(qspi_common.base + QSPI_SFB1AD) & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_B1_SIZE) & ~(0x3ff));
 		*(qspi_common.base + QSPI_SFB2AD) = (*(qspi_common.base + QSPI_SFB2AD) & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_B2_SIZE) & ~(0x3ff));
 	}
-	qspi_common.init = true;
+	qspi_common.init = 1;
 
 	return EOK;
 }

--- a/spi/imx6ull-qspi/qspi.c
+++ b/spi/imx6ull-qspi/qspi.c
@@ -39,7 +39,7 @@
 
 #define QSPI_MMAP_BASE 0x60000000
 
-#define QSPI_BASE ((void *)0x21e0000)
+#define QSPI_BASE 0x21e0000
 
 #define QSPI_LCKCR        (0x304 / sizeof(uint32_t))
 #define QSPI_LCKCR_LOCK   0x01
@@ -194,6 +194,8 @@ int qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq)
 
 	*(qspi_common.base + QSPI_LUTKEY) = QSPI_LUTKEY_KEY;
 	*(qspi_common.base + QSPI_LCKCR) = (*(qspi_common.base + QSPI_LCKCR) & ~(QSPI_LCKCR_UNLOCK | QSPI_LCKCR_LOCK)) | QSPI_LCKCR_LOCK;
+
+	return EOK;
 }
 
 
@@ -288,7 +290,7 @@ static size_t write_tx(const void *data, size_t size)
 int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void *data, size_t size)
 {
 	size_t sent = 0;
-	int err, max_iter;
+	int max_iter;
 
 	if ((dev != qspi_flash_a) && (dev != qspi_flash_b)) {
 		return -ENODEV;
@@ -325,8 +327,6 @@ int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void 
 
 int _qspi_init(qspi_dev_t dev)
 {
-	int err;
-
 	if ((dev != qspi_flash_a) && (dev != qspi_flash_b)) {
 		printf("qspi: invalid device %d.\n", dev);
 		return -ENODEV;
@@ -335,7 +335,7 @@ int _qspi_init(qspi_dev_t dev)
 	if (qspi_common.init == 0) {
 		qspi_common.base = mmap(NULL, 4 * _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_DEVICE, OID_PHYSMEM, QSPI_BASE);
 		if (qspi_common.base == MAP_FAILED) {
-			printf("qspi: could not map qspi paddr %p.\n", QSPI_BASE);
+			printf("qspi: could not map qspi paddr %p.\n", (void *)QSPI_BASE);
 			return -ENOMEM;
 		}
 		set_clk();

--- a/spi/imx6ull-qspi/qspi.c
+++ b/spi/imx6ull-qspi/qspi.c
@@ -41,54 +41,54 @@
 
 #define QSPI_BASE ((void *)0x21e0000)
 
-#define QSPI_LCKCR_ADDR   (qspi_common.base + 0x304 / sizeof(uint32_t))
+#define QSPI_LCKCR        (0x304 / sizeof(uint32_t))
 #define QSPI_LCKCR_LOCK   0x01
 #define QSPI_LCKCR_UNLOCK 0x02
 
-#define QSPI_LUT_KEY_ADDR (qspi_common.base + 0x300 / sizeof(uint32_t))
-#define QSPI_LUT_KEY      0x5af05af0
+#define QSPI_LUTKEY (0x300 / sizeof(uint32_t))
+#define QSPI_LUTKEY_KEY 0x5af05af0
 
-#define QSPI_LUTn_ADDR(n)      (qspi_common.base + (0x310 + 4 * (n)) / sizeof(uint32_t))
+#define QSPI_LUTn(n)           ((0x310 + 4 * (n)) / sizeof(uint32_t))
 #define QSPI_SEQ_START_REGN(n) (4 * (n))
 
-#define QSPI_IPCR_ADDR                    (qspi_common.base + 0x08 / sizeof(uint32_t))
+#define QSPI_IPCR                         (0x08 / sizeof(uint32_t))
 #define QSPI_IPCR_SET_SEQID(reg, seqid)   ((reg) & ~(0x0f << 24)) | ((seqid & 0x0f) << 24)
 #define QSPI_IPCR_SET_IDATSZ(reg, idatsz) ((reg) & ~(0xffff)) | (idatsz)
 
-#define QSPI_FLSHCR_ADDR (qspi_common.base + 0x0C / sizeof(uint32_t))
+#define QSPI_FLSHCR (0x0C / sizeof(uint32_t))
 
-#define QSPI_MCR_ADDR     (qspi_common.base)
+#define QSPI_MCR          (0)
 #define QSPI_MCR_CLR_TXF  (0x01 << 11)
 #define QSPI_MCR_CLR_RXF  (0x01 << 10)
 #define QSPI_MCR_CLR_MDIS (0x01 << 14)
 
-#define QSPI_BFGENCR_ADDR (qspi_common.base + 0x20 / sizeof(uint32_t))
+#define QSPI_BFGENCR (0x20 / sizeof(uint32_t))
 
-#define QSPI_SR_ADDR   (qspi_common.base + 0x15c / sizeof(uint32_t))
+#define QSPI_SR        (0x15c / sizeof(uint32_t))
 #define QSPI_SR_BUSY   (0x01)
 #define QSPI_SR_RXWE   (0x01 << 16)
 #define QSPI_SR_TXEDA  (0x01 << 24)
 #define QSPI_SR_TXFULL (0x01 << 27)
 
-#define QSPI_RBDRn_ADRR(n) (qspi_common.base + (0x200 + 4 * (n)) / sizeof(uint32_t))
+#define QSPI_RBDRn(n) ((0x200 + 4 * (n)) / sizeof(uint32_t))
 
-#define QSPI_RBSR_ADRR    (qspi_common.base + 0x10c / sizeof(uint32_t))
+#define QSPI_RBSR         (0x10c / sizeof(uint32_t))
 #define QSPI_RBSR_TO_READ (((*QSPI_RBSR_ADRR) >> 8) & 0x3f)
 
-#define QSPI_SFAR_ADDR (qspi_common.base + 0x100 / sizeof(uint32_t))
+#define QSPI_SFAR (0x100 / sizeof(uint32_t))
 
-#define QSPI_RBCT_ADDR  (qspi_common.base + 0x110 / sizeof(uint32_t))
+#define QSPI_RBCT       (0x110 / sizeof(uint32_t))
 #define QSPI_RBCT_RXBRD (0x01 << 8)
 
-#define QSPI_FR_ADDR (qspi_common.base + 0x160 / sizeof(uint32_t))
+#define QSPI_FR      (0x160 / sizeof(uint32_t))
 #define QSPI_FR_RBDF (0x01 << 16)
 
-#define QSPI_TBDR_ADDR (qspi_common.base + 0x154 / sizeof(uint32_t))
+#define QSPI_TBDR (0x154 / sizeof(uint32_t))
 
-#define QSPI_SFA1AD (qspi_common.base + 0x180 / sizeof(uint32_t))
-#define QSPI_SFA2AD (qspi_common.base + 0x184 / sizeof(uint32_t))
-#define QSPI_SFB1AD (qspi_common.base + 0x188 / sizeof(uint32_t))
-#define QSPI_SFB2AD (qspi_common.base + 0x18c / sizeof(uint32_t))
+#define QSPI_SFA1AD (0x180 / sizeof(uint32_t))
+#define QSPI_SFA2AD (0x184 / sizeof(uint32_t))
+#define QSPI_SFB1AD (0x188 / sizeof(uint32_t))
+#define QSPI_SFB2AD (0x18c / sizeof(uint32_t))
 
 #define WATERMARK 16
 
@@ -171,32 +171,32 @@ int qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq)
 	if (lut_seq >= NUM_LUT_SEQ) {
 		return -1;
 	}
-	if (*QSPI_LCKCR_ADDR & QSPI_LCKCR_LOCK) {
-		*QSPI_LUT_KEY_ADDR = QSPI_LUT_KEY;
-		*QSPI_LCKCR_ADDR = (*QSPI_LCKCR_ADDR & ~(QSPI_LCKCR_UNLOCK | QSPI_LCKCR_LOCK)) | QSPI_LCKCR_UNLOCK;
+	if (*(qspi_common.base + QSPI_LCKCR) & QSPI_LCKCR_LOCK) {
+		*(qspi_common.base + QSPI_LUTKEY) = QSPI_LUTKEY_KEY;
+		*(qspi_common.base + QSPI_LCKCR) = (*(qspi_common.base + QSPI_LCKCR) & ~(QSPI_LCKCR_UNLOCK | QSPI_LCKCR_LOCK)) | QSPI_LCKCR_UNLOCK;
 	}
 
 	for (int i = 0; i < 4; i++) {
-		*QSPI_LUTn_ADDR(QSPI_SEQ_START_REGN(lut_seq) + i) = (((uint32_t)lut->instrs[2 * i + 1]) << 16) | lut->instrs[2 * i];
+		*(qspi_common.base + QSPI_LUTn(QSPI_SEQ_START_REGN(lut_seq) + i)) = (((uint32_t)lut->instrs[2 * i + 1]) << 16) | lut->instrs[2 * i];
 	}
 
-	*QSPI_LUT_KEY_ADDR = QSPI_LUT_KEY;
-	*QSPI_LCKCR_ADDR = (*QSPI_LCKCR_ADDR & ~(QSPI_LCKCR_UNLOCK | QSPI_LCKCR_LOCK)) | QSPI_LCKCR_LOCK;
+	*(qspi_common.base + QSPI_LUTKEY) = QSPI_LUTKEY_KEY;
+	*(qspi_common.base + QSPI_LCKCR) = (*(qspi_common.base + QSPI_LCKCR) & ~(QSPI_LCKCR_UNLOCK | QSPI_LCKCR_LOCK)) | QSPI_LCKCR_LOCK;
 }
 
 static void set_IPCR(int seq_num, size_t idatsz)
 {
-	*QSPI_IPCR_ADDR = QSPI_IPCR_SET_IDATSZ(QSPI_IPCR_SET_SEQID(*QSPI_IPCR_ADDR, seq_num), idatsz & 0xffff);
+	*(qspi_common.base + QSPI_IPCR) = QSPI_IPCR_SET_IDATSZ(QSPI_IPCR_SET_SEQID(*(qspi_common.base + QSPI_IPCR), seq_num), idatsz & 0xffff);
 }
 
 void qspi_setTCSH(uint8_t cycles)
 {
-	*QSPI_FLSHCR_ADDR = (*QSPI_FLSHCR_ADDR & ~(0x0f << 8)) | (cycles << 8);
+	*(qspi_common.base + QSPI_FLSHCR) = (*(qspi_common.base + QSPI_FLSHCR) & ~(0x0f << 8)) | (cycles << 8);
 }
 
 void qspi_setTCSS(uint8_t cycles)
 {
-	*QSPI_FLSHCR_ADDR = (*QSPI_FLSHCR_ADDR & ~(0x0f)) | cycles;
+	*(qspi_common.base + QSPI_FLSHCR) = (*(qspi_common.base + QSPI_FLSHCR) & ~(0x0f)) | cycles;
 }
 
 int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size)
@@ -214,33 +214,31 @@ int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *bu
 		return -1;
 	}
 
-	*QSPI_RBCT_ADDR = (*QSPI_RBCT_ADDR & ~(0x1f) | WATERMARK);
-
-	*QSPI_SFAR_ADDR = qspi_common.flash_base_addr[dev] + addr;
-
-	*QSPI_MCR_ADDR |= QSPI_MCR_CLR_RXF;
+	*(qspi_common.base + QSPI_RBCT) = (*(qspi_common.base + QSPI_RBCT) & ~(0x1f) | WATERMARK);
+	*(qspi_common.base + QSPI_SFAR) = qspi_common.flash_base_addr[dev] + addr;
+	*(qspi_common.base + QSPI_MCR) |= QSPI_MCR_CLR_RXF;
 
 	set_IPCR(lut_seq, size);
 
 	while (len < size) {
 		do {
-			reg = *QSPI_SR_ADDR;
+			reg = *(qspi_common.base + QSPI_SR);
 		} while ((reg & QSPI_SR_RXWE) == 0 && reg & QSPI_SR_BUSY);
 
 		for (i = 0; i < WATERMARK + 1 && len < size; i++) {
-			reg = *QSPI_RBDRn_ADRR(i);
+			reg = *(qspi_common.base + QSPI_RBDRn(i));
 			for (byte = 0; byte < 4 && len + byte < size; byte++) {
 				((uint8_t *)buf)[len + byte] = reg & 0xff;
 				reg >>= 8;
 			}
 			len += byte;
 		}
-		*QSPI_FR_ADDR |= QSPI_FR_RBDF; /* Buffer pop. */
+		*(qspi_common.base + QSPI_FR) |= QSPI_FR_RBDF; /* Buffer pop. */
 	}
 
-	while (*QSPI_SR_ADDR & QSPI_SR_BUSY)
+	while (*(qspi_common.base + QSPI_SR) & QSPI_SR_BUSY)
 		;
-	*QSPI_MCR_ADDR |= QSPI_MCR_CLR_RXF;
+	*(qspi_common.base + QSPI_MCR) |= QSPI_MCR_CLR_RXF;
 
 	return EOK;
 }
@@ -250,12 +248,12 @@ static size_t write_tx(const void *data, size_t size)
 	size_t byte, sent = 0;
 	uint32_t reg;
 
-	while ((*QSPI_SR_ADDR & QSPI_SR_TXFULL) == 0 && sent < size) {
+	while ((*(qspi_common.base + QSPI_SR) & QSPI_SR_TXFULL) == 0 && sent < size) {
 		reg = 0;
 		for (byte = 0; byte < 4 && sent + byte < size; byte++) {
 			reg |= ((uint8_t *)data)[sent + byte] << (8 * byte);
 		}
-		*QSPI_TBDR_ADDR = reg;
+		*(qspi_common.base + QSPI_TBDR) = reg;
 		sent += byte;
 	}
 
@@ -273,10 +271,10 @@ int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void 
 		return -1;
 	}
 
-	if (*QSPI_SR_ADDR & QSPI_SR_TXEDA) /* Check if TX buffer is not empty. */
-		*QSPI_MCR_ADDR |= QSPI_MCR_CLR_TXF;
+	if (*(qspi_common.base + QSPI_SR) & QSPI_SR_TXEDA) /* Check if TX buffer is not empty. */
+		*(qspi_common.base + QSPI_MCR) |= QSPI_MCR_CLR_TXF;
 
-	*QSPI_SFAR_ADDR = qspi_common.flash_base_addr[dev] + addr;
+	*(qspi_common.base + QSPI_SFAR) = qspi_common.flash_base_addr[dev] + addr;
 
 	sent += write_tx(data, size);
 
@@ -286,7 +284,7 @@ int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void 
 		sent += write_tx(data + sent, size - sent);
 	}
 
-	while (*QSPI_SR_ADDR & QSPI_SR_BUSY)
+	while (*(qspi_common.base + QSPI_SR) & QSPI_SR_BUSY)
 		;
 
 	return EOK;
@@ -312,14 +310,14 @@ int _qspi_init(qspi_dev_t dev)
 
 	if (!qspi_common.init) {
 		/* Enable module */
-		*QSPI_MCR_ADDR &= ~QSPI_MCR_CLR_MDIS;
+		*(qspi_common.base + QSPI_MCR) &= ~QSPI_MCR_CLR_MDIS;
 		/* Set write to RXBR buffer */
-		*QSPI_RBCT_ADDR |= QSPI_RBCT_RXBRD;
+		*(qspi_common.base + QSPI_RBCT) |= QSPI_RBCT_RXBRD;
 		/* Set flash sizes */
-		*QSPI_SFA1AD = (*QSPI_SFA1AD & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_A1_SIZE) & ~(0x3ff));
-		*QSPI_SFA2AD = (*QSPI_SFA2AD & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_A2_SIZE) & ~(0x3ff));
-		*QSPI_SFB1AD = (*QSPI_SFB1AD & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_B1_SIZE) & ~(0x3ff));
-		*QSPI_SFB2AD = (*QSPI_SFB2AD & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_B2_SIZE) & ~(0x3ff));
+		*(qspi_common.base + QSPI_SFA1AD) = (*(qspi_common.base + QSPI_SFA1AD) & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_A1_SIZE) & ~(0x3ff));
+		*(qspi_common.base + QSPI_SFA2AD) = (*(qspi_common.base + QSPI_SFA2AD) & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_A2_SIZE) & ~(0x3ff));
+		*(qspi_common.base + QSPI_SFB1AD) = (*(qspi_common.base + QSPI_SFB1AD) & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_B1_SIZE) & ~(0x3ff));
+		*(qspi_common.base + QSPI_SFB2AD) = (*(qspi_common.base + QSPI_SFB2AD) & (0x3ff)) | ((QSPI_MMAP_BASE + QSPI_FLASH_B2_SIZE) & ~(0x3ff));
 	}
 	qspi_common.init = true;
 

--- a/spi/imx6ull-qspi/qspi.c
+++ b/spi/imx6ull-qspi/qspi.c
@@ -183,7 +183,7 @@ int qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq)
 	int i;
 
 	if (lut_seq >= NUM_LUT_SEQ) {
-		return -1;
+		return -EINVAL;
 	}
 	if (*(qspi_common.base + QSPI_LCKCR) & QSPI_LCKCR_LOCK) {
 		*(qspi_common.base + QSPI_LUTKEY) = QSPI_LUTKEY_KEY;
@@ -224,10 +224,10 @@ int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *bu
 	uint32_t reg;
 	int max_iter;
 
-	if (dev != qspi_flash_a && dev != qspi_flash_b) {
+	if ((dev != qspi_flash_a) && (dev != qspi_flash_b)) {
 		return -ENODEV;
 	}
-	if (lut_seq >= NUM_LUT_SEQ || size > MAX_READ_LEN) {
+	if ((lut_seq >= NUM_LUT_SEQ) || (size > MAX_READ_LEN)) {
 		return -EINVAL;
 	}
 
@@ -250,9 +250,9 @@ int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *bu
 			return -ETIME;
 		}
 
-		for (i = 0; i < WATERMARK + 1 && len < size; i++) {
+		for (i = 0; (i < WATERMARK + 1) && (len < size); i++) {
 			reg = *(qspi_common.base + QSPI_RBDRn(i));
-			for (byte = 0; byte < 4 && len + byte < size; byte++) {
+			for (byte = 0; (byte < 4) && (len + byte < size); byte++) {
 				((uint8_t *)buf)[len + byte] = reg & 0xff;
 				reg >>= 8;
 			}
@@ -270,9 +270,9 @@ static size_t write_tx(const void *data, size_t size)
 	size_t byte, sent = 0;
 	uint32_t reg;
 
-	while ((*(qspi_common.base + QSPI_SR) & QSPI_SR_TXFULL) == 0 && sent < size) {
+	while (((*(qspi_common.base + QSPI_SR) & QSPI_SR_TXFULL) == 0) && (sent < size)) {
 		reg = 0;
-		for (byte = 0; byte < 4 && sent + byte < size; byte++) {
+		for (byte = 0; (byte < 4) && (sent + byte < size); byte++) {
 			reg |= ((uint8_t *)data)[sent + byte] << (8 * byte);
 		}
 		*(qspi_common.base + QSPI_TBDR) = reg;
@@ -288,10 +288,10 @@ int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void 
 	size_t sent = 0;
 	int err, max_iter;
 
-	if (dev != qspi_flash_a && dev != qspi_flash_b) {
+	if ((dev != qspi_flash_a) && (dev != qspi_flash_b)) {
 		return -ENODEV;
 	}
-	if (lut_seq >= NUM_LUT_SEQ || size > MAX_READ_LEN) {
+	if ((lut_seq >= NUM_LUT_SEQ) || (size > MAX_READ_LEN)) {
 		return -EINVAL;
 	}
 
@@ -325,13 +325,14 @@ int _qspi_init(qspi_dev_t dev)
 {
 	int err;
 
-	if (dev != qspi_flash_a && dev != qspi_flash_b) {
+	if ((dev != qspi_flash_a) && (dev != qspi_flash_b)) {
 		printf("qspi: invalid device %d.\n", dev);
 		return -ENODEV;
 	}
 
 	if (qspi_common.init == 0) {
-		if ((qspi_common.base = mmap(NULL, 4 * _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_DEVICE, OID_PHYSMEM, QSPI_BASE)) == MAP_FAILED) {
+		qspi_common.base = mmap(NULL, 4 * _PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_DEVICE, OID_PHYSMEM, QSPI_BASE);
+		if (qspi_common.base == MAP_FAILED) {
 			printf("qspi: could not map qspi paddr %p.\n", QSPI_BASE);
 			return -ENOMEM;
 		}

--- a/spi/imx6ull-qspi/qspi.h
+++ b/spi/imx6ull-qspi/qspi.h
@@ -21,7 +21,7 @@
 #define LUT_INSTR(code, pad, operand) ((((code)&0x3f) << 10) | (((pad)&0x03) << 8) | ((operand)&0xff))
 
 typedef enum {
-	lut_stop,
+	lut_stop = 0,
 	lut_cmd,
 	lut_addr,
 	lut_dummy,
@@ -62,14 +62,14 @@ typedef enum {
 int _qspi_init(qspi_dev_t dev);
 
 
-int qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq);
+int _qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq);
 
 
 // int qspi_setClockDiv(qspi_ctx_t* ctx, uint8_t pre, uint8_t post);
-void qspi_setTCSH(uint8_t cycles);
+void _qspi_setTCSH(uint8_t cycles);
 
 
-void qspi_setTCSS(uint8_t cycles);
+void _qspi_setTCSS(uint8_t cycles);
 
 /* TODO non busy read. */
 int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size);

--- a/spi/imx6ull-qspi/qspi.h
+++ b/spi/imx6ull-qspi/qspi.h
@@ -44,6 +44,12 @@ typedef enum {
 
 #define LUT_INSTR(code, pad, operand) ((((code)&0x3F) << 10) | (((pad)&0x03) << 8) | ((operand)&0xFF))
 
+enum {
+	lut_pad1,
+	lut_pad2,
+	lut_pad4,
+};
+
 typedef struct {
 	uint16_t instrs[8];
 } lut_seq_t;
@@ -62,7 +68,8 @@ void qspi_setTCSH(uint8_t cycles);
 void qspi_setTCSS(uint8_t cycles);
 
 /* TODO non busy read. */
-int _qspi_read(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size);
+int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size);
+/* int _qspi_read(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size); */
 int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void *data, size_t size);
 
 

--- a/spi/imx6ull-qspi/qspi.h
+++ b/spi/imx6ull-qspi/qspi.h
@@ -15,12 +15,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <sys/threads.h>
-#include <phoenix/arch/imx6ull.h>
-
-
 #define MAX_READ_LEN  0xffff
 #define MAX_WRITE_LEN 0xffff
+
+#define LUT_INSTR(code, pad, operand) ((((code)&0x3f) << 10) | (((pad)&0x03) << 8) | ((operand)&0xff))
 
 typedef enum {
 	lut_stop,
@@ -42,7 +40,6 @@ typedef enum {
 	lut_data_learn
 } lut_code_t;
 
-#define LUT_INSTR(code, pad, operand) ((((code)&0x3f) << 10) | (((pad)&0x03) << 8) | ((operand)&0xff))
 
 enum {
 	lut_pad1,
@@ -50,26 +47,34 @@ enum {
 	lut_pad4,
 };
 
+
 typedef struct {
 	uint16_t instrs[8];
 } lut_seq_t;
+
 
 typedef enum {
 	qspi_flash_a,
 	qspi_flash_b,
 } qspi_dev_t;
 
+
 int _qspi_init(qspi_dev_t dev);
+
 
 int qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq);
 
+
 // int qspi_setClockDiv(qspi_ctx_t* ctx, uint8_t pre, uint8_t post);
 void qspi_setTCSH(uint8_t cycles);
+
+
 void qspi_setTCSS(uint8_t cycles);
 
 /* TODO non busy read. */
 int _qspi_readBusy(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size);
-/* int _qspi_read(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size); */
+
+
 int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void *data, size_t size);
 
 

--- a/spi/imx6ull-qspi/qspi.h
+++ b/spi/imx6ull-qspi/qspi.h
@@ -61,6 +61,7 @@ int qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq);
 void qspi_setTCSH(uint8_t cycles);
 void qspi_setTCSS(uint8_t cycles);
 
+/* TODO non busy read. */
 int _qspi_read(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size);
 int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void *data, size_t size);
 

--- a/spi/imx6ull-qspi/qspi.h
+++ b/spi/imx6ull-qspi/qspi.h
@@ -19,8 +19,8 @@
 #include <phoenix/arch/imx6ull.h>
 
 
-#define MAX_READ_LEN  0xFFFF
-#define MAX_WRITE_LEN 0xFFFF
+#define MAX_READ_LEN  0xffff
+#define MAX_WRITE_LEN 0xffff
 
 typedef enum {
 	lut_stop,
@@ -42,7 +42,7 @@ typedef enum {
 	lut_data_learn
 } lut_code_t;
 
-#define LUT_INSTR(code, pad, operand) ((((code)&0x3F) << 10) | (((pad)&0x03) << 8) | ((operand)&0xFF))
+#define LUT_INSTR(code, pad, operand) ((((code)&0x3f) << 10) | (((pad)&0x03) << 8) | ((operand)&0xff))
 
 enum {
 	lut_pad1,

--- a/spi/imx6ull-qspi/qspi.h
+++ b/spi/imx6ull-qspi/qspi.h
@@ -1,0 +1,68 @@
+/*
+ * Phoenix-RTOS
+ *
+ * i.MX 6ULL QSPI lib API
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Hubert Badocha
+ *
+ * %LICENSE%
+ */
+
+#ifndef IMX6ULL_QSPI_API_H
+#define IMX6ULL_QSPI_API_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <sys/threads.h>
+#include <phoenix/arch/imx6ull.h>
+
+
+#define MAX_READ_LEN  0xFFFF
+#define MAX_WRITE_LEN 0xFFFF
+
+typedef enum {
+	lut_stop,
+	lut_cmd,
+	lut_addr,
+	lut_dummy,
+	lut_mode,
+	lut_mode2,
+	lut_mode4,
+	lut_read,
+	lut_write,
+	lut_jmp_on_cs,
+	lut_addr_ddr,
+	lut_mode_ddr,
+	lut_mode2_ddr,
+	lut_mode4_ddr,
+	lut_read_ddr,
+	lut_write_ddr,
+	lut_data_learn
+} lut_code_t;
+
+#define LUT_INSTR(code, pad, operand) ((((code)&0x3F) << 10) | (((pad)&0x03) << 8) | ((operand)&0xFF))
+
+typedef struct {
+	uint16_t instrs[8];
+} lut_seq_t;
+
+typedef enum {
+	qspi_flash_a,
+	qspi_flash_b,
+} qspi_dev_t;
+
+int _qspi_init(qspi_dev_t dev);
+
+int qspi_setLutSeq(const lut_seq_t *lut, unsigned int lut_seq);
+
+// int qspi_setClockDiv(qspi_ctx_t* ctx, uint8_t pre, uint8_t post);
+void qspi_setTCSH(uint8_t cycles);
+void qspi_setTCSS(uint8_t cycles);
+
+int _qspi_read(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, void *buf, size_t size);
+int _qspi_write(qspi_dev_t dev, unsigned int lut_seq, uint32_t addr, const void *data, size_t size);
+
+
+#endif /* IMX6ULL_QSPI_API_H */

--- a/storage/imx6ull-flashnor/Makefile
+++ b/storage/imx6ull-flashnor/Makefile
@@ -1,13 +1,13 @@
 #
 # Makefile for Phoenix-RTOS imx6ull-flashnor driver
 #
-# Copyright 2021 Phoenix Systems
+# Copyright 2021, 2023 Phoenix Systems
 #
 
 NAME := imx6ull-flashnor
-LOCAL_SRCS := flashnor.c flashnor-ecspi.c storage.c
-LOCAL_HEADERS := flashnor-ecspi.h storage.h
-DEP_LIBS := libimx6ull-ecspi
+LOCAL_SRCS := flashnor.c flashnor-ecspi.c storage.c flashnor-qspi.c
+LOCAL_HEADERS := flashnor-ecspi.h storage.h flashnor-qspi.h
+DEP_LIBS := libimx6ull-ecspi libimx6ull-qspi
 LIBS := libmeterfs
 LOCAL_INSTALL_PATH := /sbin
 
@@ -15,8 +15,8 @@ include $(binary.mk)
 
 # NOR flash test program
 NAME := flashnor-test
-LOCAL_SRCS := flashnor-test.c flashnor-ecspi.c storage.c
-DEP_LIBS := libimx6ull-ecspi
+LOCAL_SRCS := flashnor-test.c flashnor-ecspi.c flashnor-qspi.c storage.c
+DEP_LIBS := libimx6ull-ecspi libimx6ull-qspi
 LIBS := libmeterfs
 
 include $(binary.mk)

--- a/storage/imx6ull-flashnor/flashnor-qspi.c
+++ b/storage/imx6ull-flashnor/flashnor-qspi.c
@@ -49,18 +49,18 @@ typedef struct {
 
 /* Supported NOR flash chips */
 static const chip_t chips[] = {
-	{ "Micron MT25QL256ABA(256Mb, 3V)", { 0x20, 0xBA, 0x19 }, 4 * 1024, 32 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(256Mb, 3V)", { 0x20, 0xba, 0x19 }, 4 * 1024, 32 * 1024 * 1024 },
 	/* Not tested.
 
-	{ "Micron MT25QL256ABA(1Gb, 3V)", { 0x20, 0xBA, 0x21 }, 64 * 1024, 1024 * 1024 * 1024 },
-	{ "Micron MT25QL256ABA(512Mb, 3V)", { 0x20, 0xBA, 0x20 }, 64 * 1024, 512 * 1024 * 1024 },
-	{ "Micron MT25QL256ABA(128Mb, 3V)", { 0x20, 0xBA, 0x18 }, 64 * 1024, 128 * 1024 * 1024 },
-	{ "Micron MT25QL256ABA(16Mb, 3V)", { 0x20, 0xBA, 0x17 }, 64 * 1024, 16 * 1024 * 1024 },
-	{ "Micron MT25QL256ABA(1Gb, 1.8V)", { 0x20, 0xBB, 0x21 }, 64 * 1024, 1024 * 1024 * 1024 },
-	{ "Micron MT25QL256ABA(512Mb, 1.8V)", { 0x20, 0xBB, 0x20 }, 64 * 1024, 512 * 1024 * 1024 },
-	{ "Micron MT25QL256ABA(256Mb, 1.8V)", { 0x20, 0xBB, 0x19 }, 64 * 1024, 256 * 1024 * 1024 },
-	{ "Micron MT25QL256ABA(128Mb, 1.8V)", { 0x20, 0xBB, 0x18 }, 64 * 1024, 128 * 1024 * 1024 },
-	{ "Micron MT25QL256ABA(16Mb, 1.8V)", { 0x20, 0xBB, 0x17 }, 64 * 1024, 16 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(1Gb, 3V)", { 0x20, 0xba, 0x21 }, 64 * 1024, 1024 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(512Mb, 3V)", { 0x20, 0xba, 0x20 }, 64 * 1024, 512 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(128Mb, 3V)", { 0x20, 0xba, 0x18 }, 64 * 1024, 128 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(16Mb, 3V)", { 0x20, 0xba, 0x17 }, 64 * 1024, 16 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(1Gb, 1.8V)", { 0x20, 0xbb, 0x21 }, 64 * 1024, 1024 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(512Mb, 1.8V)", { 0x20, 0xbb, 0x20 }, 64 * 1024, 512 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(256Mb, 1.8V)", { 0x20, 0xbb, 0x19 }, 64 * 1024, 256 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(128Mb, 1.8V)", { 0x20, 0xbb, 0x18 }, 64 * 1024, 128 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(16Mb, 1.8V)", { 0x20, 0xbb, 0x17 }, 64 * 1024, 16 * 1024 * 1024 },
 	*/
 };
 
@@ -145,8 +145,8 @@ ssize_t flashnor_qspiWrite(qspi_dev_t dev, unsigned int addr, const void *buff, 
 			size = MAX_WRITE_LEN;
 
 		/* Limit write size to the page aligned address (don't wrap around at the page boundary) */
-		if (size > 0x100 - ((addr + len) & 0xFF))
-			size = 0x100 - ((addr + len) & 0xFF);
+		if (size > 0x100 - ((addr + len) & 0xff))
+			size = 0x100 - ((addr + len) & 0xff);
 		/* TODO XIP */
 		if ((err = _qspi_write(dev, lut_seq_write, addr + len, ((const char *)buff) + len, size)) < 0) {
 			mutexUnlock(flashnor_common.lock);

--- a/storage/imx6ull-flashnor/flashnor-qspi.c
+++ b/storage/imx6ull-flashnor/flashnor-qspi.c
@@ -82,12 +82,21 @@ static int _flashnor_qspiWaitBusy(qspi_dev_t dev)
 {
 	uint8_t status;
 	int err;
-	do {
-		/* TODO add backoff */
+	unsigned int sleep = 1000;
+
+	if ((err = _qspi_read(dev, lut_seq_read_status, 0, &status, 1)) < 0) {
+		return err;
+	}
+
+	while (status & 1) {
+		usleep(sleep);
+		if (sleep < 100000)
+			sleep <<= 1;
 		if ((err = _qspi_read(dev, lut_seq_read_status, 0, &status, 1)) < 0) {
 			return err;
 		}
-	} while (status & 1);
+	}
+
 	return EOK;
 }
 

--- a/storage/imx6ull-flashnor/flashnor-qspi.c
+++ b/storage/imx6ull-flashnor/flashnor-qspi.c
@@ -19,15 +19,15 @@
 #include <qspi.h>
 #include "flashnor-qspi.h"
 
-enum {
-	cmd_wren = 0x06,      /* Write Enable */
-	cmd_rdsr = 0x05,      /* Read Status Register */
-	cmd_4qwrite = 0x34,   /* 4-byte Quad I/O Write */
-	cmd_qenable = 0x35,   /* Enable Quad I/O */
-	cmd_4erase4 = 0x21,   /*  4-byte  Sector Erase (4 KB) */
-	cmd_jedec = 0x9f,     /* JEDEC ID */
-	cmd_4qfread_io = 0xec /*  4-byte Quad Fast Read I/O */
-};
+
+#define CMD_WREN       0x06 /* Write Enable */
+#define CMD_RDSR       0x05 /* Read Status Register */
+#define CMD_4QWRITE    0x34 /* 4-byte Quad I/O Write */
+#define CMD_QENABLE    0x35 /* Enable Quad I/O */
+#define CMD_4ERASE4KB  0x21 /*  4-byte  Sector Erase (4 KB) */
+#define CMD_JEDEC      0x9f /* JEDEC ID */
+#define CMD_4QFREAD_IO 0xec /*  4-byte Quad Fast Read I/O */
+
 
 enum {
 	lut_seq_jedec,
@@ -206,7 +206,7 @@ int flashnor_qspiEraseSector(qspi_dev_t dev, unsigned int addr)
 static int get_jedec_id(qspi_dev_t dev, uint8_t data[3])
 {
 	int err;
-	lut_seq_t seq = { .instrs = { LUT_INSTR(lut_cmd, lut_pad1, cmd_jedec), LUT_INSTR(lut_read, lut_pad1, 3), 0 } };
+	lut_seq_t seq = { .instrs = { LUT_INSTR(lut_cmd, lut_pad1, CMD_JEDEC), LUT_INSTR(lut_read, lut_pad1, 3), 0 } };
 
 	err = qspi_setLutSeq(&seq, lut_seq_jedec);
 	if (err < 0) {
@@ -218,7 +218,7 @@ static int get_jedec_id(qspi_dev_t dev, uint8_t data[3])
 static int enable_quad_io(qspi_dev_t dev)
 {
 	int err;
-	lut_seq_t seq = { .instrs = { LUT_INSTR(lut_cmd, lut_pad1, cmd_qenable), 0 } };
+	lut_seq_t seq = { .instrs = { LUT_INSTR(lut_cmd, lut_pad1, CMD_QENABLE), 0 } };
 	err = qspi_setLutSeq(&seq, lut_seq_quad_io);
 	if (err < 0) {
 		return err;
@@ -235,11 +235,11 @@ static int populate_lut(void)
 		unsigned int num;
 		lut_seq_t lut_seq;
 	} seqs[5] = {
-		{ lut_seq_write_enable, { { LUT_INSTR(lut_cmd, lut_pad4, cmd_wren), 0} } },
-		{ lut_seq_read,         { { LUT_INSTR(lut_cmd, lut_pad4, cmd_4qfread_io), LUT_INSTR(lut_addr, lut_pad4, 32), LUT_INSTR(lut_dummy, lut_pad4, 10), LUT_INSTR(lut_read, lut_pad4, 0), 0} } },
-		{ lut_seq_write,        { { LUT_INSTR(lut_cmd, lut_pad4, cmd_4qwrite), LUT_INSTR(lut_addr, lut_pad4, 32), LUT_INSTR(lut_write, lut_pad4, 0), 0} } },
-		{ lut_seq_erase,        { { LUT_INSTR(lut_cmd, lut_pad4, cmd_4erase4), LUT_INSTR(lut_addr, lut_pad4, 32), 0 } } },
-		{ lut_seq_read_status,  { { LUT_INSTR(lut_cmd, lut_pad4, cmd_rdsr), LUT_INSTR(lut_read, lut_pad4, 1), 0 } }  },
+		{ lut_seq_write_enable, { { LUT_INSTR(lut_cmd, lut_pad4, CMD_WREN), 0} } },
+		{ lut_seq_read,         { { LUT_INSTR(lut_cmd, lut_pad4, CMD_4QFREAD_IO), LUT_INSTR(lut_addr, lut_pad4, 32), LUT_INSTR(lut_dummy, lut_pad4, 10), LUT_INSTR(lut_read, lut_pad4, 0), 0} } },
+		{ lut_seq_write,        { { LUT_INSTR(lut_cmd, lut_pad4, CMD_4QWRITE), LUT_INSTR(lut_addr, lut_pad4, 32), LUT_INSTR(lut_write, lut_pad4, 0), 0} } },
+		{ lut_seq_erase,        { { LUT_INSTR(lut_cmd, lut_pad4, CMD_4ERASE4KB), LUT_INSTR(lut_addr, lut_pad4, 32), 0 } } },
+		{ lut_seq_read_status,  { { LUT_INSTR(lut_cmd, lut_pad4, CMD_RDSR), LUT_INSTR(lut_read, lut_pad4, 1), 0 } }  },
 	};
 	/* clang-format on */
 	for (i = 0; i < sizeof(seqs) / sizeof(*seqs); i++) {

--- a/storage/imx6ull-flashnor/flashnor-qspi.c
+++ b/storage/imx6ull-flashnor/flashnor-qspi.c
@@ -28,6 +28,7 @@
 #define CMD_JEDEC      0x9f /* JEDEC ID */
 #define CMD_4QFREAD_IO 0xec /*  4-byte Quad Fast Read I/O */
 
+#define FLASH_PAGE_SIZE 256
 
 enum {
 	lut_seq_jedec,
@@ -154,8 +155,8 @@ ssize_t flashnor_qspiWrite(qspi_dev_t dev, unsigned int addr, const void *buff, 
 			size = MAX_WRITE_LEN;
 
 		/* Limit write size to the page aligned address (don't wrap around at the page boundary) */
-		if (size > 0x100 - ((addr + len) & 0xff))
-			size = 0x100 - ((addr + len) & 0xff);
+		if (size > FLASH_PAGE_SIZE - ((addr + len) & (FLASH_PAGE_SIZE - 1)))
+			size = FLASH_PAGE_SIZE - ((addr + len) & (FLASH_PAGE_SIZE - 1));
 		/* TODO XIP */
 		err = _qspi_write(dev, lut_seq_write, addr + len, ((const char *)buff) + len, size);
 		if (err < 0) {

--- a/storage/imx6ull-flashnor/flashnor-qspi.c
+++ b/storage/imx6ull-flashnor/flashnor-qspi.c
@@ -275,9 +275,9 @@ int _flashnor_qspiInit(qspi_dev_t dev, storage_t *storage_dev)
 	printf("imx6ull-flashnor: JEDEC ID: %#02x %#02x %#02x\n", jedec[0], jedec[1], jedec[2]);
 
 	for (i = 0; i < sizeof(chips) / sizeof(chips[0]); i++) {
-		if (!memcmp(jedec, chips[i].jedec, sizeof(chips[i].jedec))) {
+		if (memcmp(jedec, chips[i].jedec, sizeof(chips[i].jedec)) == 0) {
 			printf("imx6ull-flashnor: %s %uMbit NOR\n", chips[i].name, 8 * chips[i].flashsz >> 20);
-			if (!flashnor_common.init) {
+			if (flashnor_common.init == 0) {
 				err = mutexCreate(&flashnor_common.lock);
 				if (err < 0) {
 					return err;

--- a/storage/imx6ull-flashnor/flashnor-qspi.c
+++ b/storage/imx6ull-flashnor/flashnor-qspi.c
@@ -1,0 +1,276 @@
+/*
+ * Phoenix-RTOS
+ *
+ * i.MX 6ULL QSPI NOR flash driver
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Hubert Badocha
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <sys/threads.h>
+#include <sys/types.h>
+#include <qspi.h>
+#include "flashnor-qspi.h"
+
+enum {
+	cmd_wren = 0x06,      /* Write Enable */
+	cmd_rdsr = 0x05,      /* Read Status Register */
+	cmd_4qwrite = 0x34,   /* 4-byte Quad I/O Write */
+	cmd_qenable = 0x35,   /* Enable Quad I/O */
+	cmd_4erase4 = 0x21,   /*  4-byte  Sector Erase (4 KB) */
+	cmd_jedec = 0x9f,     /* JEDEC ID */
+	cmd_4qfread_io = 0xec /*  4-byte Quad Fast Read I/O */
+};
+
+enum {
+	lut_seq_jedec,
+	lut_seq_write_enable,
+	lut_seq_write,
+	lut_seq_erase,
+	lut_seq_read,
+	lut_seq_read_status,
+	lut_seq_quad_io,
+};
+
+typedef struct {
+	const char *name;       /* Chip name */
+	unsigned char jedec[3]; /* Chip JEDEC ID */
+	unsigned int sectorsz;  /* Chip sector size in bytes */
+	unsigned int flashsz;   /* Chip storage size in bytes */
+	size_t pagesz;          /* Chip storage size in bytes */
+} chip_t;
+
+/* Supported NOR flash chips */
+static const chip_t chips[] = {
+	{ "Micron MT25QL256ABA(256Mb, 3V)", { 0x20, 0xBA, 0x19 }, 4 * 1024, 256 * 1024 * 1024, 256 },
+	/* Not tested.
+
+	{ "Micron MT25QL256ABA(1Gb, 3V)", { 0x20, 0xBA, 0x21 }, 64 * 1024, 1024 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(512Mb, 3V)", { 0x20, 0xBA, 0x20 }, 64 * 1024, 512 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(128Mb, 3V)", { 0x20, 0xBA, 0x18 }, 64 * 1024, 128 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(16Mb, 3V)", { 0x20, 0xBA, 0x17 }, 64 * 1024, 16 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(1Gb, 1.8V)", { 0x20, 0xBB, 0x21 }, 64 * 1024, 1024 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(512Mb, 1.8V)", { 0x20, 0xBB, 0x20 }, 64 * 1024, 512 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(256Mb, 1.8V)", { 0x20, 0xBB, 0x19 }, 64 * 1024, 256 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(128Mb, 1.8V)", { 0x20, 0xBB, 0x18 }, 64 * 1024, 128 * 1024 * 1024 },
+	{ "Micron MT25QL256ABA(16Mb, 1.8V)", { 0x20, 0xBB, 0x17 }, 64 * 1024, 16 * 1024 * 1024 },
+	*/
+};
+
+struct {
+	handle_t lock;
+	bool init;
+	size_t pagesz[2];
+} flashnor_common;
+
+
+static int _flashnor_qspiWriteEnable(qspi_dev_t dev)
+{
+	return _qspi_read(dev, lut_seq_write_enable, 0, NULL, 0);
+}
+
+
+static int _flashnor_qspiWaitBusy(qspi_dev_t dev)
+{
+	uint8_t status;
+	int err;
+	do {
+		if ((err = _qspi_read(dev, lut_seq_read_status, 0, &status, 1)) < 0) {
+			return err;
+		}
+		printf("STATUS READ %d\n", status);
+		usleep(5e5);
+	} while (status & 1);
+	return EOK;
+}
+
+
+ssize_t flashnor_qspiRead(qspi_dev_t dev, unsigned int addr, void *buff, size_t bufflen)
+{
+	size_t size, len;
+	int err;
+
+	if ((err = mutexLock(flashnor_common.lock)) < 0) {
+		return err;
+	}
+
+	for (len = 0; len < bufflen; len += size) {
+		if ((size = bufflen - len) > MAX_READ_LEN)
+			size = MAX_READ_LEN;
+
+		/* TODO XIP */
+		if ((err = _qspi_read(dev, lut_seq_read, addr + len, ((char *)buff) + len, size)) < 0) {
+			mutexUnlock(flashnor_common.lock);
+			return err;
+		}
+	}
+
+	if ((err = mutexUnlock(flashnor_common.lock)) < 0) {
+		return err;
+	}
+
+	return bufflen;
+}
+
+
+ssize_t flashnor_qspiWrite(qspi_dev_t dev, unsigned int addr, const void *buff, size_t bufflen)
+{
+	size_t size, len;
+	int err;
+
+	if ((err = mutexLock(flashnor_common.lock)) < 0) {
+		return err;
+	}
+
+	for (len = 0; len < bufflen; len += size) {
+		if ((err = _flashnor_qspiWriteEnable(dev)) < 0) {
+			mutexUnlock(flashnor_common.lock);
+			return err;
+		}
+		if ((size = bufflen - len) > MAX_WRITE_LEN)
+			size = MAX_WRITE_LEN;
+
+		/* Limit write size to the page aligned address (don't wrap around at the page boundary) */
+		if (size > flashnor_common.pagesz[dev] - ((addr + len) % flashnor_common.pagesz[dev]))
+			size = flashnor_common.pagesz[dev] - ((addr + len) % flashnor_common.pagesz[dev]);
+		printf("SIZE %d\n", size);
+		if (size == 0) {
+			printf("BUFFLEN %d\n", bufflen);
+			printf("LEN %d\n", len);
+			printf("PAGE SIZE %d\n", flashnor_common.pagesz[dev]);
+			printf("ADDR %d\n", addr + len);
+			return -1;
+		}
+		/* TODO XIP */
+		if ((err = _qspi_write(dev, lut_seq_write, addr + len, ((const char *)buff) + len, size)) < 0) {
+			mutexUnlock(flashnor_common.lock);
+			return err;
+		}
+
+		if ((err = _flashnor_qspiWaitBusy(dev)) < 0) {
+			mutexUnlock(flashnor_common.lock);
+			return err;
+		}
+		usleep(5e5);
+	}
+
+	if ((err = mutexUnlock(flashnor_common.lock)) < 0) {
+		return err;
+	}
+
+	return bufflen;
+}
+
+
+int flashnor_qspiEraseSector(qspi_dev_t dev, unsigned int addr)
+{
+	int err;
+	if ((err = mutexLock(flashnor_common.lock)) < 0) {
+		return err;
+	}
+	if ((err = _flashnor_qspiWriteEnable(dev)) < 0) {
+		return err;
+	}
+	if ((err = _qspi_write(dev, lut_seq_erase, addr, NULL, 0)) < 0) {
+		return err;
+	}
+	if ((err = _flashnor_qspiWaitBusy(dev)) < 0) {
+		return err;
+	}
+	return mutexUnlock(flashnor_common.lock);
+}
+
+
+static int get_jedec_id(qspi_dev_t dev, uint8_t data[3])
+{
+	int err;
+	lut_seq_t seq = { .instrs = { LUT_INSTR(lut_cmd, 0, cmd_jedec), LUT_INSTR(lut_read, 0, 3), 0 } };
+	if ((err = qspi_setLutSeq(&seq, lut_seq_jedec)) < 0) {
+		return err;
+	}
+	return _qspi_read(dev, lut_seq_jedec, 0, data, 3);
+}
+
+static int enable_quad_io(qspi_dev_t dev)
+{
+	int err;
+	lut_seq_t seq = { .instrs = { LUT_INSTR(lut_cmd, 0, cmd_qenable), 0 } };
+	if ((err = qspi_setLutSeq(&seq, lut_seq_quad_io) < 0)) {
+		return err;
+	}
+	return _qspi_read(dev, lut_seq_quad_io, 0, NULL, 0);
+}
+
+
+static int populate_lut()
+{
+	int err, i;
+	/* clang-format off */
+	struct {
+		unsigned int num;
+		lut_seq_t lut_seq;
+	} seqs[5] = {
+		{ lut_seq_write_enable, { { LUT_INSTR(lut_cmd, 2, cmd_wren), 0} } },
+		{ lut_seq_read,         { { LUT_INSTR(lut_cmd, 2, cmd_4qfread_io), LUT_INSTR(lut_addr, 2, 32), LUT_INSTR(lut_dummy, 2, 10), LUT_INSTR(lut_read, 2, 0), 0} } },
+		{ lut_seq_write,        { { LUT_INSTR(lut_cmd, 2, cmd_4qwrite), LUT_INSTR(lut_addr, 2, 32), LUT_INSTR(lut_write, 2, 0), 0} } },
+		{ lut_seq_erase,        { { LUT_INSTR(lut_cmd, 2, cmd_4erase4), LUT_INSTR(lut_addr, 2, 32), 0 } } },
+		{ lut_seq_read_status,  { { LUT_INSTR(lut_cmd, 2, cmd_rdsr), LUT_INSTR(lut_read, 2, 1), 0 } }  },
+	};
+	/* clang-format on */
+	for (i = 0; i < 5; i++) {
+		if ((err = qspi_setLutSeq(&seqs[i].lut_seq, seqs[i].num)) < 0) {
+			return err;
+		}
+	}
+	return EOK;
+}
+
+
+int _flashnor_qspiInit(qspi_dev_t dev, storage_t *storage_dev)
+{
+	int i, err;
+	uint8_t jedec[3];
+
+	if ((err = _qspi_init(dev)) < 0) {
+		return err;
+	}
+	qspi_setTCSH(0);
+	qspi_setTCSS(0);
+
+	if ((err = get_jedec_id(dev, jedec)) < 0) {
+		return err;
+	}
+
+	printf("imx6ull-flashnor: JEDEC ID: %#02x %#02x %#02x\n", jedec[0], jedec[1], jedec[2]);
+
+	for (i = 0; i < sizeof(chips) / sizeof(chips[0]); i++) {
+		if (!memcmp(jedec, chips[i].jedec, sizeof(chips[i].jedec))) {
+			printf("imx6ull-flashnor: %s %uMbit NOR\n", chips[i].name, 8 * chips[i].flashsz >> 20);
+			flashnor_common.pagesz[dev] = chips[i].pagesz;
+			if (!flashnor_common.init) {
+				if ((err = mutexCreate(&flashnor_common.lock)) < 0) {
+					return err;
+				}
+				if ((err = populate_lut()) < 0) {
+					return err;
+				}
+				if ((err = enable_quad_io(dev))) {
+					return err;
+				}
+			}
+			flashnor_common.init = true;
+			/* TODO init storage device */
+			return EOK;
+		}
+	}
+
+	return -ENODEV;
+}

--- a/storage/imx6ull-flashnor/flashnor-qspi.h
+++ b/storage/imx6ull-flashnor/flashnor-qspi.h
@@ -1,0 +1,35 @@
+/*
+ * Phoenix-RTOS
+ *
+ * i.MX 6ULL QSPI NOR flash driver
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Hubert Badocha
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _FLASHNOR_QSPI_H_
+#define _FLASHNOR_QSPI_H_
+
+#include <unistd.h>
+#include <qspi.h>
+
+#include "storage.h"
+
+
+ssize_t flashnor_qspiRead(qspi_dev_t dev, unsigned int addr, void *buff, size_t bufflen);
+
+
+ssize_t flashnor_qspiWrite(qspi_dev_t dev, unsigned int addr, const void *buff, size_t bufflen);
+
+
+int flashnor_qspiEraseSector(qspi_dev_t dev, unsigned int addr);
+
+
+int _flashnor_qspiInit(qspi_dev_t dev, storage_t *storage_dev);
+
+
+#endif

--- a/storage/imx6ull-flashnor/flashnor-test.c
+++ b/storage/imx6ull-flashnor/flashnor-test.c
@@ -27,7 +27,6 @@
 static int (*flashnor_eraseSector)(unsigned int addr);
 static int (*flashnor_read)(unsigned int addr, void *buff, size_t bufflen);
 static int (*flashnor_write)(unsigned int addr, const void *buff, size_t bufflen);
-static int (*flashnor_init)(unsigned int ndev, storage_t *dev);
 
 static unsigned valcmp(uint8_t *buf, size_t len, uint8_t val)
 {
@@ -81,6 +80,7 @@ static int test_read_write(size_t flashsz, size_t sectorsz)
 			res = -1;
 			break;
 		}
+
 
 		if (flashnor_read(addr, buf, sectorsz) < 0) {
 			printf("fail: read sector at addr %u\n", addr);
@@ -169,382 +169,26 @@ static void flashnor_test_help(const char *prog)
 {
 	printf("Usage: %s [options]\n", prog);
 	printf("\t-e <n> | --ecspi <n>   - initialize ECSPI NOR flash device\n");
-	printf("\t\tn:      ECSPI instance number (by default ecspi no. 3 is used)\n");
+	printf("\t\tn:      ECSPI instance number\n");
 	printf("\t-q <n> | --qspi <n>   - initialize QSPI NOR flash device\n");
-	printf("\t\tn:      QSPI instance number (by default qspi no. 3 is used)\n");
+	printf("\t\tn:      QSPI flash 0=A 1=B\n");
 }
 
-#define READ_SIZE 32
-static int qspi_test(qspi_dev_t dev)
+int run_ecspi_tests(unsigned spi_no)
 {
-	_qspi_init(dev);
-	qspi_setTCSH(0);
-	qspi_setTCSS(0);
-
-	// Get device data.
-	{
-		lut_seq_t seq = { .instrs = {
-							  LUT_INSTR(lut_cmd, 0, 0x9f),
-							  LUT_INSTR(lut_read, 0, 3),
-							  0,
-						  } };
-		qspi_setLutSeq(&seq, 0);
-		char data[3];
-		memset(data, 0xFF, 3);
-
-		_qspi_read(dev, 0, 0, data, 3);
-		printf("VENDOR\n");
-		for (int i = 0; i < 3; i++) {
-			printf("%#x ", data[i]);
-		}
-		printf("\n");
-	}
-	printf("\n-------------------\n\n");
-
-	// Enter 4 I/O Mode.
-	{
-		lut_seq_t seq = { .instrs = {
-							  LUT_INSTR(lut_cmd, 0, 0x35),
-							  0,
-						  } };
-		qspi_setLutSeq(&seq, 1);
-
-		_qspi_read(dev, 1, 0, NULL, 0);
-		printf("ENTERED 4 I/O\n");
-	}
-	printf("\n-------------------\n\n");
-
-	// Write enable.
-	{
-		lut_seq_t seq = { .instrs = {
-							  LUT_INSTR(lut_cmd, 2, 0x06),  // Write enable
-							  0,
-						  } };
-		qspi_setLutSeq(&seq, 9);
-
-		_qspi_read(dev, 9, 0, NULL, 0);
-		printf("ENABLED WRITE\n");
-	}
-	printf("\n-------------------\n\n");
-	// ERASE
-	{
-		lut_seq_t seq = { .instrs = {
-							  LUT_INSTR(lut_cmd, 2, 0x21),
-							  LUT_INSTR(lut_addr, 2, 32),
-							  0,
-						  } };
-		qspi_setLutSeq(&seq, 4);
-
-		_qspi_read(dev, 4, 0, NULL, 0);
-		printf("ERASED DATA\n");
-	}
-	printf("\n-------------------\n\n");
-	{
-		lut_seq_t seq = { .instrs = {
-							  LUT_INSTR(lut_cmd, 2, 0x05),
-							  LUT_INSTR(lut_read, 2, 1),
-							  0,
-						  } };
-		qspi_setLutSeq(&seq, 10);
-		unsigned char status = 1;
-		while (status & 1) {
-			_qspi_read(dev, 10, 0, &status, 1);
-			printf("Status register: %#x\n", status);
-		}
-	}
-	printf("\n-------------------\n\n");
-	// WRITE ENABLE
-	{
-		_qspi_read(dev, 9, 0, NULL, 0);
-		printf("ENABLED WRITE\n");
-	}
-	printf("\n-------------------\n\n");
-
-	// WRITE
-	{
-		lut_seq_t seq = { .instrs = {
-							  LUT_INSTR(lut_cmd, 2, 0x34),
-							  LUT_INSTR(lut_addr, 2, 32),
-							  LUT_INSTR(lut_write, 2, 0),
-							  0,
-						  } };
-		qspi_setLutSeq(&seq, 2);
-		char data[READ_SIZE / 2];
-		memset(data, 0x06, READ_SIZE / 2);
-
-		_qspi_write(dev, 2, 0, data, READ_SIZE / 2);
-		printf("WRITTEN DATA\n");
-	}
-	printf("\n-------------------\n\n");
-
-	// Check status register
-	{
-		unsigned char status = 1;
-		while (status & 1) {
-			_qspi_read(dev, 10, 0, &status, 1);
-			printf("Status register: %#x\n", status);
-		}
-	}
-	printf("\n-------------------\n\n");
-	// WRITE ENABLE
-	{
-		_qspi_read(dev, 9, 0, NULL, 0);
-		printf("ENABLED WRITE\n");
-	}
-	printf("\n-------------------\n\n");
-	{
-		char data[READ_SIZE / 2];
-		memset(data, 0x09, READ_SIZE / 2);
-
-		_qspi_write(dev, 2, 0 + READ_SIZE / 2, data, READ_SIZE / 2);
-		printf("WRITTEN DATA\n");
-	}
-	printf("\n-------------------\n\n");
-	// Check status register
-	{
-		unsigned char status = 1;
-		while (status & 1) {
-			_qspi_read(dev, 10, 0, &status, 1);
-			printf("Status register: %#x\n", status);
-		}
-	}
-	printf("\n-------------------\n\n");
-
-	// READ
-	{
-		lut_seq_t seq = { .instrs = {
-							  LUT_INSTR(lut_cmd, 2, 0xEC),
-							  LUT_INSTR(lut_addr, 2, 32),
-							  LUT_INSTR(lut_dummy, 2, 10),
-							  LUT_INSTR(lut_read, 2, 0),
-							  0,
-						  } };
-		qspi_setLutSeq(&seq, 3);
-		char data[READ_SIZE];
-		memset(data, 0xFF, READ_SIZE);
-
-		_qspi_read(dev, 3, 0, data, READ_SIZE);
-		printf("READ\n");
-		for (int i = 0; i < READ_SIZE; i++) {
-			printf("%#x ", data[i]);
-		}
-		printf("\n");
-	}
-	// Write enable.
-	{
-		_qspi_read(dev, 9, 0, NULL, 0);
-		printf("ENABLED WRITE\n");
-	}
-	printf("\n-------------------\n\n");
-	// ERASE
-	{
-		lut_seq_t seq = { .instrs = {
-							  LUT_INSTR(lut_cmd, 2, 0x21),
-							  LUT_INSTR(lut_addr, 2, 32),
-							  0,
-						  } };
-		qspi_setLutSeq(&seq, 4);
-
-		_qspi_read(dev, 4, 0, NULL, 0);
-		printf("ERASED DATA\n");
-	}
-	printf("\n-------------------\n\n");
-
-	// Check status register
-	{
-		unsigned char status = 1;
-		while (status & 1) {
-			_qspi_read(dev, 10, 0, &status, 1);
-			printf("Status register: %#x\n", status);
-		}
-	}
-	printf("\n-------------------\n\n");
-
-	// READ AGAIN
-	{
-		char data[READ_SIZE];
-		memset(data, 0xFF, READ_SIZE);
-
-		_qspi_read(dev, 3, 0, data, READ_SIZE);
-		printf("READ\n");
-		for (int i = 0; i < READ_SIZE; i++) {
-			printf("%#x ", data[i]);
-		}
-		printf("\n");
-	}
-	printf("\n-------------------\n\n");
-
-	return 0;
-}
-
-static int qspi_test_read_write(qspi_dev_t dev, size_t flashsz, size_t sectorsz)
-{
-	int res = 0;
-	unsigned errors = 0, addr;
-	uint8_t *pattern, *buf;
-
-	printf("%s: ", __func__);
-
-	pattern = malloc(sectorsz);
-	if (pattern == NULL) {
-		printf("fail: malloc\n");
-		return -1;
-	}
-
-	buf = malloc(sectorsz);
-	if (buf == NULL) {
-		printf("fail: malloc\n");
-		free(pattern);
-		return -1;
-	}
-
-	memset(pattern, 0x55, sectorsz);
-
-	/* Test only every sixteenth block */
-	for (addr = 0; addr < flashsz; addr += sectorsz * 16) {
-		/* As meterfs is fixed right now in the driver implementation
-		   we have to erase sector before write, because of metadata written by meterfs */
-		if (flashnor_qspiEraseSector(dev, addr) < 0) {
-			printf("fail: erase sector at addr %u\n", addr);
-			res = -1;
-			break;
-		}
-
-		if (flashnor_qspiWrite(dev, addr, pattern, sectorsz) < 0) {
-			printf("fail: write sector at addr %u\n", addr);
-			res = -1;
-			break;
-		}
-
-		if (flashnor_qspiRead(dev, addr, buf, sectorsz) < 0) {
-			printf("fail: read sector at addr %u\n", addr);
-			res = -1;
-			break;
-		}
-
-		errors += valcmp(buf, sectorsz, pattern[0]);
-	}
-
-	if (res == 0) {
-		if (errors) {
-			printf("fail: read %u errors\n", errors);
-			res = -1;
-		}
-		else {
-			printf("ok\n");
-		}
-	}
-
-	free(pattern);
-	free(buf);
-
-	return res;
-}
-
-
-static int qspi_test_erase(qspi_dev_t dev, size_t flashsz, size_t sectorsz)
-{
-	int res = 0;
-	unsigned errors = 0, addr;
-	uint8_t *buf;
-
-	printf("%s: ", __func__);
-
-	buf = malloc(sectorsz);
-	if (buf == NULL) {
-		printf("fail: malloc\n");
-		return -1;
-	}
-
-	/* Clean sectors written by test_write_read */
-	for (addr = 0; addr < flashsz; addr += sectorsz * 16) {
-		if (flashnor_qspiEraseSector(dev, addr) < 0) {
-			printf("fail: erase sector at addr %u\n", addr);
-			res = -1;
-			break;
-		}
-
-		if (flashnor_qspiRead(dev, addr, buf, sectorsz) < 0) {
-			printf("fail: erase sector read at addr %u\n", addr);
-			res = -1;
-			break;
-		}
-
-		errors += valcmp(buf, sectorsz, 0xff);
-	}
-
-	if (res == 0) {
-		if (errors) {
-			printf("fail: read %u errors\n", errors);
-			res = -1;
-		}
-		else {
-			printf("ok\n");
-		}
-	}
-
-	free(buf);
-	return res;
-}
-
-
-static int qspi_run_tests(qspi_dev_t dev, size_t flashsz, size_t sectorsz)
-{
-	storage_t storage_dev = { 0 };
-	int err;
-	if ((err = _flashnor_qspiInit(dev, &storage_dev)) < 0) {
-		return err;
-	}
-
-	if (qspi_test_read_write(dev, flashsz, sectorsz) < 0)
-		return -1;
-
-	if (qspi_test_erase(dev, flashsz, sectorsz) < 0)
-		return -1;
-
-	return 0;
-}
-
-int main(int argc, char *argv[])
-{
-	return qspi_run_tests(qspi_flash_a, 16 * 1024 * 1024, 4 * 1024);
-	return qspi_test(qspi_flash_a);
-	int err, c;
-	storage_t dev = { 0 };
-	unsigned spi_no = 3;
 	meterfs_ctx_t *ctx;
+	storage_t dev = { 0 };
+	int err;
 
-	while ((c = getopt(argc, argv, "e:q")) != -1) {
-		switch (c) {
-			case 'e':
-				spi_no = strtoul(optarg, NULL, 0);
-				flashnor_eraseSector = flashnor_ecspiEraseSector;
-				flashnor_read = flashnor_ecspiRead;
-				flashnor_write = flashnor_ecspiWrite;
-				flashnor_init = flashnor_ecspiInit;
-				break;
-			case 'q':
-				return qspi_test(qspi_flash_a);
-				// spi_no = strtoul(optarg, NULL, 0);
-
-
-				// return EXIT_SUCCESS;
-				// flashnor_eraseSector = flashnor_qspiEraseSector;
-				// flashnor_read = flashnor_qspiRead;
-				// flashnor_write = flashnor_qspiWrite;
-				// flashnor_init = flashnor_qspiInit;
-				break;
-			default:
-				flashnor_test_help(argv[0]);
-				return EXIT_FAILURE;
-		}
-	}
-
-	err = flashnor_init(spi_no, &dev);
+	err = flashnor_ecspiInit(spi_no, &dev);
 	if (err < 0) {
 		printf("fail: failed to initialize device (err: %d)\n", err);
 		return EXIT_FAILURE;
 	}
+
+	flashnor_eraseSector = flashnor_ecspiEraseSector;
+	flashnor_read = flashnor_ecspiRead;
+	flashnor_write = flashnor_ecspiWrite;
 
 	ctx = dev.ctx;
 
@@ -552,4 +196,64 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 
 	return EXIT_SUCCESS;
+}
+
+unsigned dev;
+
+
+ssize_t qR(unsigned int addr, void *buff, size_t bufflen)
+{
+	return flashnor_qspiRead(dev, addr, buff, bufflen);
+}
+
+
+ssize_t qW(unsigned int addr, const void *buff, size_t bufflen)
+{
+	return flashnor_qspiWrite(dev, addr, buff, bufflen);
+}
+
+
+int qE(unsigned int addr)
+{
+	return flashnor_qspiEraseSector(dev, addr);
+}
+
+
+int run_qspi_test(unsigned dev_no)
+{
+	storage_t storage_dev = { 0 };
+	int err;
+
+	if ((err = _flashnor_qspiInit(dev, &storage_dev)) < 0) {
+		printf("fail: failed to initialize device (err: %d)\n", err);
+		return EXIT_FAILURE;
+	}
+
+	dev = dev_no;
+	flashnor_eraseSector = qE;
+	flashnor_read = qR;
+	flashnor_write = qW;
+
+	/* There's currently no way to extract those numbers from qspi. */
+	if (run_tests(16 * 1024 * 1024, 4 * 1024) < 0)
+		return EXIT_FAILURE;
+
+	return EXIT_SUCCESS;
+}
+
+int main(int argc, char *argv[])
+{
+	unsigned dev_no;
+
+	switch (getopt(argc, argv, "e:q:")) {
+		case 'e':
+			dev_no = strtoul(optarg, NULL, 0);
+			return run_ecspi_tests(dev_no);
+		case 'q':
+			dev_no = strtoul(optarg, NULL, 0);
+			return run_qspi_test(dev_no);
+		default:
+			flashnor_test_help(argv[0]);
+			return EXIT_FAILURE;
+	}
 }

--- a/storage/imx6ull-flashnor/flashnor-test.c
+++ b/storage/imx6ull-flashnor/flashnor-test.c
@@ -3,8 +3,8 @@
  *
  * i.MX 6ULL NOR flash driver test program
  *
- * Copyright 2021 Phoenix Systems
- * Author: Jakub Sarzynski
+ * Copyright 2021, 2023 Phoenix Systems
+ * Author: Jakub Sarzynski, Hubert Badocha
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -20,7 +20,14 @@
 
 #include "storage.h"
 #include "flashnor-ecspi.h"
+#include "flashnor-qspi.h"
+#include <qspi.h>
 
+
+static int (*flashnor_eraseSector)(unsigned int addr);
+static int (*flashnor_read)(unsigned int addr, void *buff, size_t bufflen);
+static int (*flashnor_write)(unsigned int addr, const void *buff, size_t bufflen);
+static int (*flashnor_init)(unsigned int ndev, storage_t *dev);
 
 static unsigned valcmp(uint8_t *buf, size_t len, uint8_t val)
 {
@@ -63,19 +70,19 @@ static int test_read_write(size_t flashsz, size_t sectorsz)
 	for (addr = 0; addr < flashsz; addr += sectorsz * 16) {
 		/* As meterfs is fixed right now in the driver implementation
 		   we have to erase sector before write, because of metadata written by meterfs */
-		if (flashnor_ecspiEraseSector(addr) < 0) {
+		if (flashnor_eraseSector(addr) < 0) {
 			printf("fail: erase sector at addr %u\n", addr);
 			res = -1;
 			break;
 		}
 
-		if (flashnor_ecspiWrite(addr, pattern, sectorsz) < 0) {
+		if (flashnor_write(addr, pattern, sectorsz) < 0) {
 			printf("fail: write sector at addr %u\n", addr);
 			res = -1;
 			break;
 		}
 
-		if (flashnor_ecspiRead(addr, buf, sectorsz) < 0) {
+		if (flashnor_read(addr, buf, sectorsz) < 0) {
 			printf("fail: read sector at addr %u\n", addr);
 			res = -1;
 			break;
@@ -117,13 +124,13 @@ static int test_erase(size_t flashsz, size_t sectorsz)
 
 	/* Clean sectors written by test_write_read */
 	for (addr = 0; addr < flashsz; addr += sectorsz * 16) {
-		if (flashnor_ecspiEraseSector(addr) < 0) {
+		if (flashnor_eraseSector(addr) < 0) {
 			printf("fail: erase sector at addr %u\n", addr);
 			res = -1;
 			break;
 		}
 
-		if (flashnor_ecspiRead(addr, buf, sectorsz) < 0) {
+		if (flashnor_read(addr, buf, sectorsz) < 0) {
 			printf("fail: erase sector read at addr %u\n", addr);
 			res = -1;
 			break;
@@ -149,7 +156,6 @@ static int test_erase(size_t flashsz, size_t sectorsz)
 
 static int run_tests(size_t flashsz, size_t sectorsz)
 {
-
 	if (test_read_write(flashsz, sectorsz) < 0)
 		return -1;
 
@@ -164,20 +170,369 @@ static void flashnor_test_help(const char *prog)
 	printf("Usage: %s [options]\n", prog);
 	printf("\t-e <n> | --ecspi <n>   - initialize ECSPI NOR flash device\n");
 	printf("\t\tn:      ECSPI instance number (by default ecspi no. 3 is used)\n");
+	printf("\t-q <n> | --qspi <n>   - initialize QSPI NOR flash device\n");
+	printf("\t\tn:      QSPI instance number (by default qspi no. 3 is used)\n");
+}
+
+#define READ_SIZE 32
+static int qspi_test(qspi_dev_t dev)
+{
+	_qspi_init(dev);
+	qspi_setTCSH(0);
+	qspi_setTCSS(0);
+
+	// Get device data.
+	{
+		lut_seq_t seq = { .instrs = {
+							  LUT_INSTR(lut_cmd, 0, 0x9f),
+							  LUT_INSTR(lut_read, 0, 3),
+							  0,
+						  } };
+		qspi_setLutSeq(&seq, 0);
+		char data[3];
+		memset(data, 0xFF, 3);
+
+		_qspi_read(dev, 0, 0, data, 3);
+		printf("VENDOR\n");
+		for (int i = 0; i < 3; i++) {
+			printf("%#x ", data[i]);
+		}
+		printf("\n");
+	}
+	printf("\n-------------------\n\n");
+
+	// Enter 4 I/O Mode.
+	{
+		lut_seq_t seq = { .instrs = {
+							  LUT_INSTR(lut_cmd, 0, 0x35),
+							  0,
+						  } };
+		qspi_setLutSeq(&seq, 1);
+
+		_qspi_read(dev, 1, 0, NULL, 0);
+		printf("ENTERED 4 I/O\n");
+	}
+	printf("\n-------------------\n\n");
+
+	// Write enable.
+	{
+		lut_seq_t seq = { .instrs = {
+							  LUT_INSTR(lut_cmd, 2, 0x06),  // Write enable
+							  0,
+						  } };
+		qspi_setLutSeq(&seq, 9);
+
+		_qspi_read(dev, 9, 0, NULL, 0);
+		printf("ENABLED WRITE\n");
+	}
+	printf("\n-------------------\n\n");
+	// ERASE
+	{
+		lut_seq_t seq = { .instrs = {
+							  LUT_INSTR(lut_cmd, 2, 0x21),
+							  LUT_INSTR(lut_addr, 2, 32),
+							  0,
+						  } };
+		qspi_setLutSeq(&seq, 4);
+
+		_qspi_read(dev, 4, 0, NULL, 0);
+		printf("ERASED DATA\n");
+	}
+	printf("\n-------------------\n\n");
+	{
+		lut_seq_t seq = { .instrs = {
+							  LUT_INSTR(lut_cmd, 2, 0x05),
+							  LUT_INSTR(lut_read, 2, 1),
+							  0,
+						  } };
+		qspi_setLutSeq(&seq, 10);
+		unsigned char status = 1;
+		while (status & 1) {
+			_qspi_read(dev, 10, 0, &status, 1);
+			printf("Status register: %#x\n", status);
+		}
+	}
+	printf("\n-------------------\n\n");
+	// WRITE ENABLE
+	{
+		_qspi_read(dev, 9, 0, NULL, 0);
+		printf("ENABLED WRITE\n");
+	}
+	printf("\n-------------------\n\n");
+
+	// WRITE
+	{
+		lut_seq_t seq = { .instrs = {
+							  LUT_INSTR(lut_cmd, 2, 0x34),
+							  LUT_INSTR(lut_addr, 2, 32),
+							  LUT_INSTR(lut_write, 2, 0),
+							  0,
+						  } };
+		qspi_setLutSeq(&seq, 2);
+		char data[READ_SIZE / 2];
+		memset(data, 0x06, READ_SIZE / 2);
+
+		_qspi_write(dev, 2, 0, data, READ_SIZE / 2);
+		printf("WRITTEN DATA\n");
+	}
+	printf("\n-------------------\n\n");
+
+	// Check status register
+	{
+		unsigned char status = 1;
+		while (status & 1) {
+			_qspi_read(dev, 10, 0, &status, 1);
+			printf("Status register: %#x\n", status);
+		}
+	}
+	printf("\n-------------------\n\n");
+	// WRITE ENABLE
+	{
+		_qspi_read(dev, 9, 0, NULL, 0);
+		printf("ENABLED WRITE\n");
+	}
+	printf("\n-------------------\n\n");
+	{
+		char data[READ_SIZE / 2];
+		memset(data, 0x09, READ_SIZE / 2);
+
+		_qspi_write(dev, 2, 0 + READ_SIZE / 2, data, READ_SIZE / 2);
+		printf("WRITTEN DATA\n");
+	}
+	printf("\n-------------------\n\n");
+	// Check status register
+	{
+		unsigned char status = 1;
+		while (status & 1) {
+			_qspi_read(dev, 10, 0, &status, 1);
+			printf("Status register: %#x\n", status);
+		}
+	}
+	printf("\n-------------------\n\n");
+
+	// READ
+	{
+		lut_seq_t seq = { .instrs = {
+							  LUT_INSTR(lut_cmd, 2, 0xEC),
+							  LUT_INSTR(lut_addr, 2, 32),
+							  LUT_INSTR(lut_dummy, 2, 10),
+							  LUT_INSTR(lut_read, 2, 0),
+							  0,
+						  } };
+		qspi_setLutSeq(&seq, 3);
+		char data[READ_SIZE];
+		memset(data, 0xFF, READ_SIZE);
+
+		_qspi_read(dev, 3, 0, data, READ_SIZE);
+		printf("READ\n");
+		for (int i = 0; i < READ_SIZE; i++) {
+			printf("%#x ", data[i]);
+		}
+		printf("\n");
+	}
+	// Write enable.
+	{
+		_qspi_read(dev, 9, 0, NULL, 0);
+		printf("ENABLED WRITE\n");
+	}
+	printf("\n-------------------\n\n");
+	// ERASE
+	{
+		lut_seq_t seq = { .instrs = {
+							  LUT_INSTR(lut_cmd, 2, 0x21),
+							  LUT_INSTR(lut_addr, 2, 32),
+							  0,
+						  } };
+		qspi_setLutSeq(&seq, 4);
+
+		_qspi_read(dev, 4, 0, NULL, 0);
+		printf("ERASED DATA\n");
+	}
+	printf("\n-------------------\n\n");
+
+	// Check status register
+	{
+		unsigned char status = 1;
+		while (status & 1) {
+			_qspi_read(dev, 10, 0, &status, 1);
+			printf("Status register: %#x\n", status);
+		}
+	}
+	printf("\n-------------------\n\n");
+
+	// READ AGAIN
+	{
+		char data[READ_SIZE];
+		memset(data, 0xFF, READ_SIZE);
+
+		_qspi_read(dev, 3, 0, data, READ_SIZE);
+		printf("READ\n");
+		for (int i = 0; i < READ_SIZE; i++) {
+			printf("%#x ", data[i]);
+		}
+		printf("\n");
+	}
+	printf("\n-------------------\n\n");
+
+	return 0;
+}
+
+static int qspi_test_read_write(qspi_dev_t dev, size_t flashsz, size_t sectorsz)
+{
+	int res = 0;
+	unsigned errors = 0, addr;
+	uint8_t *pattern, *buf;
+
+	printf("%s: ", __func__);
+
+	pattern = malloc(sectorsz);
+	if (pattern == NULL) {
+		printf("fail: malloc\n");
+		return -1;
+	}
+
+	buf = malloc(sectorsz);
+	if (buf == NULL) {
+		printf("fail: malloc\n");
+		free(pattern);
+		return -1;
+	}
+
+	memset(pattern, 0x55, sectorsz);
+
+	/* Test only every sixteenth block */
+	for (addr = 0; addr < flashsz; addr += sectorsz * 16) {
+		/* As meterfs is fixed right now in the driver implementation
+		   we have to erase sector before write, because of metadata written by meterfs */
+		if (flashnor_qspiEraseSector(dev, addr) < 0) {
+			printf("fail: erase sector at addr %u\n", addr);
+			res = -1;
+			break;
+		}
+
+		if (flashnor_qspiWrite(dev, addr, pattern, sectorsz) < 0) {
+			printf("fail: write sector at addr %u\n", addr);
+			res = -1;
+			break;
+		}
+
+		if (flashnor_qspiRead(dev, addr, buf, sectorsz) < 0) {
+			printf("fail: read sector at addr %u\n", addr);
+			res = -1;
+			break;
+		}
+
+		errors += valcmp(buf, sectorsz, pattern[0]);
+	}
+
+	if (res == 0) {
+		if (errors) {
+			printf("fail: read %u errors\n", errors);
+			res = -1;
+		}
+		else {
+			printf("ok\n");
+		}
+	}
+
+	free(pattern);
+	free(buf);
+
+	return res;
 }
 
 
+static int qspi_test_erase(qspi_dev_t dev, size_t flashsz, size_t sectorsz)
+{
+	int res = 0;
+	unsigned errors = 0, addr;
+	uint8_t *buf;
+
+	printf("%s: ", __func__);
+
+	buf = malloc(sectorsz);
+	if (buf == NULL) {
+		printf("fail: malloc\n");
+		return -1;
+	}
+
+	/* Clean sectors written by test_write_read */
+	for (addr = 0; addr < flashsz; addr += sectorsz * 16) {
+		if (flashnor_qspiEraseSector(dev, addr) < 0) {
+			printf("fail: erase sector at addr %u\n", addr);
+			res = -1;
+			break;
+		}
+
+		if (flashnor_qspiRead(dev, addr, buf, sectorsz) < 0) {
+			printf("fail: erase sector read at addr %u\n", addr);
+			res = -1;
+			break;
+		}
+
+		errors += valcmp(buf, sectorsz, 0xff);
+	}
+
+	if (res == 0) {
+		if (errors) {
+			printf("fail: read %u errors\n", errors);
+			res = -1;
+		}
+		else {
+			printf("ok\n");
+		}
+	}
+
+	free(buf);
+	return res;
+}
+
+
+static int qspi_run_tests(qspi_dev_t dev, size_t flashsz, size_t sectorsz)
+{
+	storage_t storage_dev = { 0 };
+	int err;
+	if ((err = _flashnor_qspiInit(dev, &storage_dev)) < 0) {
+		return err;
+	}
+
+	if (qspi_test_read_write(dev, flashsz, sectorsz) < 0)
+		return -1;
+
+	if (qspi_test_erase(dev, flashsz, sectorsz) < 0)
+		return -1;
+
+	return 0;
+}
+
 int main(int argc, char *argv[])
 {
+	return qspi_run_tests(qspi_flash_a, 256 * 1024 * 1024, 4 * 1024);
+	return qspi_test(qspi_flash_a);
 	int err, c;
 	storage_t dev = { 0 };
-	unsigned ecspi_no = 3;
+	unsigned spi_no = 3;
 	meterfs_ctx_t *ctx;
 
-	while ((c = getopt(argc, argv, "e:")) != -1) {
+	while ((c = getopt(argc, argv, "e:q")) != -1) {
 		switch (c) {
 			case 'e':
-				ecspi_no = strtoul(optarg, NULL, 0);
+				spi_no = strtoul(optarg, NULL, 0);
+				flashnor_eraseSector = flashnor_ecspiEraseSector;
+				flashnor_read = flashnor_ecspiRead;
+				flashnor_write = flashnor_ecspiWrite;
+				flashnor_init = flashnor_ecspiInit;
+				break;
+			case 'q':
+				return qspi_test(qspi_flash_a);
+				// spi_no = strtoul(optarg, NULL, 0);
+
+
+				// return EXIT_SUCCESS;
+				// flashnor_eraseSector = flashnor_qspiEraseSector;
+				// flashnor_read = flashnor_qspiRead;
+				// flashnor_write = flashnor_qspiWrite;
+				// flashnor_init = flashnor_qspiInit;
 				break;
 			default:
 				flashnor_test_help(argv[0]);
@@ -185,7 +540,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	err = flashnor_ecspiInit(ecspi_no, &dev);
+	err = flashnor_init(spi_no, &dev);
 	if (err < 0) {
 		printf("fail: failed to initialize device (err: %d)\n", err);
 		return EXIT_FAILURE;

--- a/storage/imx6ull-flashnor/flashnor-test.c
+++ b/storage/imx6ull-flashnor/flashnor-test.c
@@ -507,7 +507,7 @@ static int qspi_run_tests(qspi_dev_t dev, size_t flashsz, size_t sectorsz)
 
 int main(int argc, char *argv[])
 {
-	return qspi_run_tests(qspi_flash_a, 256 * 1024 * 1024, 4 * 1024);
+	return qspi_run_tests(qspi_flash_a, 16 * 1024 * 1024, 4 * 1024);
 	return qspi_test(qspi_flash_a);
 	int err, c;
 	storage_t dev = { 0 };


### PR DESCRIPTION
Add NOR flash driver over QSPI on imx6ull.

## Description
Creates qspi lib.
Creates flashnor over qspi driver.
Adjusts flashnor tests to support using qspi.

## Motivation and Context
On imx6ull there was no support for QSPI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull-evk.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
