### PR TITLE
sensors/gps: increase accuracy of lat/lon with `double`/`int64_t` type

### DIFF
--- a/sensors/gps/nmea.h
+++ b/sensors/gps/nmea.h
@@ -61,8 +61,8 @@ enum nmea_fields_vtg { field_vtg_track = 1, field_vtg_tracktype = 2, field_vtg_s
 
 /* GPGGA nmea type definitions: Global Positioning System Fix Data  */
 typedef struct {
-	float lat;
-	float lon;
+	double lat;
+	double lon;
 	unsigned int fix;
 	unsigned int sats;
 	float hdop;

--- a/sensors/gps/pa6h.c
+++ b/sensors/gps/pa6h.c
@@ -313,8 +313,8 @@ int pa6h_update(nmea_t *message, sensor_event_t *evtGps)
 	/* timestamp update happens only on GPGGA message as it contains position */
 	switch (message->type) {
 		case nmea_gga:
-			evtGps->gps.lat = message->msg.gga.lat * 1e7;
-			evtGps->gps.lon = message->msg.gga.lon * 1e7;
+			evtGps->gps.lat = message->msg.gga.lat * 1e9;
+			evtGps->gps.lon = message->msg.gga.lon * 1e9;
 			evtGps->gps.hdop = (unsigned int)(message->msg.gga.hdop * 1e2);
 			evtGps->gps.fix = message->msg.gga.fix;
 			evtGps->gps.alt = message->msg.gga.h_asl * 1e3;

--- a/sensors/include/libsensors.h
+++ b/sensors/include/libsensors.h
@@ -50,11 +50,11 @@ typedef struct {
 /* GPS position in WGS84 coordinates */
 typedef struct {
 	uint32_t devId;
-	int32_t lat;           /* latitude in 1E-7 degrees */
-	int32_t lon;           /* longitude in 1E-7 degrees */
+	int32_t alt;           /* altitude in 1E-3 [m] (millimetres) above MSL */
+	int64_t lat;           /* latitude in 1E-9 [deg] (nanodegrees) */
+	int64_t lon;           /* longitude in 1E-9 [deg] (nanodegrees) */
 	uint16_t hdop;         /* horizontal dilution of precision */
 	uint16_t vdop;         /* vertical dilution of precision */
-	int32_t alt;           /* altitude in 1E-3 [m] (millimetres) above MSL */
 	int32_t altEllipsoid;  /* altitude in 1E-3 [m] (millimetres) above Ellipsoid */
 	uint32_t groundSpeed;  /* GPS ground speed, [mm/s] */
 	int32_t velNorth;      /* GPS North velocity, [mm/s] */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - Using `double` variable type for calculations on latitude and longitude to not loose accuracy.
 - Using `int64_t` as transfer data type for longitude and latitude to not loose accuracy
 - Transferring latitude and longitude in nanodegrees (10^9 * [deg]). This gives worst case scenario (on equator) accuracy of 100µm/LSB which is far more that necessary. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
