### PR TITLE
qspi.c: fix incorrect condition on return error by mmap()

### DIFF
--- a/spi/imx6ull-qspi/qspi.c
+++ b/spi/imx6ull-qspi/qspi.c
@@ -281,14 +281,14 @@ int qspi_init(qspi_t *qspi)
 	size_t ahbSize;
 
 	qspi->base = mmap(NULL, _PAGE_SIZE, PROT_WRITE | PROT_READ, MAP_DEVICE, OID_PHYSMEM, QSPI_BASE);
-	if (qspi->base == NULL) {
+	if (qspi->base == MAP_FAILED) {
 		return -ENOMEM;
 	}
 
 	qspi->ahbAddr = QSPI_MMAP_BASE;
 	ahbSize = qspi->base[QSPI_SFB2AD] - qspi->ahbAddr;
 	qspi->ahbBase = mmap(NULL, ahbSize, PROT_READ, MAP_DEVICE, OID_PHYSMEM, qspi->ahbAddr);
-	if (qspi->ahbBase == NULL) {
+	if (qspi->ahbBase == MAP_FAILED) {
 		(void)munmap(qspi->base, _PAGE_SIZE);
 		return -ENOMEM;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
On error `mmap()` returns `MAP_FAILED` not `NULL`


## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
