### PR TITLE
zynq7000pwm: channels number define in api

### DIFF
--- a/gpio/zynq7000-pwm/zynq7000-pwm-msg.c
+++ b/gpio/zynq7000-pwm/zynq7000-pwm-msg.c
@@ -17,7 +17,7 @@
 #include "zynq7000-pwm-msg.h"
 
 
-int zynq7000pwm_set(oid_t *oid, uint32_t compval[8], uint8_t mask)
+int zynq7000pwm_set(oid_t *oid, uint32_t compval[ZYNQ7000_PWM_CHANNELS], uint8_t mask)
 {
 	int ret;
 	msg_t msg;
@@ -43,7 +43,7 @@ int zynq7000pwm_set(oid_t *oid, uint32_t compval[8], uint8_t mask)
 }
 
 
-int zynq7000pwm_get(oid_t *oid, uint32_t compval[8])
+int zynq7000pwm_get(oid_t *oid, uint32_t compval[ZYNQ7000_PWM_CHANNELS])
 {
 	int ret;
 	msg_t msg;

--- a/gpio/zynq7000-pwm/zynq7000-pwm-msg.h
+++ b/gpio/zynq7000-pwm/zynq7000-pwm-msg.h
@@ -18,10 +18,13 @@
 #include <sys/msg.h>
 
 
-int zynq7000pwm_set(oid_t *oid, uint32_t compval[8], uint8_t mask);
+#define ZYNQ7000_PWM_CHANNELS 8
 
 
-int zynq7000pwm_get(oid_t *oid, uint32_t compval[8]);
+int zynq7000pwm_set(oid_t *oid, uint32_t compval[ZYNQ7000_PWM_CHANNELS], uint8_t mask);
+
+
+int zynq7000pwm_get(oid_t *oid, uint32_t compval[ZYNQ7000_PWM_CHANNELS]);
 
 
 #endif


### PR DESCRIPTION
JIRA: PP-119

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Adding define in `zynq7000-pwm-msg.h` that specifies the number of channels available in pwm driver.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Although it is redundant to `PWM_NCHAN` in `pwm.c` there is currently no better place to define it so that it is accessible on user level. Without this define the size of 8 channels must be magically defined in user application and thus the driver related values are hardcoded in user application, which is structurally not very nice. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
