### PR TITLE
pc-tty: Disable libtty TAB expansion

### DIFF
--- a/tty/pc-tty/ttypc_vt.c
+++ b/tty/pc-tty/ttypc_vt.c
@@ -723,6 +723,9 @@ int ttypc_vt_init(ttypc_t *ttypc, unsigned int ttybuffsz, ttypc_vt_t *vt)
 		return err;
 	}
 
+	/* Disable default libtty tab expansion */
+	vt->tty.term.c_oflag &= ~(XTABS);
+
 	/* Init emulator */
 	vt->ttypc = ttypc;
 	vt->cols = 80;


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

By default `libtty` sets `TAB3` a.k.a. `XTABS` oflag so internally all `TAB` (\x09) characters are expanded to series of spaces (\x20). The `pc-tty` understands `\x09` character and `TABSTOP` setting, but `TAB expansion`, `enabled by default` in `libtty` distorts the way `pc-tty` displays `TABs`, resulting `in misaligned columns`. Disabling XTABS after `libtty_init()` solves the problem of `pc-tty` not displaying TABS correctly.


JIRA: RTOS-518

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before:
![2023-07-10-115943_813x897_scrot](https://github.com/phoenix-rtos/phoenix-rtos-devices/assets/141153/b24a8869-8d55-4d53-aea9-95005ce464be)

After (with this patch):
![2023-07-10-115850_712x846_scrot](https://github.com/phoenix-rtos/phoenix-rtos-devices/assets/141153/b303ed78-3d24-4a70-ad1a-faa5d4d6fecf)

Result of:
`printf("%ld\t%s\n", size, path);`



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
