### PR TITLE
sensorhub: add delta angle to gyroscope API

### DIFF
--- a/sensors/include/libsensors.h
+++ b/sensors/include/libsensors.h
@@ -70,12 +70,23 @@ typedef struct {
 } gps_data_t;
 
 
-/* Gyroscope data */
+/*
+* Gyroscope data
+*
+* Delta angles are time integrated and are meant to over/underflow uint32_t.
+* Calculation of delta angle between `old` and `new` measurements:
+* 1) calculate d1 = (uint32_t)(new - old)
+* 2) calculate d2 = (uint32_t)(old - new)
+* 3) if (d1 <= d2) then (delta_angle = d1) else (delta_angle = -d2)
+*/
 typedef struct {
 	uint32_t devId;
-	int32_t gyroX; /* angular velocity value in [mrad/s] */
-	int32_t gyroY; /* angular velocity value in [mrad/s] */
-	int32_t gyroZ; /* angular velocity value in [mrad/s] */
+	int32_t gyroX;    /* latest angular velocity value in [mrad/s] */
+	int32_t gyroY;    /* latest angular velocity value in [mrad/s] */
+	int32_t gyroZ;    /* latest angular velocity value in [mrad/s] */
+	uint32_t dAngleX; /* delta angle in [urad] since driver start */
+	uint32_t dAngleY; /* delta angle in [urad] since driver start */
+	uint32_t dAngleZ; /* delta angle in [urad] since driver start */
 } gyro_data_t;
 
 


### PR DESCRIPTION
JIRA: PP-119

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Adding delta angle integral values for gyroscope API. That way less data is lost for higher level application if it is performing time integration of gyroscope data.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Gyroscope values are often used for attitude estimation rather that sole angular speed measuring. This includes time integration of gyroscope data to acquire changes in angles. Currently higher level application that wants to fully utilize sensorhub gyroscope data needs to match its polling speed with sensor output data rate. Although this change doesn`t improve performance of angular speed reading it helps for mentioned AHRS algorithms.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (zynq7000) zturn board based drone

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
