### PR TITLE
sensors: compile-time sensors selection

### DIFF
--- a/sensors/Makefile
+++ b/sensors/Makefile
@@ -17,13 +17,13 @@ DEPS := libzynq7000-gpio-msg libspi-msg
 include $(static-lib.mk)
 
 # Sensors Server
+SENSORS_ALL := imu/lsm9dsxx mag/lsm9dsxx baro/lps25xx baro/ms5611 gps/pa6h gps/ubx
+SENSORS_SIM := imu/imu_sim.c mag/mag_sim.c baro/baro_sim.c gps/gps_sim.c gps/gps_sim.c
+SENSORS_LOCAL := $(SENSORS_SIM) $(addsuffix .c, $(filter $(SENSORS_ALL), $(DEVICE_SENSORS)))
+
 NAME := sensors
 LOCAL_HEADERS_DIR := nothing
-LOCAL_SRCS := sensors.c
-LOCAL_SRCS += imu/lsm9dsxx.c imu/imu_sim.c
-LOCAL_SRCS += baro/lps25xx.c baro/ms5611.c baro/baro_sim.c
-LOCAL_SRCS += gps/pa6h.c gps/ubx.c gps/nmea.c gps/common.c gps/gps_sim.c
-LOCAL_SRCS += mag/lsm9dsxx.c mag/mag_sim.c
-LOCAL_SRCS += simsensor_common/event_queue.c simsensor_common/simsensor_reader.c simsensor_common/simsensor_generic.c
+LOCAL_SRCS += sensors.c $(SENSORS_LOCAL) $(SENSORS_SIM)
+LOCAL_SRCS += gps/nmea.c gps/common.c simsensor_common/event_queue.c simsensor_common/simsensor_reader.c simsensor_common/simsensor_generic.c
 DEP_LIBS := libsensors libsensors-spi libzynq7000-gpio-msg libspi-msg
 include $(binary.mk)


### PR DESCRIPTION
JIRA: PP-153

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Adding option to select what sensors are compiled via `DEVICE_SENSORS` environment variable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As mentioned in https://github.com/phoenix-rtos/phoenix-rtos-project/issues/744 sensors have no selection on what drivers are compiled (i.e. everything is compiled).

This somehow patches (not solves!) the issue of compiling zynq7000-dependent code on non-zynq7000 targets as lack of `DEVICE_SENSORS` in `_projects/<non-zynq-target>/build.project` won`t activate a compilation of such sensors. However this solution should be treated as complementary to future changes in devices/sensors that will add more generic api for those instances of sensors which use target-dependent code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zynq7000-based drone

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
