### PR TITLE
simsensor reader: fix type of sensor types

### DIFF
--- a/sensors/simsensor_common/simsensor_reader.c
+++ b/sensors/simsensor_common/simsensor_reader.c
@@ -302,7 +302,8 @@ int reader_read(simsens_reader_t *rd, event_queue_t *queue)
 {
 	const char *actField;
 	long long tmp;
-	int sensorID, err = 0, emptyIter = 100;
+	int err = 0, emptyIter = 100;
+	sensor_type_t sensorID;
 	ssize_t lineLen;
 	time_t timestamp, timeStart = READER_TIMESTAMP_NOT_SET;
 	sensor_event_t parsed;
@@ -433,7 +434,7 @@ void reader_close(simsens_reader_t *reader)
 }
 
 
-int reader_open(simsens_reader_t *rd, const char *path, int sensorTypes, time_t timeHorizon)
+int reader_open(simsens_reader_t *rd, const char *path, sensor_type_t sensorTypes, time_t timeHorizon)
 {
 	ssize_t lineLen;
 	time_t act_time;

--- a/sensors/simsensor_common/simsensor_reader.h
+++ b/sensors/simsensor_common/simsensor_reader.h
@@ -25,7 +25,7 @@
 typedef struct {
 	FILE *scenarioFile;
 	ssize_t headerLen;
-	int sensorTypes;
+	sensor_type_t sensorTypes;
 
 	time_t timeHorizon;
 
@@ -45,7 +45,7 @@ typedef struct {
  *
  * Successful open initialises timeline of sensor reader
  */
-extern int reader_open(simsens_reader_t *rd, const char *path, int sensorTypes, time_t timeHorizon);
+extern int reader_open(simsens_reader_t *rd, const char *path, sensor_type_t sensorTypes, time_t timeHorizon);
 
 
 /* Frees elements form `reader`  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Now reader doesn't use `int` for sensor type, but secial `sensor_type_t`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More elegant code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `armv7a9-zynq7000-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
