### PR TITLE
sensors: use `rcv->bufSz` in gps common

### DIFF
--- a/sensors/gps/common.c
+++ b/sensors/gps/common.c
@@ -84,7 +84,7 @@ int gps_recv(int fd, gps_receiver_t *rcv)
 	rcv->pos = 0;
 
 	/* NMEA/PMTK messages are no longer than 128 bytes. Discard partials longer than sizeof(buf)/2 */
-	if (rcv->remLen < (sizeof(rcv->buf) / 2)) {
+	if (rcv->remLen < (rcv->bufSz / 2)) {
 		/* move partial at the end to the beginning of buffer */
 		if (rcv->remStart != rcv->buf) {
 			memmove(rcv->buf, rcv->remStart, rcv->remLen);
@@ -92,7 +92,7 @@ int gps_recv(int fd, gps_receiver_t *rcv)
 		rcv->pos = rcv->remLen;
 	}
 
-	ret = read(fd, &rcv->buf[rcv->pos], sizeof(rcv->buf) - 1 - rcv->pos);
+	ret = read(fd, &rcv->buf[rcv->pos], rcv->bufSz - 1 - rcv->pos);
 	rcv->remStart = rcv->buf;
 	nextStartToken = NULL;
 
@@ -123,6 +123,7 @@ int gps_recv(int fd, gps_receiver_t *rcv)
 			}
 
 			/* Read and validate checksum. Save message to inbox if there is space there */
+			errno = EOK;
 			val = strtol(tokenEnd + 1, (char **)NULL, 16);
 			if (!(val == 0 && errno == EINVAL) && val <= 0xff && inboxFill < rcv->inboxLen) {
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixing error where sizeof of char pointer was used instead of the variable that holds the buffer size.

This error is legacy error, previousely this buffer was static and sizeof usage was correct.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/370#issuecomment-1551874641

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
