### PR TITLE
imxrt-multi: add optional libdummyfs support

### DIFF
--- a/multi/imxrt-multi/Makefile
+++ b/multi/imxrt-multi/Makefile
@@ -6,12 +6,16 @@
 
 NAME := imxrt-multi
 
-LOCAL_SRCS = imxrt-multi.c common.c uart.c gpio.c spi.c
+LOCAL_PATH := $(call my-dir)
+
+LOCAL_SRCS = imxrt-multi.c common.c uart.c gpio.c spi.c fs.c
 ifneq ($(TARGET_SUBFAMILY), imxrt117x)
   LOCAL_SRCS += i2c.c trng.c
 else
   LOCAL_SRCS += cm4.c
 endif
 DEP_LIBS := libtty libklog
+LIBS := libdummyfs libklog
 LOCAL_HEADERS := imxrt-multi.h
+
 include $(binary.mk)

--- a/multi/imxrt-multi/config.h
+++ b/multi/imxrt-multi/config.h
@@ -266,6 +266,11 @@
 #define TRNG 0
 #endif
 
+/* libdummyfs */
+#ifndef IMXRT_MULTI_DUMMYFS
+#define IMXRT_MULTI_DUMMYFS 0
+#endif
+
 /* Cortex M4 */
 
 #ifdef TARGET_IMXRT1170

--- a/multi/imxrt-multi/fs.c
+++ b/multi/imxrt-multi/fs.c
@@ -1,0 +1,170 @@
+/*
+ * Phoenix-RTOS
+ *
+ * STM32L4 Filesystem driver
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Maciej Purski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <board_config.h>
+#include "config.h"
+
+#if IMXRT_MULTI_DUMMYFS
+
+#include <errno.h>
+#include <sys/file.h>
+#include <sys/mman.h>
+#include <sys/msg.h>
+#include <sys/threads.h>
+#include <stdlib.h>
+
+#include <phoenix/sysinfo.h>
+
+#include <dummyfs.h>
+
+#define MSGTHR_STACKSZ 4096
+
+struct {
+	char stack[MSGTHR_STACKSZ] __attribute__((aligned(8)));
+	unsigned port;
+} fs_common;
+
+
+static int syspage_create(void *ctx, oid_t *root)
+{
+	oid_t sysoid = { 0 };
+	oid_t toid = { 0 };
+	syspageprog_t prog;
+	int i, progsz;
+
+	if ((progsz = syspageprog(NULL, -1)) < 0)
+		return -1;
+
+	if (dummyfs_create(ctx, root, "syspage", &sysoid, 0666, otDir, NULL) != 0)
+		return -ENOMEM;
+
+	for (i = 0; i < progsz; i++) {
+		if (syspageprog(&prog, i) != 0)
+			continue;
+
+		dummyfs_createMapped(ctx, &sysoid, prog.name, (void *)prog.addr, prog.size, &toid);
+	}
+
+	return EOK;
+}
+
+
+static void msgthr(void *ctx)
+{
+	msg_t msg;
+	unsigned long rid;
+
+	for (;;) {
+		if (msgRecv(fs_common.port, &msg, &rid) < 0)
+			continue;
+
+		switch (msg.type) {
+
+			case mtOpen:
+				msg.o.io.err = dummyfs_open(ctx, &msg.i.openclose.oid);
+				break;
+
+			case mtClose:
+				msg.o.io.err = dummyfs_close(ctx, &msg.i.openclose.oid);
+				break;
+
+			case mtRead:
+				msg.o.io.err = dummyfs_read(ctx, &msg.i.io.oid, msg.i.io.offs, msg.o.data, msg.o.size);
+				break;
+
+			case mtWrite:
+				msg.o.io.err = dummyfs_write(ctx, &msg.i.io.oid, msg.i.io.offs, msg.i.data, msg.i.size);
+				break;
+
+			case mtTruncate:
+				msg.o.io.err = dummyfs_truncate(ctx, &msg.i.io.oid, msg.i.io.len);
+				break;
+
+			case mtDevCtl:
+				msg.o.io.err = -EINVAL;
+				break;
+
+			case mtCreate:
+				msg.o.create.err = dummyfs_create(ctx, &msg.i.create.dir, msg.i.data, &msg.o.create.oid, msg.i.create.mode, msg.i.create.type, &msg.i.create.dev);
+				break;
+
+			case mtDestroy:
+				msg.o.io.err = dummyfs_destroy(ctx, &msg.i.destroy.oid);
+				break;
+
+			case mtSetAttr:
+				msg.o.attr.err = dummyfs_setattr(ctx, &msg.i.attr.oid, msg.i.attr.type, msg.i.attr.val, msg.i.data, msg.i.size);
+				break;
+
+			case mtGetAttr:
+				msg.o.attr.err = dummyfs_getattr(ctx, &msg.i.attr.oid, msg.i.attr.type, &msg.o.attr.val);
+				break;
+
+			case mtLookup:
+				msg.o.lookup.err = dummyfs_lookup(ctx, &msg.i.lookup.dir, msg.i.data, &msg.o.lookup.fil, &msg.o.lookup.dev);
+				break;
+
+			case mtLink:
+				msg.o.io.err = dummyfs_link(ctx, &msg.i.ln.dir, msg.i.data, &msg.i.ln.oid);
+				break;
+
+			case mtUnlink:
+				msg.o.io.err = dummyfs_unlink(ctx, &msg.i.ln.dir, msg.i.data);
+				break;
+
+			case mtReaddir:
+				msg.o.io.err = dummyfs_readdir(ctx, &msg.i.readdir.dir, msg.i.readdir.offs,
+					msg.o.data, msg.o.size);
+				break;
+		}
+		msgRespond(fs_common.port, &msg, rid);
+	}
+}
+
+
+int fs_init(void)
+{
+	void *ctx;
+	oid_t root = { 0 };
+
+	if (portCreate(&fs_common.port) != 0)
+		return -1;
+
+	if (portRegister(fs_common.port, "/", &root)) {
+		portDestroy(fs_common.port);
+		return -1;
+	}
+
+	root.port = fs_common.port;
+	if (dummyfs_mount(&ctx, NULL, 0, &root) != EOK) {
+		printf("dummyfs mount failed\n");
+		portDestroy(fs_common.port);
+		return -1;
+	}
+
+	if (syspage_create(ctx, &root) != EOK) {
+		dummyfs_unmount(ctx);
+		portDestroy(fs_common.port);
+		return -1;
+	}
+
+	if (beginthread(msgthr, 4, fs_common.stack, MSGTHR_STACKSZ, ctx) != EOK) {
+		dummyfs_unmount(ctx);
+		portDestroy(fs_common.port);
+		return -1;
+	}
+
+	return EOK;
+}
+
+#endif

--- a/multi/imxrt-multi/imxrt-multi.c
+++ b/multi/imxrt-multi/imxrt-multi.c
@@ -47,7 +47,6 @@
 #define IMXRT_MULTI_PRIO 2
 #endif
 
-
 #define STACKSZ 512
 
 
@@ -207,9 +206,11 @@ static int createDevFiles(void)
 	oid_t dir;
 	char name[8];
 
-	while (lookup("/", NULL, &dir) < 0) {
-		usleep(100000);
-	}
+#ifndef IMXRT_MULTI_DUMMYFS
+	/* Wait for the filesystem */
+	while (lookup("/", NULL, &dir) < 0)
+		usleep(10000);
+#endif
 
 	/* /dev */
 
@@ -488,6 +489,11 @@ static void uart_thread(void *arg)
 }
 
 
+#if IMXRT_MULTI_DUMMYFS
+int fs_init(void);
+#endif
+
+
 int main(void)
 {
 	int i;
@@ -496,6 +502,9 @@ int main(void)
 	portCreate(&common.uart_port);
 	portCreate(&multi_port);
 
+#if IMXRT_MULTI_DUMMYFS
+	fs_init();
+#endif
 
 	uart_init();
 	gpio_init();


### PR DESCRIPTION
Depending on board config imxrt-multi can be build with incorporated dummyfs support. Implementation is based on stm32l4-multi, but does not assume that libdummyfs is always compiled with imxrt-multi.

Implementer may choose if he/she want to use classic dummyfs server or imxrt-multi with dummyfs, depending on project demands and how memory is divided on the target, how booting is done: whether from xip or ram.

Requires:
https://github.com/phoenix-rtos/phoenix-rtos-filesystems/pull/97

JIRA: NIL-414

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: nil-imxrt1176.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-filesystems/pull/97
- [ ] I will merge this PR by myself when appropriate.
