### PR TITLE
sensors: `utc` field and `read()`-sleeping in gps

### DIFF
--- a/sensors/gps/common.c
+++ b/sensors/gps/common.c
@@ -172,8 +172,9 @@ int gps_updateEvt(nmea_t *message, sensor_event_t *evtGps, float posStdev, float
 			evtGps->gps.altEllipsoid = message->msg.gga.h_wgs * 1e3;
 			evtGps->gps.satsNb = message->msg.gga.sats;
 			evtGps->gps.eph = evtGps->gps.hdop * posStdev;
+			evtGps->gps.utc = message->msg.gga.utc * 1000000;
 
-			gettime(&(evtGps->timestamp), NULL);
+			gettime(&evtGps->timestamp, NULL);
 			break;
 
 		case nmea_gsa:

--- a/sensors/gps/nmea.c
+++ b/sensors/gps/nmea.c
@@ -117,8 +117,15 @@ static void nmea_parsegga(char *str, nmea_t *out)
 
 	out->type = nmea_broken;
 
+	/* utc fix time */
+	p = nmea_nField(p, field_gga_utc);
+	if (p == NULL) {
+		return;
+	}
+	in.utc = strtod(p + 1, NULL);
+
 	/* latitude read */
-	p = nmea_nField(p, field_gga_lat);
+	p = nmea_nField(p, field_gga_lat - field_gga_utc);
 	if (p == NULL) {
 		return;
 	}

--- a/sensors/gps/nmea.h
+++ b/sensors/gps/nmea.h
@@ -14,9 +14,10 @@
 #ifndef _NMEA_H_
 #define _NMEA_H_
 
-
+/* clang-format off */
 /* types of messages interpreted, together with unknown, and broken message */
 enum nmea_type { nmea_gga, nmea_gsa, nmea_rmc, nmea_vtg, nmea_unknown, nmea_broken };
+/* clang-format on */
 
 /* GPGSA nmea type definitions: GPS DOP and active satellites */
 typedef struct {
@@ -26,11 +27,12 @@ typedef struct {
 	float vdop;
 } nmea_gsa_t;
 
-
+/* clang-format off */
 enum nmea_gsa_fix { gsa_fix_notavailable = 1, gsa_fix_2d, gsa_fix_3d };
 
 
 enum nmea_fields_gsa { field_gsa_fix = 2, field_gsa_pdop = 15, field_gsa_hdop = 16, field_gsa_vdop = 17 };
+/* clang-format on */
 
 
 /* GPRMC nmea type definitions: Recommended minimum specific GPS/Transit data */
@@ -42,9 +44,10 @@ typedef struct {
 	float magvar;
 } nmea_rmc_t;
 
-
+/* clang-format off */
 enum nmea_fields_rmc { field_rmc_lat = 3, field_rmc_lon = 5, field_rmc_speedknots = 7, field_rmc_course = 8,
 	field_rmc_magvar = 10 };
+/* clang-format on */
 
 
 /* GPVTG nmea type definitions: Track Made Good and Ground Speed. */
@@ -56,13 +59,16 @@ typedef struct {
 } nmea_vtg_t;
 
 
+/* clang-format off */
 enum nmea_fields_vtg { field_vtg_track = 1, field_vtg_tracktype = 2, field_vtg_speedknots = 5, field_vtg_speedkmh = 7 };
+/* clang-format on */
 
 
 /* GPGGA nmea type definitions: Global Positioning System Fix Data  */
 typedef struct {
 	double lat;
 	double lon;
+	float utc;
 	unsigned int fix;
 	unsigned int sats;
 	float hdop;
@@ -70,13 +76,14 @@ typedef struct {
 	float h_wgs;
 } nmea_gga_t;
 
-
+/* clang-format off */
 enum nmea_gga_fix { gga_fix_invalid, gga_fix_gnss, gga_fix_dpgs, gga_fix_pps, gga_fix_rtkinematic,
 	gga_fix_estimated = 6,gga_fix_maninput, gga_fix_simulation };
 
 
-enum nmea_fields_gga { field_gga_lat = 2, field_gga_lon = 4, field_gga_fix = 6, field_gga_sats = 7,
+enum nmea_fields_gga { field_gga_utc = 1, field_gga_lat = 2, field_gga_lon = 4, field_gga_fix = 6, field_gga_sats = 7,
 	field_gga_hdop = 8, field_gga_h_asl = 9, field_gga_h_wgs = 11 };
+/* clang-format on */
 
 
 /* incoming message storage */

--- a/sensors/gps/ubx.c
+++ b/sensors/gps/ubx.c
@@ -71,8 +71,6 @@ static void ubx_threadPublish(void *data)
 		if (update != 0) {
 			sensors_publish(info->id, &ctx->evtGps);
 		}
-
-		usleep(UPDATE_RATE_MS * 1000);
 	}
 }
 
@@ -146,7 +144,7 @@ static int ubx_alloc(sensor_info_t *info, const char *args)
 
 	/* Opening serial device */
 	do {
-		ctx->filedes = open(path, O_RDWR | O_NOCTTY | O_NONBLOCK);
+		ctx->filedes = open(path, O_RDWR | O_NOCTTY);
 
 		if (ctx->filedes < 0) {
 			usleep(10 * 1000);

--- a/sensors/include/libsensors.h
+++ b/sensors/include/libsensors.h
@@ -55,6 +55,7 @@ typedef struct {
 	int32_t alt;           /* altitude in 1E-3 [m] (millimetres) above MSL */
 	int64_t lat;           /* latitude in 1E-9 [deg] (nanodegrees) */
 	int64_t lon;           /* longitude in 1E-9 [deg] (nanodegrees) */
+	uint64_t utc;          /* gps utc time in us */
 	uint16_t hdop;         /* horizontal dilution of precision */
 	uint16_t vdop;         /* vertical dilution of precision */
 	int32_t altEllipsoid;  /* altitude in 1E-3 [m] (millimetres) above Ellipsoid */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - adding utc field to gps messages indicating real fix time of messages
 - read-sleeping in common gps code

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
