### PR TITLE
pa6h: fix off-by-one during nul-terminating messages

### DIFF
--- a/sensors/gps/pa6h.c
+++ b/sensors/gps/pa6h.c
@@ -155,7 +155,7 @@ static int pa6h_receiver(int fd, pa6h_msg_t *inbox, size_t inboxSz)
 			}
 
 			/* Ensure space for checksum and nul character not interfering with next message. Lack '/r/n' at the end is discarded */
-			len = ((nextStartToken == NULL) ? &buf[pos] : nextStartToken) - tokenEnd;
+			len = ((nextStartToken == NULL) ? &buf[pos] : nextStartToken - 1) - tokenEnd;
 			if (len < 3) {
 				break;
 			}
@@ -188,7 +188,7 @@ static int pa6h_receiver(int fd, pa6h_msg_t *inbox, size_t inboxSz)
 	}
 
 	for (i = 0; i < inboxFill; i++) {
-		inbox[i].msg[inbox[i].sz] = 0;
+		inbox[i].msg[inbox[i].sz - 1] = 0;
 	}
 
 	return inboxFill;


### PR DESCRIPTION
JIRA: PP-90

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Removing two possible bugs:
 1) nul terminating message at the end of `pa6h_receiver` has a bug that nul terminates it one character to far. This can cause the off-by-one error and writing outside of the buffer if message is unfortunately alligned at the end of the buffer.
 2) in an unfortunate event of message clipping a situation can occur where nul-terminating previous message causes `$` of the next message to be overwritten with `\0`.

Fixes issue:
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/612

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn deone.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
