### PR TITLE
ade7913: Change read of interrupt counter

### DIFF
--- a/adc/ade7913/ade7913-driver.c
+++ b/adc/ade7913/ade7913-driver.c
@@ -765,7 +765,7 @@ static int dev_read(void *data, size_t size)
 	mutexLock(common.edma_spi_rcv_lock);
 	res = condWait(common.edma_spi_rcv_cond, common.edma_spi_rcv_lock, 1000000);
 	if (res == 0) {
-		*(uint32_t **)data = (uint32_t *)&common.edma_transfers;
+		*(uint32_t *)data = common.edma_transfers;
 	}
 	mutexUnlock(common.edma_spi_rcv_lock);
 


### PR DESCRIPTION
Change the way the interrupt counter is read from the ADC driver. The counter value will now be copied (msgSend <-> msgResponse) instead of sharing a direct pointer to a memory location between processes. A change in the procedure of reading samples in the metering server is required: block on msgSend until the driver interrupt handler signals the condWait to the sample read process.

JIRA: NIL-433

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `nil-imxrt1176`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
