### PR TITLE
zynq7000-flash: timeouts rework

### DIFF
--- a/storage/zynq7000-flash/flashdrv.c
+++ b/storage/zynq7000-flash/flashdrv.c
@@ -166,6 +166,7 @@ static int _flashdrv_wipCheck(unsigned int id, time_t timeout)
 	int res;
 	unsigned int st;
 	time_t start = flashdrv_timeMsGet();
+	int lastTry = 0;
 
 	do {
 		res = _flashdrv_statusRegGet(id, &st);
@@ -174,7 +175,13 @@ static int _flashdrv_wipCheck(unsigned int id, time_t timeout)
 		}
 
 		if ((flashdrv_timeMsGet() - start) >= timeout) {
-			return -ETIME;
+			/* Check one last time to prevent the possibility of starvation. */
+			if (lastTry == 0) {
+				lastTry = 1;
+			}
+			else {
+				return -ETIME;
+			}
 		}
 	} while ((st >> 8) & 0x1);
 


### PR DESCRIPTION
JIRA: RTOS-481

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed timeouts to prevent timeouts on starvation.

## Motivation and Context
https://github.com/phoenix-rtos/phoenix-rtos-project/issues/725

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zynq-7000.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
