### PR TITLE
remove LIBS sets before calling static-lib.mk

### DIFF
--- a/storage/host-flash/Makefile
+++ b/storage/host-flash/Makefile
@@ -9,6 +9,5 @@
 NAME := host-flash
 LOCAL_SRCS := host-flash.c host-flashsrv.c
 LOCAL_HEADERS := host-flashsrv.h
-LIBS := libmeterfs
 
 include $(static-lib.mk)

--- a/storage/zynq7000-flash/Makefile
+++ b/storage/zynq7000-flash/Makefile
@@ -10,7 +10,6 @@
 NAME := libflashdrv-zynq
 LOCAL_SRCS := qspi.c flashcfg.c flashdrv.c
 LOCAL_HEADERS := flashdrv.h flashcfg.h
-LIBS := libstorage libcache
 
 include $(static-lib.mk)
 


### PR DESCRIPTION
LIBS is not used in static-lib and this value can corrupt next binary.mk

This needs to be merged before https://github.com/phoenix-rtos/phoenix-rtos-build/pull/144
