### PR TITLE
zynq7000-xspi: Generate irq on fifo empty, not each byte

### DIFF
--- a/spi/zynq7000-xspi/libzynq7000-xspi.c
+++ b/spi/zynq7000-xspi/libzynq7000-xspi.c
@@ -87,7 +87,7 @@ static int spi_isr(unsigned int n, void *arg)
 	spi_t *spi = arg;
 
 	/* TX FIFO empty */
-	if (*(spi->base + SPI_ISR) & (1 << 2)) {
+	if (*(spi->base + SPI_ISR) & (1 << 3)) {
 		return 1;
 	}
 
@@ -234,7 +234,7 @@ int spi_xfer(unsigned int dev, unsigned int ss, const void *out, size_t olen, vo
 
 		/* Wait until TX FIFO is empty */
 		/* spi->lock mutex is locked in spi_init() */
-		while (!(*(spi->base + SPI_ISR) & (1 << 2))) {
+		while (!(*(spi->base + SPI_ISR) & (1 << 3))) {
 			condWait(spi->cond, spi->lock, 0);
 		}
 
@@ -296,7 +296,7 @@ int spi_init(unsigned int dev)
 	spi_dmb();
 
 	/* Disable all interrupts and enable global interrupt gate */
-	*(spi->base + SPI_IER) = 1 << 2;
+	*(spi->base + SPI_IER) = 1 << 3;
 	*(spi->base + SPI_DGIER) = 1U << 31;
 	spi_dmb();
 


### PR DESCRIPTION
DONE: RTOS-472

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Should fix high cpu usage by this driver

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
