### PR TITLE
pc-tty: CSI extensions and fixes for `busybox/vi`, `psh/edit`

### DIFF
--- a/tty/pc-tty/ttypc_kbd.c
+++ b/tty/pc-tty/ttypc_kbd.c
@@ -517,7 +517,11 @@ static int ttypc_kbd_waitstatus(ttypc_t *ttypc, unsigned char bit, unsigned char
 
 
 /* Reads a byte from keyboard controller output buffer */
-static int ttypc_kbd_read(ttypc_t *ttypc)
+/*
+ * FIXME: (unused) Function not to be removed, needs to be preserved
+ * for future implementation of ps2-aux (mouse device) support.
+ */
+__attribute__((unused)) static int ttypc_kbd_read(ttypc_t *ttypc)
 {
 	int err;
 

--- a/tty/pc-tty/ttypc_vga.h
+++ b/tty/pc-tty/ttypc_vga.h
@@ -105,7 +105,8 @@ enum {
 	FG_LIGHTMAGENTA = 0x0d,
 	FG_YELLOW       = 0x0e,
 	FG_WHITE        = 0x0f,
-	FG_BLINK        = 0x80
+	FG_BLINK        = 0x80,
+	FG_BRIGHT       = 0x800
 };
 
 
@@ -118,7 +119,8 @@ enum {
 	BG_RED          = 0x40,
 	BG_MAGENTA      = 0x50,
 	BG_BROWN        = 0x60,
-	BG_LIGHTGREY    = 0x70
+	BG_LIGHTGREY    = 0x70,
+	BG_BRIGHT       = 0x8000
 };
 
 

--- a/tty/pc-tty/ttypc_vga.h
+++ b/tty/pc-tty/ttypc_vga.h
@@ -20,6 +20,9 @@
 #include "ttypc_vt.h"
 
 
+/* clang-format off */
+
+
 /* VGA screen memory address */
 enum {
 	VGA_GRAPHICS   = 0xa0000, /* Graphics mode */
@@ -149,6 +152,9 @@ enum {
 	CUR_DEF         = CUR_UNDERLINE
 };
 
+
+
+/* clang-format off */
 
 /* Copies VGA screen buffer to buff */
 extern ssize_t _ttypc_vga_read(volatile uint16_t *vga, uint16_t *buff, size_t n);

--- a/tty/pc-tty/ttypc_vt.c
+++ b/tty/pc-tty/ttypc_vt.c
@@ -4,8 +4,8 @@
  * Virtual Terminal (based on FreeBSD 4.4 pcvt)
  *
  * Copyright 2007-2008 Pawel Pisarczyk
- * Copyright 2012, 2018, 2019, 2020 Phoenix Systems
- * Author: Pawel Pisarczyk, Lukasz Kosinski
+ * Copyright 2012, 2018, 2019, 2020, 2023 Phoenix Systems
+ * Author: Pawel Pisarczyk, Lukasz Kosinski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -524,7 +524,7 @@ static void _ttypc_vt_sput(ttypc_vt_t *vt, char c)
 			case '8':
 			case '9':   /* Parameters */
 				vt->parms[vt->parmi] *= 10;
-				vt->parms[vt->parmi] += (c -'0');
+				vt->parms[vt->parmi] += (c - '0');
 				break;
 
 			case ';':   /* Next parameter */
@@ -620,6 +620,16 @@ ssize_t ttypc_vt_read(ttypc_vt_t *vt, int mode, char *buff, size_t len)
 ssize_t ttypc_vt_write(ttypc_vt_t *vt, int mode, const char *buff, size_t len)
 {
 	return libtty_write(&vt->tty, buff, len, mode);
+}
+
+
+int ttypc_vt_respond(ttypc_vt_t *vt, const char *buff)
+{
+	int err = 0;
+	while ((*buff != '\0') && (err == 0)) {
+		err = libtty_putchar(&vt->tty, *(buff++), NULL);
+	}
+	return err;
 }
 
 

--- a/tty/pc-tty/ttypc_vt.h
+++ b/tty/pc-tty/ttypc_vt.h
@@ -125,7 +125,7 @@ typedef struct {
 	uint8_t dcsst;           /* Device Control String state machine */
 	uint8_t escst;           /* Escape sequence state machine */
 	uint8_t parmi;           /* Escape sequence parameter index */
-	uint8_t parms[MAXPARMS]; /* Escape sequence parameter array */
+	uint16_t parms[MAXPARMS]; /* Escape sequence parameter array */
 	char tabs[MAXTABS];      /* Table of active tab stops */
 	libtty_common_t tty;     /* Terminal character processing (using libtty) */
 

--- a/tty/pc-tty/ttypc_vt.h
+++ b/tty/pc-tty/ttypc_vt.h
@@ -4,8 +4,8 @@
  * Virtual Terminal (based on FreeBSD 4.4 pcvt)
  *
  * Copyright 2006-2008 Pawel Pisarczyk
- * Copyright 2019, 2020 Phoenix Systems
- * Author: Pawel Pisarczyk, Lukasz Kosinski
+ * Copyright 2019, 2020, 2023 Phoenix Systems
+ * Author: Pawel Pisarczyk, Lukasz Kosinski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -144,6 +144,10 @@ extern ssize_t ttypc_vt_read(ttypc_vt_t *vt, int mode, char *buff, size_t len);
 
 /* Write characters to virtual terminal */
 extern ssize_t ttypc_vt_write(ttypc_vt_t *vt, int mode, const char *buff, size_t len);
+
+
+/* Respond to requests for a terminal reports */
+extern int ttypc_vt_respond(ttypc_vt_t *vt, const char *buff);
 
 
 /* Polls virtual terminal status */

--- a/tty/pc-tty/ttypc_vtf.c
+++ b/tty/pc-tty/ttypc_vtf.c
@@ -671,6 +671,36 @@ void _ttypc_vtf_sgr(ttypc_vt_t *vt)
 				attr = (bgansitopc[(vt->parms[i - 1] - 40) & 7] << 8) | (attr & 0x0f00);
 			}
 			break;
+
+		case 90: /* Bright Foreground colors */
+		case 91:
+		case 92:
+		case 93:
+		case 94:
+		case 95:
+		case 96:
+		case 97:
+			if (ttypc->color) {
+				cc = 1;
+				attr = (attr & 0xf000) | (fgansitopc[(vt->parms[i - 1] - 90) & 7] << 8);
+				attr |= 0x0800;
+			}
+			break;
+
+		case 100: /* Bright Background colors */
+		case 101:
+		case 102:
+		case 103:
+		case 104:
+		case 105:
+		case 106:
+		case 107:
+			if (ttypc->color) {
+				cc = 1;
+				attr = (bgansitopc[(vt->parms[i - 1] - 100) & 7] << 8) | (attr & 0x0f00);
+				attr |= 0x8000;
+			}
+			break;
 		}
 	} while (i <= vt->parmi);
 

--- a/tty/pc-tty/ttypc_vtf.c
+++ b/tty/pc-tty/ttypc_vtf.c
@@ -4,8 +4,8 @@
  * Virtual Terminal Functions
  *
  * Copyright 2008 Pawel Pisarczyk
- * Copyright 2012, 2019, 2020 Phoenix Systems
- * Author: Pawel Pisarczyk, Lukasz Kosinski
+ * Copyright 2012, 2019, 2020, 2023 Phoenix Systems
+ * Author: Pawel Pisarczyk, Lukasz Kosinski, Gerard Swiderski
  *
  * %LICENSE%
  */
@@ -284,8 +284,8 @@ void _ttypc_vtf_rc(ttypc_vt_t *vt)
 void _ttypc_vtf_da(ttypc_vt_t *vt)
 {
 	/* 62 - class 2 terminal, c - end of attributes list */
-	static char da[] = "\033[62;c";
-	write(0, da, sizeof(da));
+	static const char da[] = "\033[62;c";
+	ttypc_vt_respond(vt, da);
 }
 
 
@@ -680,17 +680,17 @@ void _ttypc_vtf_sgr(ttypc_vt_t *vt)
 /* Device status reports */
 void _ttypc_vtf_dsr(ttypc_vt_t *vt)
 {
-	static char stat[]  = "\033[0n";     /* Status */
-	static char print[] = "\033[?13n";   /* Printer Unattached */
-	static char udk[]   = "\033[?21n";   /* UDK Locked */
-	static char lang[]  = "\033[?27;1n"; /* North American */
+	static const char stat[] = "\033[0n";     /* Status */
+	static const char print[] = "\033[?13n";  /* Printer Unattached */
+	static const char udk[] = "\033[?21n";    /* UDK Locked */
+	static const char lang[] = "\033[?27;1n"; /* North American */
 	char buff[16];
 	int i = 0;
 
 	switch (vt->parms[0]) {
 	/* Status */
 	case 5:
-		write(0, stat, sizeof(stat));
+		ttypc_vt_respond(vt, stat);
 		break;
 
 	/* Cursor position */
@@ -709,22 +709,22 @@ void _ttypc_vtf_dsr(ttypc_vt_t *vt)
 		buff[i++] = 'R';
 		buff[i++] = '\0';
 
-		write(0, buff, i);
+		ttypc_vt_respond(vt, buff);
 		break;
 
 	/* Printer status */
 	case 15:
-		write(0, print, sizeof(print));
+		ttypc_vt_respond(vt, print);
 		break;
 
 	/* User Defined Keys status */
 	case 25:
-		write(0, udk, sizeof(udk));
+		ttypc_vt_respond(vt, udk);
 		break;
 
 	/* Language status */
 	case 26:
-		write(0, lang, sizeof(lang));
+		ttypc_vt_respond(vt, lang);
 		break;
 
 	default:
@@ -981,8 +981,8 @@ void _ttypc_vtf_resetansi(ttypc_vt_t *vt)
 
 void _ttypc_vtf_reqtparm(ttypc_vt_t *vt)
 {
-	static char tparm[] = "\033[3;1;1;120;120;1;0x";
-	write(0, tparm, sizeof(tparm));
+	static const char tparm[] = "\033[3;1;1;120;120;1;0x";
+	ttypc_vt_respond(vt, tparm);
 }
 
 

--- a/tty/pc-tty/ttypc_vtf.c
+++ b/tty/pc-tty/ttypc_vtf.c
@@ -658,6 +658,13 @@ void _ttypc_vtf_sgr(ttypc_vt_t *vt)
 			}
 			break;
 
+		case 39: /* Reset foreground color to default */
+			if (ttypc->color) {
+				cc = 1;
+				attr = (attr & 0xf000) | (fgansitopc[FG_LIGHTGREY] << 8);
+			}
+			break;
+
 		case 40: /* Background colors */
 		case 41:
 		case 42:
@@ -669,6 +676,13 @@ void _ttypc_vtf_sgr(ttypc_vt_t *vt)
 			if (ttypc->color) {
 				cc = 1;
 				attr = (bgansitopc[(vt->parms[i - 1] - 40) & 7] << 8) | (attr & 0x0f00);
+			}
+			break;
+
+		case 49: /* Reset background color to default */
+			if (ttypc->color) {
+				cc = 1;
+				attr = (bgansitopc[BG_BLACK] << 8) | (attr & 0x0f00);
 			}
 			break;
 

--- a/tty/pc-tty/ttypc_vtf.c
+++ b/tty/pc-tty/ttypc_vtf.c
@@ -674,7 +674,27 @@ void _ttypc_vtf_sgr(ttypc_vt_t *vt)
 		}
 	} while (i <= vt->parmi);
 
-	vt->attr = (ttypc->color) ? ((cc) ? attr : csgr[vt->sgr] << 8) : msgr[vt->sgr] << 8;
+	if (ttypc->color != 0) {
+		if (cc == 0) {
+			attr = csgr[vt->sgr] << 8;
+		}
+
+		if ((vt->sgr & VT_BOLD) != 0) {
+			if ((vt->sgr & VT_INVERSED) != 0) {
+				attr &= ~FG_BRIGHT;
+				attr |= BG_BRIGHT;
+			}
+			else {
+				attr |= FG_BRIGHT;
+				attr &= ~BG_BRIGHT;
+			}
+		}
+
+		vt->attr = attr;
+	}
+	else {
+		vt->attr = msgr[vt->sgr] << 8;
+	}
 }
 
 

--- a/tty/pc-tty/ttypc_vtf.c
+++ b/tty/pc-tty/ttypc_vtf.c
@@ -424,7 +424,7 @@ void _ttypc_vtf_curadr(ttypc_vt_t *vt)
 
 	if (vt->parms[0] < 1)
 		vt->parms[0] = 1;
-	else if (vt->parms[0] > (vt->om) ? vt->bottom - vt->top + 1 : vt->rows)
+	else if (vt->parms[0] > ((vt->om) ? vt->bottom - vt->top + 1 : vt->rows))
 		vt->parms[0] = (vt->om) ? vt->bottom - vt->top + 1 : vt->rows;
 
 	if (vt->parms[1] < 1)
@@ -432,7 +432,7 @@ void _ttypc_vtf_curadr(ttypc_vt_t *vt)
 	else if (vt->parms[1] > vt->cols)
 		vt->parms[1] = vt->cols;
 
-	vt->cpos = (vt->parms[0] - 1) * vt->cols + vt->parms[1] - 1 + (vt->om) ? vt->top * vt->cols : 0;
+	vt->cpos = (vt->parms[0] - 1) * vt->cols + vt->parms[1] - 1 + ((vt->om) ? vt->top * vt->cols : 0);
 	vt->ccol = vt->parms[1] - 1;
 }
 

--- a/tty/pc-tty/ttypc_vtf.c
+++ b/tty/pc-tty/ttypc_vtf.c
@@ -608,7 +608,8 @@ void _ttypc_vtf_sgr(ttypc_vt_t *vt)
 	do {
 		switch (vt->parms[i++]) {
 		case 0: /* Reset to normal attributes */
-			vt->sgr &= VT_INVERSED;
+			vt->sgr = VT_NORMAL;
+			cc = 0;
 			break;
 
 		case 1: /* Bold */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

This change is addressed to fix issues with `busybox/vi` and `psh/edit`:
* Fixes https://github.com/phoenix-rtos/phoenix-rtos-devices/issues/102
* Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/487 (requires additional tiny change in `psh/edit` --  https://github.com/phoenix-rtos/phoenix-rtos-utils/pull/173)

This change introduces:
* compatibility with terminals that support bright colors (VGA), for foreground`ESC [ 90 m` `ESC [ 97 m`, and background `ESC [ 100 m` - `ESC [ 107m`.
* compatibility with terminals that support independent reset of only colors using: `ESC [ 39 m`  (reset foreground color), `ESC [ 49 m` (reset background color), to reset all attributes and colors using: `ESC [ 0 m`
* adds emulation of `bold` attribute by using brighter color (when used with `inverse` attribute bright color is applied to background, normally for foreground color).
* fix for cursor positioning with `ESC [ ypos ; xpos H` and its variants
* fix for reading back terminal reports like: DA, terminal status, current cursor position (required for vi and edit), other reports supported by pcvt


## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


### `busybox/vi` (with this pull-request):
![2023-03-20-195455_1460x846_scrot](https://user-images.githubusercontent.com/141153/226440512-70ead915-d678-4d9f-9528-878f3a80b5e5.png)

### `psh/edit` (with this pull-request):
![2023-03-20-195929_1447x864_scrot](https://user-images.githubusercontent.com/141153/226440573-e73f048d-4461-4cce-b1c0-6f5a8b052a71.png)

### `pc-tty` (Normal & bright colors support and fixed cursor positioning - this pull-request)
![2023-03-20-215658_1449x820_scrot](https://user-images.githubusercontent.com/141153/226464492-953aec2f-43fb-4f83-97a9-0719921efdf2.png)

### `xterm` for comparison (Linux Console color set):
![2023-03-20-215830_1280x645_scrot](https://user-images.githubusercontent.com/141153/226464530-cc3531db-5c2b-4ab6-8bca-71b5c40d04cc.png)

## Test file drawing the above frame and color attributes [colortest.txt](https://github.com/phoenix-rtos/phoenix-rtos-devices/files/11027121/colortest.txt), -- assumed 80x25 min. terminal size.
Put this file in `_projects/ia32-generic-qemu/rootfs-overlay`,
than run phoenix-rtos (ia32-generic) and type `cat colortest.txt`.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: **ia32-generic**.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-utils/pull/173
- [ ] I will merge this PR by myself when appropriate.
