### PR TITLE
sensorhub: change default priorities of threads

### DIFF
--- a/sensors/baro/lps25xx.c
+++ b/sensors/baro/lps25xx.c
@@ -178,7 +178,7 @@ static int lps25xx_start(sensor_info_t *info)
 	int err;
 	lps25xx_ctx_t *ctx = (lps25xx_ctx_t *)info->ctx;
 
-	err = beginthread(lps25xx_publishthr, 4, ctx->stack, sizeof(ctx->stack), info);
+	err = beginthread(lps25xx_publishthr, THREAD_PRIORITY_SENSOR, ctx->stack, sizeof(ctx->stack), info);
 	if (err >= 0) {
 		printf("lps25xx: launched sensor\n");
 	}

--- a/sensors/baro/ms5611.c
+++ b/sensors/baro/ms5611.c
@@ -233,7 +233,7 @@ static int ms5611_start(sensor_info_t *info)
 	int err;
 	ms5611_ctx_t *ctx = (ms5611_ctx_t *)info->ctx;
 
-	err = beginthread(ms5611_publishthr, 4, ctx->stack, sizeof(ctx->stack), info);
+	err = beginthread(ms5611_publishthr, THREAD_PRIORITY_SENSOR, ctx->stack, sizeof(ctx->stack), info);
 	if (err >= 0) {
 		printf("ms5611: launched sensor\n");
 	}

--- a/sensors/gps/pa6h.c
+++ b/sensors/gps/pa6h.c
@@ -128,7 +128,7 @@ static int pa6h_start(sensor_info_t *info)
 	ctx->evtGps.type = SENSOR_TYPE_GPS;
 	ctx->evtGps.gps.devId = info->id;
 
-	err = beginthread(pa6h_threadPublish, 4, ctx->stack, sizeof(ctx->stack), info);
+	err = beginthread(pa6h_threadPublish, THREAD_PRIORITY_SENSOR, ctx->stack, sizeof(ctx->stack), info);
 	if (err < 0) {
 		free(ctx);
 	}

--- a/sensors/imu/lsm9dsxx.c
+++ b/sensors/imu/lsm9dsxx.c
@@ -247,7 +247,7 @@ static int lsm9dsxx_start(sensor_info_t *info)
 	int err;
 	lsm9dsxx_ctx_t *ctx = (lsm9dsxx_ctx_t *)info->ctx;
 
-	err = beginthread(lsm9dsxx_threadPublish, 4, ctx->stack, sizeof(ctx->stack), info);
+	err = beginthread(lsm9dsxx_threadPublish, THREAD_PRIORITY_SENSOR, ctx->stack, sizeof(ctx->stack), info);
 	if (err >= 0) {
 		printf("lsm9dsxx: launched sensor\n");
 	}

--- a/sensors/mag/lsm9dsxx.c
+++ b/sensors/mag/lsm9dsxx.c
@@ -180,7 +180,7 @@ static int lsm9dsxx_start(sensor_info_t *info)
 	int err;
 	lsm9dsxx_ctx_t *ctx = (lsm9dsxx_ctx_t *)info->ctx;
 
-	err = beginthread(lsm9dsxx_threadPublish, 4, ctx->stack, sizeof(ctx->stack), info);
+	err = beginthread(lsm9dsxx_threadPublish, THREAD_PRIORITY_SENSOR, ctx->stack, sizeof(ctx->stack), info);
 	if (err >= 0) {
 		printf("lsm9dsxx_mag: launched sensor\n");
 	}

--- a/sensors/sensors.c
+++ b/sensors/sensors.c
@@ -20,6 +20,7 @@
 #include <sys/list.h>
 #include <sys/threads.h>
 #include <posix/utils.h>
+#include <sys/threads.h>
 
 #include <sensors-spi.h>
 
@@ -624,6 +625,8 @@ int main(int argc, char **argv)
 		sensors_cleanup(devsz);
 		return EXIT_FAILURE;
 	}
+
+	priority(THREAD_PRIORITY_MSGSRV);
 
 	sensors_run();
 	sensors_msgThread();

--- a/sensors/sensors.h
+++ b/sensors/sensors.h
@@ -20,6 +20,10 @@
 #include <posix/idtree.h>
 
 
+#define THREAD_PRIORITY_MSGSRV 3 /* priority of messaging server of sensorhub */
+#define THREAD_PRIORITY_SENSOR 3 /* priority of sensor driver threads */
+
+
 /* Info structure is filled by a sensor driver */
 typedef struct {
 	unsigned int id;     /* device identifier */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Introduced and used defines for priorities of messaging thread and sensor threads.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sensorhub works between the low-level bus drivers (e.g spi) which are typically on priority 2 and higher level user applications which are typically on priorty 4. Thus it is sensible to run it on priority level 3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
