### PR TITLE
zynq7000-pwm: add message based api 

### DIFF
--- a/_targets/Makefile.armv7a9-zynq7000
+++ b/_targets/Makefile.armv7a9-zynq7000
@@ -7,6 +7,6 @@
 #
 
 DEFAULT_COMPONENTS := zynq7000-uart uart16550 zynq7000-pwm zynq7000-xgpio zynq7000-spi zynq7000-xspi zynq7000-gpio
-DEFAULT_COMPONENTS += libflashdrv-zynq zynq7000-flash test_flashdrv libspi-msg libzynq7000-gpio-msg
+DEFAULT_COMPONENTS += libflashdrv-zynq zynq7000-flash test_flashdrv libspi-msg libzynq7000-gpio-msg libpwmmsg
 DEFAULT_COMPONENTS += libsensors sensors
 DEFAULT_COMPONENTS += zynq7000-i2c

--- a/gpio/zynq7000-pwm/Makefile
+++ b/gpio/zynq7000-pwm/Makefile
@@ -8,3 +8,10 @@ NAME := zynq7000-pwm
 LOCAL_SRCS := pwm.c
 
 include $(binary.mk)
+
+
+# PWM message API
+NAME := libpwmmsg
+LOCAL_SRCS := pwm-msg.c
+LOCAL_HEADERS := pwm-msg.h
+include $(static-lib.mk)

--- a/gpio/zynq7000-pwm/pwm-msg.c
+++ b/gpio/zynq7000-pwm/pwm-msg.c
@@ -1,0 +1,135 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Xilinx Zynq 7000 PWM driver message API
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <sys/msg.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "pwm-msg.h"
+
+
+int pwmmsg_batchWrite(const pwm_ctx_t *ctx, pwm_data_t *vals, int n)
+{
+	int err;
+	msg_t msg;
+
+	if (ctx == NULL || vals == NULL || n == 0) {
+		return -EINVAL;
+	}
+
+	msg.type = mtDevCtl;
+	msg.i.data = (void *)vals;
+	msg.i.size = sizeof(pwm_data_t) * n;
+	msg.o.data = NULL;
+	msg.o.size = 0;
+
+	msg.i.io.oid = ctx->oid;
+
+	err = msgSend(ctx->oid.port, &msg);
+	if (err < 0) {
+		return err;
+	}
+
+	return EOK;
+}
+
+
+int pwmmsg_read(const pwm_ctx_t *ctx, uint32_t *val)
+{
+	int err;
+	msg_t msg;
+
+	if (ctx == NULL || val == NULL) {
+		return -EINVAL;
+	}
+
+	msg.type = mtDevCtl;
+	msg.i.data = NULL;
+	msg.i.size = 0;
+	msg.o.data = (void *)val;
+	msg.o.size = sizeof(uint32_t);
+
+	msg.i.io.oid = ctx->oid;
+
+	err = msgSend(ctx->oid.port, &msg);
+	if (err < 0) {
+		return err;
+	}
+
+	return EOK;
+}
+
+
+int pwmmsg_write(const pwm_ctx_t *ctx, const uint32_t val)
+{
+	int err;
+	msg_t msg;
+	pwm_data_t data;
+
+	if (ctx == NULL) {
+		return -EINVAL;
+	}
+
+	data.id = ctx->oid.id;
+	data.val = val;
+
+	msg.type = mtDevCtl;
+	msg.i.data = (void *)&data;
+	msg.i.size = sizeof(pwm_data_t);
+	msg.o.data = NULL;
+	msg.o.size = 0;
+
+	msg.i.io.oid = ctx->oid;
+
+	err = msgSend(ctx->oid.port, &msg);
+	if (err < 0) {
+		return err;
+	}
+
+	return EOK;
+}
+
+
+int pwmmsg_close(pwm_ctx_t *ctx)
+{
+	if (ctx == NULL) {
+		return -EINVAL;
+	}
+
+	return EOK;
+}
+
+
+int pwmmsg_open(pwm_ctx_t *ctx, const char *path)
+{
+	unsigned int ntries = 10;
+	oid_t oid;
+
+	if (ctx == NULL || path == NULL) {
+		return -EINVAL;
+	}
+
+	while (lookup(path, NULL, &oid) < 0) {
+		ntries--;
+		if (ntries == 0) {
+			return -ETIMEDOUT;
+		}
+		usleep(10 * 1000);
+	}
+
+	ctx->oid = oid;
+
+	return EOK;
+}

--- a/gpio/zynq7000-pwm/pwm-msg.h
+++ b/gpio/zynq7000-pwm/pwm-msg.h
@@ -1,0 +1,50 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Xilinx Zynq 7000 PWM driver message API
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifndef LIBPWMMSG_H
+#define LIBPWMMSG_H
+
+
+/* pwmmsg API context. Stores communication information between client and pwm driver */
+typedef struct {
+	oid_t oid;
+} pwm_ctx_t;
+
+typedef struct {
+	uint32_t id;
+	uint32_t val;
+} pwm_data_t;
+
+
+extern int pwmmsg_batchWrite(const pwm_ctx_t *ctx, pwm_data_t *vals, int n);
+
+/* Reads value from pwm channel associated with opened `ctx` into `val` */
+extern int pwmmsg_read(const pwm_ctx_t *ctx, uint32_t *val);
+
+
+/* Writes `val` to pwm channel associated with opened `ctx` */
+extern int pwmmsg_write(const pwm_ctx_t *ctx, const uint32_t val);
+
+
+/* Closes pwmmsg API context specified by `ctx` */
+extern int pwmmsg_close(pwm_ctx_t *ctx);
+
+
+/* Opens pwmmsg API communication context. Returns 0 on success */
+extern int pwmmsg_open(pwm_ctx_t *ctx, const char *path);
+
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
A `pwm-msg` api for pwm control is introduced. API uses `mtDevCtl` message type. API supports single channel read and write operation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is motivated by Phoenix-Pilot project. In this case writes to four PWM channels are made using current API. Expected frequency of writes is about 400Hz. Currently writing to four channels takes approximately 2ms. Using this API it is far below 1ms (`gettime()` resolution is 1ms, unable to give better estimate).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
