### PR TITLE
storage: fix storage size checks

### DIFF
--- a/storage/imx6ull-flash/flashsrv.c
+++ b/storage/imx6ull-flash/flashsrv.c
@@ -248,7 +248,7 @@ static int flashsrv_devErase(const flash_i_devctl_t *idevctl)
 
 	if (strg == NULL || strg->dev == NULL || strg->dev->ctx == NULL || strg->dev->mtd == NULL || strg->dev->mtd->ops == NULL ||
 			strg->dev->mtd->ops->block_markBad == NULL || strg->dev->mtd->ops->block_isBad == NULL || strg->dev->mtd->ops->erase == NULL ||
-			(offs + size) >= strg->size) {
+			(offs + size) > strg->size) {
 		return -EINVAL;
 	}
 
@@ -271,7 +271,7 @@ static int flashsrv_devReadMeta(flash_i_devctl_t *idevctl, void *data)
 	TRACE("META read off: %lld, size: %d, ptr: %p", offs, size, data);
 
 	if (strg == NULL || strg->dev == NULL || strg->dev->ctx == NULL || strg->dev->mtd == NULL || strg->dev->mtd->ops == NULL ||
-			strg->dev->mtd->ops->meta_read == NULL || (offs + size) >= strg->size || data == NULL) {
+			strg->dev->mtd->ops->meta_read == NULL || (offs + size) > strg->size || data == NULL) {
 		return -EINVAL;
 	}
 
@@ -295,7 +295,7 @@ static int flashsrv_devWriteMeta(flash_i_devctl_t *idevctl, void *data)
 	TRACE("META write off: %lld, size: %d, ptr: %p", offs, size, data);
 
 	if (strg == NULL || strg->dev == NULL || strg->dev->ctx == NULL || strg->dev->mtd == NULL || strg->dev->mtd->ops == NULL ||
-			strg->dev->mtd->ops->meta_write == NULL || (offs + size) >= strg->size || data == NULL) {
+			strg->dev->mtd->ops->meta_write == NULL || (offs + size) > strg->size || data == NULL) {
 		return -EINVAL;
 	}
 

--- a/storage/zynq7000-flash/zynq7000-flash.c
+++ b/storage/zynq7000-flash/zynq7000-flash.c
@@ -44,7 +44,7 @@ static ssize_t flash_read(oid_t *oid, offs_t offs, void *buff, size_t len)
 	ssize_t res = -ENOSYS;
 	storage_t *strg = storage_get(GET_STORAGE_ID(oid->id));
 
-	if (strg == NULL || strg->dev == NULL || (offs + len) >= strg->size || buff == NULL) {
+	if (strg == NULL || strg->dev == NULL || (offs + len) > strg->size || buff == NULL) {
 		res = -EINVAL;
 	}
 	else if (len == 0) {
@@ -74,7 +74,7 @@ static ssize_t flash_write(oid_t *oid, offs_t offs, const void *buff, size_t len
 	ssize_t res = -ENOSYS;
 	storage_t *strg = storage_get(GET_STORAGE_ID(oid->id));
 
-	if (strg == NULL || strg->dev == NULL || (offs + len) >= strg->size) {
+	if (strg == NULL || strg->dev == NULL || (offs + len) > strg->size) {
 		res = -EINVAL;
 	}
 	else if (len == 0) {


### PR DESCRIPTION
JIRA: DTR-389

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix storage size checks

## Motivation and Context
Errorneus checks made it impossible to erase last sector or write to last byte.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
