### PR TITLE
stm32: add option to handle tty using DMA

### DIFF
--- a/multi/stm32l4-multi/config.h
+++ b/multi/stm32l4-multi/config.h
@@ -58,6 +58,86 @@
 
 /* UART_CONSOLE has to be specified in board_config.h */
 
+#ifndef TTY1_DMA
+#define TTY1_DMA 0
+#endif
+
+#ifndef TTY2_DMA
+#define TTY2_DMA 0
+#endif
+
+#ifndef TTY3_DMA
+#define TTY3_DMA 0
+#endif
+
+#ifndef TTY4_DMA
+#define TTY4_DMA 0
+#endif
+
+#ifndef TTY5_DMA
+#define TTY5_DMA 0
+#endif
+
+#ifndef TTY1_DMA_RXSZ
+#define TTY1_DMA_RXSZ 64
+#endif
+
+#ifndef TTY2_DMA_RXSZ
+#define TTY2_DMA_RXSZ 64
+#endif
+
+#ifndef TTY3_DMA_RXSZ
+#define TTY3_DMA_RXSZ 64
+#endif
+
+#ifndef TTY4_DMA_RXSZ
+#define TTY4_DMA_RXSZ 64
+#endif
+
+#ifndef TTY5_DMA_RXSZ
+#define TTY5_DMA_RXSZ 64
+#endif
+
+#ifndef TTY1_DMA_TXSZ
+#define TTY1_DMA_TXSZ 64
+#endif
+
+#ifndef TTY2_DMA_TXSZ
+#define TTY2_DMA_TXSZ 64
+#endif
+
+#ifndef TTY3_DMA_TXSZ
+#define TTY3_DMA_TXSZ 64
+#endif
+
+#ifndef TTY4_DMA_TXSZ
+#define TTY4_DMA_TXSZ 64
+#endif
+
+#ifndef TTY5_DMA_TXSZ
+#define TTY5_DMA_TXSZ 64
+#endif
+
+#ifndef TTY1_LIBTTY_BUFSZ
+#define TTY1_LIBTTY_BUFSZ 512
+#endif
+
+#ifndef TTY2_LIBTTY_BUFSZ
+#define TTY2_LIBTTY_BUFSZ 512
+#endif
+
+#ifndef TTY3_LIBTTY_BUFSZ
+#define TTY3_LIBTTY_BUFSZ 512
+#endif
+
+#ifndef TTY4_LIBTTY_BUFSZ
+#define TTY4_LIBTTY_BUFSZ 512
+#endif
+
+#ifndef TTY5_LIBTTY_BUFSZ
+#define TTY5_LIBTTY_BUFSZ 512
+#endif
+
 
 /* SPI */
 #ifndef SPI1

--- a/multi/stm32l4-multi/libmulti/include/libmulti/libdma.h
+++ b/multi/stm32l4-multi/libmulti/include/libmulti/libdma.h
@@ -13,15 +13,59 @@
 #define LIBDMA_H_
 
 #include <stddef.h>
+#include <stdint.h>
+#include <sys/threads.h>
 
 
+#define DMA_MAX_LEN ((1u << 16) - 1u)
+
+
+/* clang-format off */
 enum { dma_per2mem = 0, dma_mem2per };
 
 
-int libdma_configureSpi(int num, int dir, int priority, void *paddr, int msize, int psize, int minc, int pinc);
+enum { dma_spi = 0, dma_uart };
 
 
-int libdma_transferSpi(int num, void *rx_maddr, const void *tx_maddr, size_t len);
+enum { dma_ht = 0, dma_tc };
+/* clang-format on */
+
+
+struct libdma_per;
+
+
+/* If cond == NULL only sync function maybe used, otherwise only async functions. */
+int libdma_configurePeripheral(const struct libdma_per *per, int dir, int priority, void *paddr, int msize, int psize, int minc, int pinc, handle_t *cond);
+
+
+/* SYNC FUNCTIONS */
+
+
+int libdma_transfer(const struct libdma_per *per, void *rx_maddr, const void *tx_maddr, size_t len);
+
+
+/* ASYNC FUNCTIONS */
+
+
+/* Only one tx request per channel may be issued at a time. */
+int libdma_txAsync(const struct libdma_per *per, const void *tx_maddr, size_t len, volatile int *done_flag);
+
+
+/* Only one rx request per channel may be issued at a time. */
+int libdma_rxAsync(const struct libdma_per *per, void *rx_maddr, size_t len, volatile int *done_flag);
+
+
+/* Receive infinite rx into circular buffer. Fn is called at each Transfer Complete and Half Transfer interrupt. */
+int libdma_infiniteRxAsync(const struct libdma_per *per, void *rx_maddr, size_t len, void fn(void *arg, int type), void *arg);
+
+
+/* UTILITY FUNCTIONS */
+
+
+uint16_t libdma_leftToRx(const struct libdma_per *per);
+
+
+const struct libdma_per *libdma_getPeripheral(int per, unsigned int num);
 
 
 int libdma_init(void);

--- a/multi/stm32l4-multi/libmulti/include/libmulti/libspi.h
+++ b/multi/stm32l4-multi/libmulti/include/libmulti/libspi.h
@@ -18,6 +18,7 @@
 
 #include <stddef.h>
 #include <sys/threads.h>
+#include "libmulti/libdma.h"
 
 
 typedef struct {
@@ -27,21 +28,23 @@ typedef struct {
 	const unsigned char *obuff;
 	size_t cnt;
 
-	int usedma;
+	const struct libdma_per *per;
 } libspi_ctx_t;
 
 
-enum { spi1 = 0, spi2, spi3 };
-
-
 #define SPI_ADDRSHIFT 3
-#define SPI_ADDRMASK 0x3
+#define SPI_ADDRMASK  0x3
+
+
+/* clang-format off */
+enum { spi1 = 0, spi2, spi3 };
 
 
 enum { spi_cmd = 0x1, spi_dummy = 0x2, /* 3-bits for SPI_ADDR* ,*/ spi_addrlsb = 0x20 };
 
 
 enum { spi_dir_read = 0, spi_dir_write, spi_dir_readwrite };
+/* clang-format on */
 
 
 int libspi_transaction(libspi_ctx_t *ctx, int dir, unsigned char cmd, unsigned int addr, unsigned char flags,

--- a/multi/stm32l4-multi/libmulti/libdma.c
+++ b/multi/stm32l4-multi/libmulti/libdma.c
@@ -11,11 +11,16 @@
 
 
 #include <errno.h>
-#include <sys/threads.h>
 #include <sys/interrupt.h>
 
 #include "../common.h"
 #include "libmulti/libdma.h"
+
+
+#define DMA_TCIE_FLAG     (1 << 1)
+#define DMA_HTIE_FLAG     (1 << 2)
+#define DMA_CIRCULAR_FLAG (1 << 5)
+
 
 struct {
 	volatile unsigned int *base;
@@ -25,20 +30,40 @@ struct {
 } dma_common[2];
 
 
-enum { dma1 = 0, dma2 };
-
-
 static const int dma2pctl[] = { pctl_dma1, pctl_dma2 };
 
 
-static const struct dma_map {
+struct libdma_per {
 	char dma;
 	char channel[2];
 	char reqmap;
-} spiChanMap[3] = {
+};
+
+
+/* clang-format off */
+enum { dma1 = 0, dma2 };
+
+
+enum { isr = 0, ifcr, cselr = 42 };
+
+
+enum { ccr = 0, cndtr, cpar, cmar };
+/* clang-format on */
+
+
+static const struct libdma_per libdma_persSpi[] = {
 	{ dma1, { 1, 2 }, 0x1 },
 	{ dma1, { 3, 4 }, 0x1 },
 	{ dma2, { 0, 1 }, 0x3 },
+};
+
+
+static const struct libdma_per libdma_persUart[] = {
+	{ dma1, { 4, 3 }, 0x2 },  // or { dma2, { 6, 5 }, 0x2 }
+	{ dma1, { 5, 6 }, 0x2 },
+	{ dma1, { 2, 1 }, 0x2 },
+	{ dma2, { 4, 2 }, 0x2 },
+	{ dma2, { 1, 0 }, 0x2 },
 };
 
 
@@ -48,30 +73,87 @@ static const struct {
 } dmainfo[2] = { { 0x40020000, 11 }, { 0x40020400, 56 } };
 
 
-enum { isr = 0, ifcr, cselr = 42 };
+static struct {
+	enum {
+		dma_transferNull = 0,
+		dma_transferInf,
+		dma_transferOnce,
+	} type;
+	union {
+		struct {
+			void (*fn)(void *arg, int type);
+			void *arg;
+		} inf;
+		struct {
+			volatile int *done_flag;
+			volatile unsigned int *channel_base;
+		} once;
+	};
+} dma_transfers[2][8];
 
 
-enum { ccr = 0, cndtr, cpar, cmar };
+static void _prepare_transfer(volatile unsigned int *channel_base, void *maddr, size_t len, int flags)
+{
+	*(channel_base + cmar) = (unsigned int)maddr;
+	*(channel_base + cndtr) = len;
+	dataBarier();
+	*(channel_base + ccr) |= flags | 0x1;
+	dataBarier();
+}
+
+
+static void _unprepare_transfer(volatile unsigned int *channel_base)
+{
+	dataBarier();
+	/* Disable interrupts, disable channel */
+	*(channel_base + ccr) &= ~(DMA_TCIE_FLAG | DMA_HTIE_FLAG | 0x1);
+	dataBarier();
+}
 
 
 static int irqHandler(unsigned int n, void *arg)
 {
-	int channel = n - dma_common[(int)arg].irq_base - 16;
-	volatile unsigned int *base = dma_common[(int)arg].base;
+	int dma = (int)arg;
+	int channel = n - dma_common[dma].irq_base - 16;
+	volatile unsigned int *base = dma_common[dma].base;
+	unsigned int flags = (*(base + isr) & (0xF << (channel * 4))) >> (channel * 4);
 
-	if (*(base + isr) & (0xF << channel * 4)) {
-		*(base + ifcr) = (0xF << channel * 4);
-		return 1;
-	} else {
+	if (flags == 0) {
 		return -1;
 	}
+
+	*(base + ifcr) = (0xF << (channel * 4));
+
+	switch (dma_transfers[dma][channel].type) {
+		case dma_transferOnce:
+			_unprepare_transfer(dma_transfers[dma][channel].once.channel_base);
+
+			*dma_transfers[dma][channel].once.done_flag = 1;
+
+			dma_transfers[dma][channel].type = dma_transferNull;
+			break;
+		case dma_transferInf:
+			if ((flags & DMA_HTIE_FLAG) != 0) {
+				dma_transfers[dma][channel].inf.fn(dma_transfers[dma][channel].inf.arg, dma_ht);
+			}
+			if ((flags & DMA_TCIE_FLAG) != 0) {
+				dma_transfers[dma][channel].inf.fn(dma_transfers[dma][channel].inf.arg, dma_tc);
+			}
+			break;
+		case dma_transferNull:
+			/* Shouldn't happen */
+			break;
+	}
+
+	return 1;
 }
 
 
-static void _configureChannel(int dma, int channel, int dir, int priority, void *paddr, int msize, int psize, int minc, int pinc, unsigned char reqmap)
+static void _configureChannel(int dma, int channel, int dir, int priority, void *paddr, int msize, int psize, int minc, int pinc, unsigned char reqmap, handle_t *cond)
 {
 	unsigned int tmp, irqnum;
-	volatile unsigned int *channel_base = dma_common[dma].base + 2 + 5 * channel;
+	volatile unsigned int *channel_base = dma_common[dma].base + 2 + (5 * channel);
+	handle_t interruptCond = (cond == NULL) ? dma_common[dma].cond : *cond;
 
 	/* Channels of DMA2 are noncontiguous */
 	if (dma == dma2 && channel >= 5) {
@@ -81,57 +163,30 @@ static void _configureChannel(int dma, int channel, int dir, int priority, void 
 		irqnum = 16 + dmainfo[dma].irq_base + channel;
 	}
 
-	interrupt(irqnum, irqHandler, (void *)dma, dma_common[dma].cond, NULL);
+	interrupt(irqnum, irqHandler, (void *)dma, interruptCond, NULL);
 
 	*(channel_base + ccr) = ((priority & 0x3) << 12) | ((msize & 0x3) << 10) | ((psize & 0x3) << 8) |
 		((minc & 0x1) << 7) | ((pinc & 0x1) << 6) | ((dir & 0x1) << 4);
-	*(channel_base + cpar) = (unsigned int) paddr;
+	*(channel_base + cpar) = (unsigned int)paddr;
 	tmp = *(dma_common[dma].base + cselr) & ~(0xF << channel * 4);
-	*(dma_common[dma].base + cselr) = tmp | ((unsigned int) reqmap << channel * 4);
+	*(dma_common[dma].base + cselr) = tmp | ((unsigned int)reqmap << channel * 4);
 }
 
 
-int libdma_configureSpi(int num, int dir, int priority, void *paddr, int msize, int psize, int minc, int pinc)
+int libdma_configurePeripheral(const struct libdma_per *per, int dir, int priority, void *paddr, int msize, int psize, int minc, int pinc, handle_t *cond)
 {
-	int dma = spiChanMap[num].dma;
-	int channel = spiChanMap[num].channel[dir];
-	char reqmap = spiChanMap[num].reqmap;
+	int dma = per->dma, channel = per->channel[dir];
+	char reqmap = per->reqmap;
 
-	_configureChannel(dma, channel, dir, priority, paddr, msize, psize, minc, pinc, reqmap);
+	_configureChannel(dma, channel, dir, priority, paddr, msize, psize, minc, pinc, reqmap, cond);
 
 	return 0;
 }
 
 
-static void _prepare_transfer(volatile unsigned int *channel_base, void *maddr, size_t len, int tcie)
-{
-	*(channel_base + cmar) = (unsigned int) maddr;
-	*(channel_base + cndtr) = len;
-	dataBarier();
-
-	if (tcie)
-		/* Enable Transfer Complete interrupt, enable channel */
-		*(channel_base + ccr) |= (1 << 1) | 0x1;
-	else
-		/* Enable channel */
-		*(channel_base + ccr) |= 0x1;
-
-	dataBarier();
-}
-
-
-static void _unprepare_transfer(volatile unsigned int *channel_base)
-{
-	dataBarier();
-	/* Disable Transfer Complete interrupt, disable channel */
-	*(channel_base + ccr) &= ~((1 << 1) | 0x1);
-	dataBarier();
-}
-
-
 static int _has_channel_finished(const void *maddr, volatile unsigned int *channel_base)
 {
-	return (maddr != NULL && *(channel_base + cndtr) > 0);
+	return ((maddr != NULL) && (*(channel_base + cndtr) > 0)) ? 1 : 0;
 }
 
 
@@ -139,22 +194,26 @@ static int _transfer(int dma, int rx_channel, int tx_channel, void *rx_maddr, co
 {
 	/* Empirically chosen value to avoid mutex+cond overhead for short transactions */
 	int use_interrupts = len > 24;
+	int interrupts_flags = (use_interrupts == 0) ? 0 : DMA_TCIE_FLAG;
 
-	volatile unsigned int *rx_channel_base = dma_common[dma].base + 2 + 5 * rx_channel;
-	volatile unsigned int *tx_channel_base = dma_common[dma].base + 2 + 5 * tx_channel;
+	volatile unsigned int *rx_channel_base = dma_common[dma].base + 2 + (5 * rx_channel);
+	volatile unsigned int *tx_channel_base = dma_common[dma].base + 2 + (5 * tx_channel);
 
-	if (rx_maddr != NULL)
-		_prepare_transfer(rx_channel_base, rx_maddr, len, use_interrupts);
+	if (rx_maddr != NULL) {
+		_prepare_transfer(rx_channel_base, rx_maddr, len, interrupts_flags);
+	}
 
-	if (tx_maddr != NULL)
+	if (tx_maddr != NULL) {
 		/* When doing rw transfer, avoid unnecessary interrupt handling and condSignal()
 		by waiting only for RX transfer completion, ignoring TX */
-		_prepare_transfer(tx_channel_base, (void *)tx_maddr, len, use_interrupts && rx_maddr == NULL);
+		_prepare_transfer(tx_channel_base, (void *)tx_maddr, len, rx_maddr == NULL ? interrupts_flags : 0);
+	}
 
-	if (use_interrupts) {
+	if (use_interrupts != 0) {
 		mutexLock(dma_common[dma].irqLock);
-		while (_has_channel_finished(rx_maddr, rx_channel_base) || _has_channel_finished(tx_maddr, tx_channel_base))
+		while (_has_channel_finished(rx_maddr, rx_channel_base) || _has_channel_finished(tx_maddr, tx_channel_base)) {
 			condWait(dma_common[dma].cond, dma_common[dma].irqLock, 1);
+		}
 		mutexUnlock(dma_common[dma].irqLock);
 	}
 	else {
@@ -162,29 +221,91 @@ static int _transfer(int dma, int rx_channel, int tx_channel, void *rx_maddr, co
 			;
 	}
 
-	if (rx_maddr != NULL)
+	if (rx_maddr != NULL) {
 		_unprepare_transfer(rx_channel_base);
+	}
 
-	if (tx_maddr != NULL)
+	if (tx_maddr != NULL) {
 		_unprepare_transfer(tx_channel_base);
+	}
 
 	return len;
 }
 
 
-int libdma_transferSpi(int num, void *rx_maddr, const void *tx_maddr, size_t len)
+static int libdma_transferAsync(const struct libdma_per *per, void *maddr, int dir, size_t len, volatile int *done_flag)
+{
+	int dma = per->dma;
+	int channel = per->channel[dir];
+	volatile unsigned int *channel_base = dma_common[dma].base + 2 + (5 * channel);
+
+	/* Only one request may be issued on one channel at one time. */
+	if ((dma_transfers[dma][channel].type != dma_transferNull) || (DMA_MAX_LEN < len)) {
+		return -EINVAL;
+	}
+
+	*done_flag = 0;
+
+	dma_transfers[dma][channel].type = dma_transferOnce;
+	dma_transfers[dma][channel].once.done_flag = done_flag;
+	dma_transfers[dma][channel].once.channel_base = channel_base;
+
+	_prepare_transfer(channel_base, maddr, len, DMA_TCIE_FLAG);
+
+	return 0;
+}
+
+
+int libdma_txAsync(const struct libdma_per *per, const void *tx_maddr, size_t len, volatile int *done_flag)
+{
+	return libdma_transferAsync(per, (void *)tx_maddr, dma_mem2per, len, done_flag);
+}
+
+
+int libdma_rxAsync(const struct libdma_per *per, void *rx_maddr, size_t len, volatile int *done_flag)
+{
+	return libdma_transferAsync(per, rx_maddr, dma_per2mem, len, done_flag);
+}
+
+
+int libdma_infiniteRxAsync(const struct libdma_per *per, void *rx_maddr, size_t len, void fn(void *arg, int type), void *arg)
+{
+	int dma = per->dma;
+	int channel = per->channel[dma_per2mem];
+	volatile unsigned int *channel_base = dma_common[dma].base + 2 + (5 * channel);
+
+	/* Only one request may be issued on one channel at one time. */
+	if ((dma_transfers[dma][channel].type != dma_transferNull) || (DMA_MAX_LEN < len)) {
+		return -EINVAL;
+	}
+
+	dma_transfers[dma][channel].type = dma_transferInf;
+	dma_transfers[dma][channel].inf.fn = fn;
+	dma_transfers[dma][channel].inf.arg = arg;
+
+	_prepare_transfer(channel_base, rx_maddr, len, DMA_TCIE_FLAG | DMA_HTIE_FLAG | DMA_CIRCULAR_FLAG);
+
+	return 0;
+}
+
+
+int libdma_transfer(const struct libdma_per *per, void *rx_maddr, const void *tx_maddr, size_t len)
 {
 	int res;
 	volatile unsigned int *tx_channel_base;
-	int dma = spiChanMap[num].dma;
-	int rx_channel = spiChanMap[num].channel[dma_per2mem];
-	int tx_channel = spiChanMap[num].channel[dma_mem2per];
+	int dma = per->dma;
+	int rx_channel = per->channel[dma_per2mem];
+	int tx_channel = per->channel[dma_mem2per];
 	unsigned char txbuf = 0;
+
+	if (DMA_MAX_LEN < len) {
+		return -EINVAL;
+	}
 
 	if (tx_maddr == NULL) {
 		/* In case no tx buffer is provided, use a 1-byte dummy
 		and configure DMA not to increment the memory address. */
-		tx_channel_base = dma_common[dma].base + 2 + 5 * tx_channel;
+		tx_channel_base = dma_common[dma].base + 2 + (5 * tx_channel);
 		*(tx_channel_base + ccr) &= ~(1 << 7);
 		res = _transfer(dma, rx_channel, tx_channel, rx_maddr, &txbuf, len);
 		*(tx_channel_base + ccr) |= (1 << 7);
@@ -197,13 +318,44 @@ int libdma_transferSpi(int num, void *rx_maddr, const void *tx_maddr, size_t len
 }
 
 
+uint16_t libdma_leftToRx(const struct libdma_per *per)
+{
+	int dma = per->dma;
+	int channel = per->channel[dma_per2mem];
+	volatile unsigned int *channel_base = dma_common[dma].base + 2 + (5 * channel);
+
+	/* Only bottom 16 bits contain data. */
+	return (uint16_t)(*(channel_base + cndtr));
+}
+
+
+const struct libdma_per *libdma_getPeripheral(int per, unsigned int num)
+{
+	switch (per) {
+		case dma_spi:
+			if (num >= sizeof(libdma_persSpi) / sizeof(libdma_persSpi[0])) {
+				return NULL;
+			}
+			return &libdma_persSpi[num];
+		case dma_uart:
+			if (num >= sizeof(libdma_persUart) / sizeof(libdma_persUart[0])) {
+				return NULL;
+			}
+			return &libdma_persUart[num];
+		default:
+			return NULL;
+	}
+}
+
+
 int libdma_init(void)
 {
 	int dma;
 	static int init = 0;
 
-	if (init)
+	if (init != 0) {
 		return 0;
+	}
 
 	init = 1;
 

--- a/multi/stm32l4-multi/tty.c
+++ b/multi/stm32l4-multi/tty.c
@@ -23,9 +23,12 @@
 #include <sys/platform.h>
 #include <sys/file.h>
 #include <sys/threads.h>
+#include <sys/time.h>
 #include <libtty.h>
 #include <libtty-lf-fifo.h>
+#include <stdatomic.h>
 
+#include "libmulti/libdma.h"
 #include "stm32l4-multi.h"
 #include "common.h"
 #include "config.h"
@@ -42,13 +45,33 @@
 
 #define TTY_CNT (TTY1 + TTY2 + TTY3 + TTY4 + TTY5)
 
-#define THREAD_POOL 3
+#define THREAD_POOL    3
 #define THREAD_STACKSZ 768
-#define THREAD_PRIO 1
+#define THREAD_PRIO    1
+
+#define TTY_RX_NOT_READY_FLAG 0
+#define TTY_RX_READY_FLAG     (1 << 0)
+#define TTY_RX_FILLED_FLAG    (1 << 1)
+#define TTY_RX_FLAG_SHIFT     28
+#define TTY_RX_DATA_MASK      0xfffffff
 
 #if TTY_CNT != 0
+
+#define IS_POWER_OF_TWO(n) ((n > 0) && (n & (n - 1)) == 0)
+
+#if (!IS_POWER_OF_TWO(TTY1_DMA_RXSZ)) || (!IS_POWER_OF_TWO(TTY2_DMA_RXSZ)) || \
+	(!IS_POWER_OF_TWO(TTY3_DMA_RXSZ)) || (!IS_POWER_OF_TWO(TTY4_DMA_RXSZ)) || \
+	(!IS_POWER_OF_TWO(TTY5_DMA_RXSZ))
+#error "Size of RX DMA buffer has to be a power of two!"
+#endif
+
+#if (TTY1_DMA && !TTY1) || (TTY2_DMA && !TTY2) || (TTY3_DMA && !TTY3) || \
+	(TTY4_DMA && !TTY4) || (TTY5_DMA && !TTY5)
+#error "DMA mode cannot be enabled on a disabled TTY!"
+#endif
+
 typedef struct {
-	char stack[512] __attribute__ ((aligned(8)));
+	char stack[512] __attribute__((aligned(8)));
 
 	volatile unsigned int *base;
 	volatile int enabled;
@@ -63,9 +86,37 @@ typedef struct {
 
 	libtty_common_t tty_common;
 
-	uint8_t rx_fifo_buffer[16];
-	lf_fifo_t rx_fifo;
-	volatile int rxready;
+	enum {
+		tty_irq,
+		tty_dma,
+	} type;
+	union {
+		struct {
+			uint8_t rx_fifo_buffer[16];
+			lf_fifo_t rx_fifo;
+			volatile int rxready;
+		} irq;
+		struct {
+			const struct libdma_per *per;
+			volatile int tx_done_flag;
+
+			unsigned char *rxbuf;
+			unsigned char *txbuf;
+			size_t rxbufsz;
+			unsigned int rxbufsz_mask;
+			size_t txbufsz;
+
+			unsigned int read_pos;
+
+			/* Flag followed by the number of bytes left to rx */
+			atomic_ulong rxready;
+
+			struct {
+				size_t dropped_bytes;
+				atomic_uint fill_cnt;
+			} debug;
+		} dma;
+	} data;
 } tty_ctx_t;
 
 
@@ -77,16 +128,28 @@ static struct {
 } uart_common;
 
 
-static const int uartConfig[] = { TTY1, TTY2, TTY3, TTY4, TTY5 };
+static const struct {
+	int enabled;
+	int dma;
+	size_t dma_buf_size_rx;
+	size_t dma_buf_size_tx;
+	int pos;
+	size_t libtty_buf_size;
+} ttySetup[] = {
+	{ TTY1, TTY1_DMA, TTY1_DMA_RXSZ, TTY1_DMA_TXSZ, TTY1_POS, TTY1_LIBTTY_BUFSZ },
+	{ TTY2, TTY2_DMA, TTY2_DMA_RXSZ, TTY2_DMA_TXSZ, TTY2_POS, TTY2_LIBTTY_BUFSZ },
+	{ TTY3, TTY3_DMA, TTY3_DMA_RXSZ, TTY3_DMA_TXSZ, TTY3_POS, TTY3_LIBTTY_BUFSZ },
+	{ TTY4, TTY4_DMA, TTY4_DMA_RXSZ, TTY4_DMA_TXSZ, TTY4_POS, TTY4_LIBTTY_BUFSZ },
+	{ TTY5, TTY5_DMA, TTY5_DMA_RXSZ, TTY5_DMA_TXSZ, TTY5_POS, TTY5_LIBTTY_BUFSZ },
+};
 
 
-static const int uartPos[] = { TTY1_POS, TTY2_POS, TTY3_POS, TTY4_POS, TTY5_POS };
-
-
+/* clang-format off */
 enum { cr1 = 0, cr2, cr3, brr, gtpr, rtor, rqr, isr, icr, rdr, tdr };
 
 
 enum { tty_parnone = 0, tty_pareven, tty_parodd };
+/* clang-format on */
 
 
 static inline int tty_txready(tty_ctx_t *ctx)
@@ -99,18 +162,170 @@ static int tty_irqHandler(unsigned int n, void *arg)
 {
 	tty_ctx_t *ctx = (tty_ctx_t *)arg;
 
-	if (*(ctx->base + isr) & ((1 << 5) | (1 << 3))) {
+	if ((*(ctx->base + isr) & ((1 << 5) | (1 << 3))) != 0) {
 		/* Clear overrun error bit */
 		*(ctx->base + icr) |= (1 << 3);
 
-		lf_fifo_push(&ctx->rx_fifo, *(ctx->base + rdr));
-		ctx->rxready = 1;
+		lf_fifo_push(&ctx->data.irq.rx_fifo, *(ctx->base + rdr));
+		ctx->data.irq.rxready = 1;
 	}
 
-	if (tty_txready(ctx))
+	if (tty_txready(ctx) != 0) {
 		*(ctx->base + cr1) &= ~(1 << 7);
+	}
 
 	return 1;
+}
+
+
+/* Nonnegative type must be one of dma_ht or dm_tc,
+   negative type means idle line detected in which case it's negated number of bytes read. */
+static void tty_dmaCallback(void *arg, int type)
+{
+	tty_ctx_t *ctx = (tty_ctx_t *)arg;
+	unsigned long rxreadyFlags = TTY_RX_READY_FLAG;
+	unsigned long rxready = libdma_leftToRx(ctx->data.dma.per) & TTY_RX_DATA_MASK;
+
+	if (type == dma_tc) {
+		rxreadyFlags |= TTY_RX_FILLED_FLAG;
+		atomic_fetch_add_explicit(&ctx->data.dma.debug.fill_cnt, 1, memory_order_acq_rel);
+	}
+
+	rxready |= rxreadyFlags << TTY_RX_FLAG_SHIFT;
+
+	atomic_fetch_or_explicit(&ctx->data.dma.rxready, rxready, memory_order_acq_rel);
+}
+
+
+static int tty_irqHandlerDMA(unsigned int n, void *arg)
+{
+	tty_ctx_t *ctx = (tty_ctx_t *)arg;
+	int read;
+
+	/* Check for the idle line. */
+	if ((*(ctx->base + isr) & ((1 << 4))) == 0) {
+		return -1;
+	}
+	/* Clear idle line bit */
+	*(ctx->base + icr) |= (1 << 4);
+
+	read = libdma_leftToRx(ctx->data.dma.per);
+
+	if (read != 0) {
+		tty_dmaCallback(ctx, -read);
+	}
+
+	return 1;
+}
+
+
+static void tty_dmaHandleRx(tty_ctx_t *ctx)
+{
+	unsigned int write_pos, read_pos;
+	int wake = 0, wake_helper;
+	unsigned long rxready = atomic_exchange_explicit(&ctx->data.dma.rxready, TTY_RX_NOT_READY_FLAG << TTY_RX_FLAG_SHIFT, memory_order_acq_rel);
+	unsigned long rxreadyFlags = rxready >> TTY_RX_FLAG_SHIFT;
+	unsigned long leftToRx = rxready & TTY_RX_DATA_MASK;
+	unsigned int fill_cnt;
+	unsigned int rxBytes;
+
+	if (rxreadyFlags == TTY_RX_NOT_READY_FLAG) {
+		return;
+	}
+
+	if ((rxreadyFlags & TTY_RX_FILLED_FLAG) != 0) {
+		fill_cnt = atomic_exchange_explicit(&ctx->data.dma.debug.fill_cnt, 0, memory_order_acq_rel);
+		if (fill_cnt > 1) {
+			ctx->data.dma.debug.dropped_bytes += (fill_cnt - 1) * ctx->data.dma.rxbufsz;
+		}
+	}
+
+	libtty_putchar_lock(&ctx->tty_common);
+
+	write_pos = (ctx->data.dma.rxbufsz - leftToRx) & ctx->data.dma.rxbufsz_mask;
+	read_pos = ctx->data.dma.read_pos;
+
+	if (((rxreadyFlags & TTY_RX_FILLED_FLAG) != 0) && (write_pos >= read_pos)) {
+		rxBytes = ctx->data.dma.rxbufsz;
+		/* Detect dropped bytes. */
+		if (write_pos > read_pos) {
+			ctx->data.dma.debug.dropped_bytes += write_pos - read_pos;
+			read_pos = write_pos;
+		}
+	}
+	else {
+		rxBytes = (ctx->data.dma.rxbufsz + (write_pos - read_pos)) & ctx->data.dma.rxbufsz_mask;
+	}
+
+	for (; rxBytes != 0; rxBytes--) {
+		libtty_putchar_unlocked(&ctx->tty_common, ctx->data.dma.rxbuf[read_pos], &wake_helper);
+		read_pos = (read_pos + 1) & ctx->data.dma.rxbufsz_mask;
+		wake |= wake_helper;
+	}
+
+	libtty_putchar_unlock(&ctx->tty_common);
+
+	if (wake != 0) {
+		libtty_wake_reader(&ctx->tty_common);
+	}
+	ctx->data.dma.read_pos = read_pos;
+}
+
+
+static void tty_dmaHandleTx(tty_ctx_t *ctx)
+{
+	unsigned int i;
+
+	if (libtty_txready(&ctx->tty_common) != 0) {
+		for (i = 0; i < ctx->data.dma.txbufsz && (libtty_txready(&ctx->tty_common) != 0); i++) {
+			ctx->data.dma.txbuf[i] = libtty_popchar(&ctx->tty_common);
+		}
+		libtty_wake_writer(&ctx->tty_common);
+
+		*(ctx->base + icr) |= (1 << 6);
+
+		(void)libdma_txAsync(ctx->data.dma.per, ctx->data.dma.txbuf, i, &ctx->data.dma.tx_done_flag);
+	}
+}
+
+
+static int tty_dmarxready(tty_ctx_t *ctx)
+{
+	return atomic_load_explicit(&ctx->data.dma.rxready, memory_order_acquire) != TTY_RX_NOT_READY_FLAG;
+}
+
+
+static int tty_dmatxready(tty_ctx_t *ctx)
+{
+	return (ctx->data.dma.tx_done_flag != 0) && (libtty_txready(&ctx->tty_common) != 0);
+}
+
+
+static int tty_uartenabled(tty_ctx_t *ctx)
+{
+	return *(ctx->base + cr1) & 1;
+}
+
+
+static void tty_dmathread(void *arg)
+{
+	tty_ctx_t *ctx = (tty_ctx_t *)arg;
+
+	/* Start rx routine. */
+	libdma_infiniteRxAsync(ctx->data.dma.per, ctx->data.dma.rxbuf, ctx->data.dma.rxbufsz, tty_dmaCallback, ctx);
+
+	while (1) {
+		if (tty_dmarxready(ctx) == 0) {
+			mutexLock(ctx->irqlock);
+			while (((tty_dmarxready(ctx) == 0) && (tty_dmatxready(ctx) == 0)) || (tty_uartenabled(ctx) == 0)) {
+				condWait(ctx->cond, ctx->irqlock, 0);
+			}
+			mutexUnlock(ctx->irqlock);
+		}
+
+		tty_dmaHandleRx(ctx);
+		tty_dmaHandleTx(ctx);
+	}
 }
 
 
@@ -119,40 +334,42 @@ static void tty_irqthread(void *arg)
 	tty_ctx_t *ctx = (tty_ctx_t *)arg;
 	int keptidle = 0;
 
-
 	while (1) {
 		uint8_t rxbyte;
 		unsigned rxcount;
 
 		mutexLock(ctx->irqlock);
-		while ((!ctx->rxready && !(tty_txready(ctx) && (libtty_txready(&ctx->tty_common) || keptidle))) || !(*(ctx->base + cr1) & 1))
+		while (((ctx->data.irq.rxready == 0) && !((tty_txready(ctx) != 0) && ((libtty_txready(&ctx->tty_common) != 0) || (keptidle != 0)))) || (tty_uartenabled(ctx) == 0)) {
 			condWait(ctx->cond, ctx->irqlock, 0);
+		}
 		mutexUnlock(ctx->irqlock);
 
-		ctx->rxready = 0;
+		ctx->data.irq.rxready = 0;
 		dataBarier();
 
 		/* limiting byte count to 8 to avoid starving tx */
-		for (rxcount = 8; rxcount && lf_fifo_pop(&ctx->rx_fifo, &rxbyte); rxcount--) {
+		for (rxcount = 8; (rxcount != 0) && (lf_fifo_pop(&ctx->data.irq.rx_fifo, &rxbyte) != 0); rxcount--) {
 			libtty_putchar(&ctx->tty_common, rxbyte, NULL);
 		}
-		if (!rxcount) {
-			/* aborted due rxcount limit - setting rxready to skip next condWait */
-			ctx->rxready = 1;
+		if (rxcount == 0) {
+			/* aborted due to rxcount limit - setting rxready to skip next condWait */
+			ctx->data.irq.rxready = 1;
 		}
 
-		/* TODO add small TX fifo that can be read directly from IRQ */
-		if (libtty_txready(&ctx->tty_common)) {
-			if (tty_txready(ctx)) {
-				if (!keptidle) {
+
+		if (libtty_txready(&ctx->tty_common) != 0) {
+			if (tty_txready(ctx) != 0) {
+				if (keptidle == 0) {
 					keptidle = 1;
 					keepidle(1);
 				}
+
+				/* TODO add small TX fifo that can be read directly from IRQ */
 				*(ctx->base + tdr) = libtty_getchar(&ctx->tty_common, NULL);
 				*(ctx->base + cr1) |= (1 << 7);
 			}
 		}
-		else if (keptidle) {
+		else if (keptidle != 0) {
 			keptidle = 0;
 			keepidle(0);
 		}
@@ -170,6 +387,7 @@ static int _tty_configure(tty_ctx_t *ctx, char bits, char parity, char enable)
 {
 	int err = EOK;
 	unsigned int tcr1 = 0;
+	unsigned int flags;
 	char tbits = bits;
 
 	ctx->enabled = 0;
@@ -180,23 +398,23 @@ static int _tty_configure(tty_ctx_t *ctx, char bits, char parity, char enable)
 	}
 
 	switch (tbits) {
-	case 9:
-		tcr1 &= ~(1 << 28);
-		tcr1 |= (1 << 12);
-		break;
+		case 9:
+			tcr1 &= ~(1 << 28);
+			tcr1 |= (1 << 12);
+			break;
 
-	case 8:
-		tcr1 &= ~((1 << 28) | (1 << 12));
-		break;
+		case 8:
+			tcr1 &= ~((1 << 28) | (1 << 12));
+			break;
 
-	case 7:
-		tcr1 &= ~(1 << 12);
-		tcr1 |= (1 << 28);
-		break;
+		case 7:
+			tcr1 &= ~(1 << 12);
+			tcr1 |= (1 << 28);
+			break;
 
-	default:
-		err = -1;
-		break;
+		default:
+			err = -1;
+			break;
 	}
 
 	if (err == EOK) {
@@ -204,16 +422,24 @@ static int _tty_configure(tty_ctx_t *ctx, char bits, char parity, char enable)
 		dataBarier();
 		*(ctx->base + cr1) = tcr1;
 
-		if (parity == tty_parodd)
+		if (parity == tty_parodd) {
 			*(ctx->base + cr1) |= 1 << 9;
-		else
+		}
+		else {
 			*(ctx->base + cr1) &= ~(1 << 9);
+		}
 
 		*(ctx->base + icr) = -1;
 		(void)*(ctx->base + rdr);
 
-		if (enable) {
-			*(ctx->base + cr1) |= (1 << 5) | (1 << 3) | (1 << 2);
+		if (enable != 0) {
+			flags = (1 << 5) | (1 << 3) | (1 << 2);
+			if (ctx->type == tty_dma) {
+				/* Idle line interrupt enable. */
+				flags |= (1 << 4);
+			}
+			*(ctx->base + cr1) |= flags;
+
 			dataBarier();
 			*(ctx->base + cr1) |= 1;
 			ctx->enabled = 1;
@@ -259,6 +485,7 @@ static void tty_setBaudrate(void *uart, speed_t baud)
 {
 	tty_ctx_t *ctx = (tty_ctx_t *)uart;
 	int baudr = libtty_baudrate_to_int(baud);
+	int flags;
 
 	if (ctx->baud != baudr) {
 		*(ctx->base + cr1) &= ~1;
@@ -269,7 +496,12 @@ static void tty_setBaudrate(void *uart, speed_t baud)
 		*(ctx->base + icr) = -1;
 		(void)*(ctx->base + rdr);
 
-		*(ctx->base + cr1) |= (1 << 5) | (1 << 3) | (1 << 2);
+		flags = (1 << 5) | (1 << 3) | (1 << 2);
+		if (ctx->type == tty_dma) {
+			/* Idle line interrupt enable. */
+			flags |= (1 << 4);
+		}
+		*(ctx->base + cr1) |= flags;
 		dataBarier();
 		*(ctx->base + cr1) |= 1;
 		ctx->enabled = 1;
@@ -290,7 +522,7 @@ static tty_ctx_t *tty_getCtx(id_t id)
 	id -= 1;
 
 	if (id >= usart1 && id <= uart5)
-		ctx = &uart_common.ctx[uartPos[id - usart1]];
+		ctx = &uart_common.ctx[ttySetup[id - usart1].pos];
 
 	return ctx;
 }
@@ -314,52 +546,52 @@ static void tty_thread(void *arg)
 		priority(msg.priority);
 
 		switch (msg.type) {
-		case mtOpen:
-		case mtClose:
-			if ((ctx = tty_getCtx(msg.i.io.oid.id)) == NULL) {
-				msg.o.io.err = -EINVAL;
+			case mtOpen:
+			case mtClose:
+				if ((ctx = tty_getCtx(msg.i.io.oid.id)) == NULL) {
+					msg.o.io.err = -EINVAL;
+					break;
+				}
+
+				msg.o.io.err = EOK;
 				break;
-			}
 
-			msg.o.io.err = EOK;
-			break;
-
-		case mtWrite:
-			if ((ctx = tty_getCtx(msg.i.io.oid.id)) == NULL) {
-				msg.o.io.err = -EINVAL;
+			case mtWrite:
+				if ((ctx = tty_getCtx(msg.i.io.oid.id)) == NULL) {
+					msg.o.io.err = -EINVAL;
+					break;
+				}
+				msg.o.io.err = libtty_write(&ctx->tty_common, msg.i.data, msg.i.size, msg.i.io.mode);
 				break;
-			}
-			msg.o.io.err = libtty_write(&ctx->tty_common, msg.i.data, msg.i.size, msg.i.io.mode);
-			break;
 
-		case mtRead:
-			if ((ctx = tty_getCtx(msg.i.io.oid.id)) == NULL) {
-				msg.o.io.err = -EINVAL;
+			case mtRead:
+				if ((ctx = tty_getCtx(msg.i.io.oid.id)) == NULL) {
+					msg.o.io.err = -EINVAL;
+					break;
+				}
+				msg.o.io.err = libtty_read(&ctx->tty_common, msg.o.data, msg.o.size, msg.i.io.mode);
 				break;
-			}
-			msg.o.io.err = libtty_read(&ctx->tty_common, msg.o.data, msg.o.size, msg.i.io.mode);
-			break;
 
-		case mtGetAttr:
-			if ((msg.i.attr.type != atPollStatus) || ((ctx = tty_getCtx(msg.i.attr.oid.id)) == NULL)) {
-				msg.o.attr.err = -EINVAL;
+			case mtGetAttr:
+				if ((msg.i.attr.type != atPollStatus) || ((ctx = tty_getCtx(msg.i.attr.oid.id)) == NULL)) {
+					msg.o.attr.err = -EINVAL;
+					break;
+				}
+				msg.o.attr.val = libtty_poll_status(&ctx->tty_common);
+				msg.o.attr.err = EOK;
 				break;
-			}
-			msg.o.attr.val = libtty_poll_status(&ctx->tty_common);
-			msg.o.attr.err = EOK;
-			break;
 
-		case mtDevCtl:
-			in_data = ioctl_unpack(&msg, &request, &id);
-			if ((ctx = tty_getCtx(id)) == NULL) {
-				err = -EINVAL;
-			}
-			else {
-				pid = ioctl_getSenderPid(&msg);
-				err = libtty_ioctl(&ctx->tty_common, pid, request, in_data, &out_data);
-			}
-			ioctl_setResponse(&msg, request, err, out_data);
-			break;
+			case mtDevCtl:
+				in_data = ioctl_unpack(&msg, &request, &id);
+				if ((ctx = tty_getCtx(id)) == NULL) {
+					err = -EINVAL;
+				}
+				else {
+					pid = ioctl_getSenderPid(&msg);
+					err = libtty_ioctl(&ctx->tty_common, pid, request, in_data, &out_data);
+				}
+				ioctl_setResponse(&msg, request, err, out_data);
+				break;
 		}
 
 		msgRespond(uart_common.port, &msg, rid);
@@ -390,7 +622,7 @@ void tty_createDev(void)
 int tty_init(void)
 {
 #if TTY_CNT != 0
-	unsigned int uart, i;
+	unsigned int tty, i;
 	char fname[] = "uartx";
 	speed_t baudrate = B115200;
 	oid_t oid;
@@ -411,49 +643,92 @@ int tty_init(void)
 	portCreate(&uart_common.port);
 	oid.port = uart_common.port;
 
-	for (uart = usart1; uart <= uart5; ++uart) {
-		if (!uartConfig[uart])
+	for (tty = 0; tty <= uart5 - usart1; ++tty) {
+		if (ttySetup[tty].enabled == 0) {
 			continue;
+		}
 
-		ctx = &uart_common.ctx[uartPos[uart - usart1]];
+		ctx = &uart_common.ctx[ttySetup[tty].pos];
 
-		devClk(info[uart - usart1].dev, 1);
+		devClk(info[tty].dev, 1);
 
 		callbacks.arg = ctx;
 		callbacks.set_baudrate = tty_setBaudrate;
 		callbacks.set_cflag = tty_setCflag;
 		callbacks.signal_txready = tty_signalTxReady;
 
-		if (libtty_init(&ctx->tty_common, &callbacks, 512, baudrate) < 0)
+		if (libtty_init(&ctx->tty_common, &callbacks, ttySetup[tty].libtty_buf_size, baudrate) < 0) {
 			return -1;
+		}
 
 		mutexCreate(&ctx->irqlock);
 		condCreate(&ctx->cond);
 
-		ctx->base = info[uart - usart1].base;
-		lf_fifo_init(&ctx->rx_fifo, ctx->rx_fifo_buffer, sizeof(ctx->rx_fifo_buffer));
-		ctx->rxready = 0;
+		ctx->base = info[tty].base;
 		ctx->bits = -1;
 		ctx->parity = -1;
 		ctx->baud = -1;
+
+		if (ttySetup[tty].dma == 0) {
+			lf_fifo_init(&ctx->data.irq.rx_fifo, ctx->data.irq.rx_fifo_buffer, sizeof(ctx->data.irq.rx_fifo_buffer));
+			ctx->data.irq.rxready = 0;
+
+			ctx->type = tty_irq;
+		}
+		else {
+			libdma_init();
+			ctx->data.dma.per = libdma_getPeripheral(dma_uart, tty);
+			/* Configure dma for tx and rx, medium priority, transfer size 8bits, increment memory address by 1 after each transfer. */
+			libdma_configurePeripheral(ctx->data.dma.per, dma_mem2per, 0x1, (void *)(ctx->base + tdr), 0x0, 0x0, 0x1, 0x0, &ctx->cond);
+			libdma_configurePeripheral(ctx->data.dma.per, dma_per2mem, 0x1, (void *)(ctx->base + rdr), 0x0, 0x0, 0x1, 0x0, &ctx->cond);
+			*(ctx->base + cr3) |= (1 << 7) | (1 << 6); /* Enable DMA for transmission and reception. */
+
+			ctx->data.dma.tx_done_flag = 1;
+			ctx->data.dma.read_pos = 0;
+			atomic_init(&ctx->data.dma.rxready, TTY_RX_NOT_READY_FLAG << TTY_RX_FLAG_SHIFT);
+
+			ctx->data.dma.debug.dropped_bytes = 0;
+			atomic_init(&ctx->data.dma.debug.fill_cnt, 0);
+
+			ctx->data.dma.rxbufsz = ttySetup[tty].dma_buf_size_rx;
+			ctx->data.dma.rxbufsz_mask = ctx->data.dma.rxbufsz - 1;
+			ctx->data.dma.rxbuf = malloc(ctx->data.dma.rxbufsz);
+			if (ctx->data.dma.rxbuf == NULL) {
+				return -ENOMEM;
+			}
+			ctx->data.dma.txbufsz = ttySetup[tty].dma_buf_size_tx;
+			ctx->data.dma.txbuf = malloc(ctx->data.dma.txbufsz);
+			if (ctx->data.dma.txbuf == NULL) {
+				free(ctx->data.dma.rxbuf);
+				return -ENOMEM;
+			}
+
+			ctx->type = tty_dma;
+		}
 
 		/* Set up UART to 9600,8,n,1 16-bit oversampling */
 		_tty_configure(ctx, 8, tty_parnone, 1);
 		tty_setBaudrate(ctx, baudrate);
 
-		interrupt(info[uart - usart1].irq, tty_irqHandler, (void *)ctx, ctx->cond, NULL);
-
-		beginthread(tty_irqthread, 1, ctx->stack, sizeof(ctx->stack), (void *)ctx);
+		if (ttySetup[tty].dma == 0) {
+			interrupt(info[tty].irq, tty_irqHandler, (void *)ctx, ctx->cond, NULL);
+			beginthread(tty_irqthread, 1, ctx->stack, sizeof(ctx->stack), (void *)ctx);
+		}
+		else {
+			interrupt(info[tty].irq, tty_irqHandlerDMA, (void *)ctx, ctx->cond, NULL);
+			beginthread(tty_dmathread, 1, ctx->stack, sizeof(ctx->stack), (void *)ctx);
+		}
 
 		ctx->enabled = 1;
 
-		fname[sizeof(fname) - 2] = '0' + uart - usart1;
-		oid.id = uart - usart1 + 1;
+		fname[sizeof(fname) - 2] = '0' + tty;
+		oid.id = tty + 1;
 		create_dev(&oid, fname);
 	}
 
-	for (i = 0; i < THREAD_POOL; ++i)
+	for (i = 0; i < THREAD_POOL; ++i) {
 		beginthread(tty_thread, THREAD_PRIO, uart_common.poolstack[i], sizeof(uart_common.poolstack[i]), (void *)i);
+	}
 
 	return EOK;
 #else

--- a/tty/libtty/fifo.h
+++ b/tty/libtty/fifo.h
@@ -92,7 +92,7 @@ static inline int fifo_has_char(fifo_t *f, char byte)
 		return 0;
 
 	while (tail != f->head) {
-		if (f->data[tail] == (uint8_t) byte)
+		if (f->data[tail] == (uint8_t)byte)
 			return 1;
 
 		tail = (tail + 1) & f->size_mask;
@@ -101,4 +101,4 @@ static inline int fifo_has_char(fifo_t *f, char byte)
 	return 0;
 }
 
-#endif // _LIBTTY_FIFO_H
+#endif /* _LIBTTY_FIFO_H */

--- a/tty/libtty/libtty-lf-fifo.h
+++ b/tty/libtty/libtty-lf-fifo.h
@@ -32,6 +32,7 @@ struct lf_fifo_s {
 
 
 /* NOTE: size must be a power of 2 */
+/* NOTE: effective capacity is size - 1 */
 static inline void lf_fifo_init(lf_fifo_t *f, uint8_t *data, unsigned int size)
 {
 	f->head = 0;
@@ -73,5 +74,6 @@ static inline int lf_fifo_pop(lf_fifo_t *f, uint8_t *byte)
 
 	return 1;
 }
+
 
 #endif

--- a/tty/libtty/libtty.h
+++ b/tty/libtty/libtty.h
@@ -102,6 +102,10 @@ ssize_t libtty_read_nonblock(libtty_common_t *tty, char *data, size_t size, unsi
 
 /* internal (HW) interface */
 int libtty_putchar(libtty_common_t *tty, unsigned char c, int *wake_reader);
+void libtty_putchar_lock(libtty_common_t *tty);
+void libtty_putchar_unlock(libtty_common_t *tty);
+void libtty_wake_reader(libtty_common_t *tty);
+int libtty_putchar_unlocked(libtty_common_t *tty, unsigned char c, int *wake_reader);
 /* writer wake up is done outside of libtty if wake_writer is not NULL */
 unsigned char libtty_getchar(libtty_common_t *tty, int *wake_writer);
 unsigned char libtty_popchar(libtty_common_t *tty);

--- a/tty/libtty/libtty.h
+++ b/tty/libtty/libtty.h
@@ -27,14 +27,14 @@ typedef struct fifo_s fifo_t;
 typedef struct libtty_read_state_s libtty_read_state_t;
 
 struct libtty_callbacks_s {
-	void* arg; /* argument to be passed to each of the callbacks */
+	void *arg; /* argument to be passed to each of the callbacks */
 
 	/* HW configuration */
-	void (*set_baudrate)(void* arg, speed_t baudrate);
-	void (*set_cflag)(void* arg, tcflag_t* cflag);
+	void (*set_baudrate)(void *arg, speed_t baudrate);
+	void (*set_cflag)(void *arg, tcflag_t *cflag);
 
 	/* at least one character ready to be sent */
-	void (*signal_txready)(void* arg);
+	void (*signal_txready)(void *arg);
 };
 
 struct libtty_common_s {
@@ -52,12 +52,12 @@ struct libtty_common_s {
 	handle_t tx_mutex;
 	handle_t rx_mutex;
 
-	// cached optimizations
-	char breakchars[4];	/* enough to hold \n, VEOF and VEOL. */
+	/* cached optimizations */
+	char breakchars[4]; /* enough to hold \n, VEOF and VEOL. */
 	unsigned int t_flags;
 
-	// TODO: remove
-	volatile uint32_t* debug;
+	/* TODO: remove */
+	volatile uint32_t *debug;
 };
 
 struct libtty_read_state_s {
@@ -65,29 +65,30 @@ struct libtty_read_state_s {
 	int prevlen;
 };
 
-static inline void libtty_read_state_init(libtty_read_state_t *st) {
+static inline void libtty_read_state_init(libtty_read_state_t *st)
+{
 	st->timeout_ms = -1;
 	st->prevlen = 0;
 }
 
 
-// t_flags
-#define	TF_HAVEBREAK	0x00001	/* There is a breakchar present in RX fifo */
-#define	TF_LITERAL	0x00200	/* Accept the next character literally. */
-#define	TF_BYPASS	0x04000	/* Optimized input path. */
-#define TF_CLOSING  0x08000 /* TTY is being closed */
+/* t_flags */
+#define TF_HAVEBREAK 0x00001 /* There is a breakchar present in RX fifo */
+#define TF_LITERAL   0x00200 /* Accept the next character literally. */
+#define TF_BYPASS    0x04000 /* Optimized input path. */
+#define TF_CLOSING   0x08000 /* TTY is being closed */
 
 
 /* bufsize: TX/RX buffer size - has to be power of 2 ! */
 int libtty_init(libtty_common_t *tty, libtty_callbacks_t *callbacks, unsigned int bufsize, speed_t speed);
-int libtty_destroy(libtty_common_t* tty);
-int libtty_close(libtty_common_t* tty);
+int libtty_destroy(libtty_common_t *tty);
+int libtty_close(libtty_common_t *tty);
 
 /* external (message) interface */
 ssize_t libtty_read(libtty_common_t *tty, char *data, size_t size, unsigned mode);
 ssize_t libtty_write(libtty_common_t *tty, const char *data, size_t size, unsigned mode);
-int libtty_poll_status(libtty_common_t* tty);
-int libtty_ioctl(libtty_common_t* tty, pid_t sender_pid, unsigned int cmd, const void* in_arg, const void** out_arg);
+int libtty_poll_status(libtty_common_t *tty);
+int libtty_ioctl(libtty_common_t *tty, pid_t sender_pid, unsigned int cmd, const void *in_arg, const void **out_arg);
 
 /* non-blocking interface:
  *  - first invocation has to be done with initialized libtty_read_state_t st param
@@ -105,11 +106,11 @@ int libtty_putchar(libtty_common_t *tty, unsigned char c, int *wake_reader);
 unsigned char libtty_getchar(libtty_common_t *tty, int *wake_writer);
 unsigned char libtty_popchar(libtty_common_t *tty);
 void libtty_wake_writer(libtty_common_t *tty);
-void libtty_signal_pgrp(libtty_common_t* tty, int signal);
+void libtty_signal_pgrp(libtty_common_t *tty, int signal);
 
-int libtty_txready(libtty_common_t *tty);	// at least 1 character ready to be sent
-int libtty_txfull(libtty_common_t *tty);	// no more place in the TX buffer
-int libtty_rxready(libtty_common_t *tty);	// at least 1 character ready to be read out
+int libtty_txready(libtty_common_t *tty); /* at least 1 character ready to be sent */
+int libtty_txfull(libtty_common_t *tty);  /* no more place in the TX buffer */
+int libtty_rxready(libtty_common_t *tty); /* at least 1 character ready to be read out */
 
 static inline void libtty_set_mode_raw(libtty_common_t *tty)
 {
@@ -122,44 +123,45 @@ static inline void libtty_set_mode_raw(libtty_common_t *tty)
 static inline int libtty_baudrate_to_int(speed_t baudrate)
 {
 	switch (baudrate) {
-	case B0: 	return 0;
-	case B300:	return 300;
-	case B600:	return 600;
-	case B1200:	return 1200;
-	case B1800:	return 1800;
-	case B2400:	return 2400;
-	case B4800:	return 4800;
-	case B9600:	return 9600;
-	case B19200:	return 19200;
-	case B38400:	return 38400;
-	case B57600:	return 57600;
-	case B115200:	return 115200;
-	case B230400:	return 230400;
-	case B460800:	return 460800;
+		case B0: return 0;
+		case B300: return 300;
+		case B600: return 600;
+		case B1200: return 1200;
+		case B1800: return 1800;
+		case B2400: return 2400;
+		case B4800: return 4800;
+		case B9600: return 9600;
+		case B19200: return 19200;
+		case B38400: return 38400;
+		case B57600: return 57600;
+		case B115200: return 115200;
+		case B230400: return 230400;
+		case B460800: return 460800;
 	}
 
 	return -1;
 }
 
-static inline speed_t libtty_int_to_baudrate(int baudrate) {
+static inline speed_t libtty_int_to_baudrate(int baudrate)
+{
 	switch (baudrate) {
-	case 0: 	return B0;
-	case 300:	return B300;
-	case 600:	return B600;
-	case 1200:	return B1200;
-	case 1800:	return B1800;
-	case 2400:	return B2400;
-	case 4800:	return B4800;
-	case 9600:	return B9600;
-	case 19200:	return B19200;
-	case 38400:	return B38400;
-	case 57600:	return B57600;
-	case 115200:	return B115200;
-	case 230400:	return B230400;
-	case 460800:	return B460800;
+		case 0: return B0;
+		case 300: return B300;
+		case 600: return B600;
+		case 1200: return B1200;
+		case 1800: return B1800;
+		case 2400: return B2400;
+		case 4800: return B4800;
+		case 9600: return B9600;
+		case 19200: return B19200;
+		case 38400: return B38400;
+		case 57600: return B57600;
+		case 115200: return B115200;
+		case 230400: return B230400;
+		case 460800: return B460800;
 	}
 
 	return -1;
 }
 
-#endif //_LIBTTY_H_
+#endif /* _LIBTTY_H_ */

--- a/tty/libtty/libtty_disc.c
+++ b/tty/libtty/libtty_disc.c
@@ -57,48 +57,55 @@
 
 #include "ttydefaults.h"
 
-// DEBUG {
-#include <stdio.h> // printf
+/* DEBUG { */
+#include <stdio.h> /* printf */
 
-#define COL_RED     "\033[1;31m"
-#define COL_CYAN    "\033[1;36m"
-#define COL_YELLOW  "\033[1;33m"
-#define COL_NORMAL  "\033[0m"
+#define COL_RED    "\033[1;31m"
+#define COL_CYAN   "\033[1;36m"
+#define COL_YELLOW "\033[1;33m"
+#define COL_NORMAL "\033[0m"
+
 
 #define LOG_TAG "libtty-disc: "
+
+/* clang-format off */
 #define log_debug(fmt, ...)     do { if (0) printf(LOG_TAG fmt "\n", ##__VA_ARGS__); } while (0)
 #define log_info(fmt, ...)      do { if (0) printf(COL_CYAN LOG_TAG fmt "\n" COL_NORMAL, ##__VA_ARGS__); } while (0)
 #define log_warn(fmt, ...)      do { if (0) printf(COL_YELLOW LOG_TAG fmt "\n" COL_NORMAL, ##__VA_ARGS__); } while (0)
 #define log_error(fmt, ...)     do { if (0) printf(COL_RED  LOG_TAG fmt "\n" COL_NORMAL, ##__VA_ARGS__); } while (0)
-// } DEBUG
+/* clang-format on */
 
-#define CALLBACK(cb_name, ...) do {\
-	if (tty->cb.cb_name != NULL)\
-		tty->cb.cb_name(tty->cb.arg, ##__VA_ARGS__);\
+/* } DEBUG */
+
+#define CALLBACK(cb_name, ...) \
+	do { \
+		if (tty->cb.cb_name != NULL) \
+			tty->cb.cb_name(tty->cb.arg, ##__VA_ARGS__); \
 	} while (0)
 
-#define DEBUG_CHAR(c) do {\
-		*(tty->debug + 16) = (c);\
+#define DEBUG_CHAR(c) \
+	do { \
+		*(tty->debug + 16) = (c); \
 	} while (0)
 
 /* Control character should be printed using ^X notation. */
-#define CTL_PRINT(c)	((c) == 0x7f || ((unsigned char)(c) < 0x20 && ((c) != CTAB && (c) != CNL)))
+#define CTL_PRINT(c) ((c) == 0x7f || ((unsigned char)(c) < 0x20 && ((c) != CTAB && (c) != CNL)))
 /* Control character should be processed on echo. */
-#define CTL_ECHO(c)	((c) == CTAB || (c) == CNL || (c) == CCR)
+#define CTL_ECHO(c) ((c) == CTAB || (c) == CNL || (c) == CCR)
 /* Character is whitespace. */
-#define CTL_WHITE(c)	((c) == ' ' || (c) == CTAB)
+#define CTL_WHITE(c) ((c) == ' ' || (c) == CTAB)
 /* Character is alphanumeric. */
-#define CTL_ALNUM(c)	(((c) >= '0' && (c) <= '9') || \
-    ((c) >= 'a' && (c) <= 'z') || ((c) >= 'A' && (c) <= 'Z'))
+#define CTL_ALNUM(c) (((c) >= '0' && (c) <= '9') || \
+	((c) >= 'a' && (c) <= 'z') || ((c) >= 'A' && (c) <= 'Z'))
 
 /* writing chars to TX buffer without any futher processing */
-static int tx_write_ifspace(libtty_common_t* tty, const char* data, size_t len)
+static int tx_write_ifspace(libtty_common_t *tty, const char *data, size_t len)
 {
-	// WARN: no locking
-	const char* data_end = data + len;
+	/* WARN: no locking */
+	const char *data_end = data + len;
 
 	while ((data < data_end) && !fifo_is_full(tty->tx_fifo))
-		fifo_push(tty->tx_fifo, (uint8_t) *data++);
+		fifo_push(tty->tx_fifo, (uint8_t)*data++);
 
 	CALLBACK(signal_txready);
 	return len - (data_end - data);
@@ -119,7 +126,8 @@ static int libttydisc_echo(libtty_common_t *tty, char c)
 		 * and the character is an unquoted BS/TB/NL/CR.
 		 */
 		return libttydisc_write_oproc(tty, c);
-	} else if (CMP_FLAG(l, ECHOCTL) && CTL_PRINT(c)) {
+	}
+	else if (CMP_FLAG(l, ECHOCTL) && CTL_PRINT(c)) {
 		/*
 		 * Only use ^X notation when ECHOCTL is turned on and
 		 * we've got an quoted control character.
@@ -134,10 +142,12 @@ static int libttydisc_echo(libtty_common_t *tty, char c)
 
 		if (CMP_CC(VEOF, c)) {
 			return tx_write_ifspace(tty, ob, 4);
-		} else {
+		}
+		else {
 			return tx_write_ifspace(tty, ob, 2);
 		}
-	} else {
+	}
+	else {
 		/* Can just be printed. */
 		tx_write_ifspace(tty, &c, 1);
 	}
@@ -146,7 +156,7 @@ static int libttydisc_echo(libtty_common_t *tty, char c)
 }
 
 /* remove one char from RX buffer */
-static int libttydisc_rubchar(libtty_common_t* tty)
+static int libttydisc_rubchar(libtty_common_t *tty)
 {
 	char c;
 
@@ -167,14 +177,17 @@ static int libttydisc_rubchar(libtty_common_t* tty)
 				if (CMP_FLAG(l, ECHOCTL)) {
 					tx_write_ifspace(tty, "\b\b  \b\b", 6);
 				}
-			} else if (c == ' ') {
+			}
+			else if (c == ' ') {
 				/* Space character needs no rubbing. */
 				tx_write_ifspace(tty, "\b", 1);
-			} else {
+			}
+			else {
 				/* remove a regular character by punching a space over it. */
 				tx_write_ifspace(tty, "\b \b", 3);
 			}
-		} else {
+		}
+		else {
 			/* Don't print spaces. */
 			libttydisc_echo(tty, tty->term.c_cc[VERASE]);
 		}
@@ -183,23 +196,28 @@ static int libttydisc_rubchar(libtty_common_t* tty)
 	return 0;
 }
 
+
 int libtty_putchar(libtty_common_t *tty, unsigned char c, int *wake_reader)
 {
-	if (wake_reader)
+	if (wake_reader != NULL) {
 		*wake_reader = 0;
+	}
 
 	/* ISTRIP: removing the top bit */
-	if (CMP_FLAG(i, ISTRIP))
+	if (CMP_FLAG(i, ISTRIP)) {
 		c &= ~0x80;
+	}
 
 	/* ISIG: signal processing */
 	if (CMP_FLAG(l, ISIG)) {
 		int signal = 0;
 		if (CMP_CC(VINTR, c)) {
 			signal = SIGINT;
-		} else if (CMP_CC(VQUIT, c)) {
+		}
+		else if (CMP_CC(VQUIT, c)) {
 			signal = SIGQUIT;
-		} else if (CMP_CC(VSUSP, c)) {
+		}
+		else if (CMP_CC(VSUSP, c)) {
 			signal = SIGTSTP;
 		}
 
@@ -222,28 +240,33 @@ int libtty_putchar(libtty_common_t *tty, unsigned char c, int *wake_reader)
 		/* Accept the next character as literal. */
 		if (CMP_CC(VLNEXT, c)) {
 			if (CMP_FLAG(l, ECHO)) {
-				if (CMP_FLAG(l, ECHOE))
+				if (CMP_FLAG(l, ECHOE)) {
 					tx_write_ifspace(tty, "^\b", 2);
-				else
+				}
+				else {
 					libttydisc_echo(tty, c);
+				}
 			}
 			tty->t_flags |= TF_LITERAL;
-			return (0);
+			return 0;
 		}
 	}
 
 	/* INCRNL/INNLCR/IGNCR : conversion of CR and NL */
 	switch (c) {
-	case CCR:
-		if (CMP_FLAG(i, IGNCR))
-			return (0);
-		if (CMP_FLAG(i, ICRNL))
-			c = CNL;
-		break;
-	case CNL:
-		if (CMP_FLAG(i, INLCR))
-			c = CCR;
-		break;
+		case CCR:
+			if (CMP_FLAG(i, IGNCR)) {
+				return (0);
+			}
+			if (CMP_FLAG(i, ICRNL)) {
+				c = CNL;
+			}
+			break;
+		case CNL:
+			if (CMP_FLAG(i, INLCR)) {
+				c = CCR;
+			}
+			break;
 	}
 
 	/* ICANON: Canonical line editing. */
@@ -251,15 +274,19 @@ int libtty_putchar(libtty_common_t *tty, unsigned char c, int *wake_reader)
 		if (CMP_CC(VERASE, c) || CMP_CC(VERASE2, c)) {
 			libttydisc_rubchar(tty);
 			return 0;
-		} else if (CMP_CC(VKILL, c)) {
-			while (libttydisc_rubchar(tty) == 0);
+		}
+		else if (CMP_CC(VKILL, c)) {
+			while (libttydisc_rubchar(tty) == 0)
+				;
 			return 0;
 #if 0
-		} else if (CMP_FLAG(l, IEXTEN)) {
+		}
+		else if (CMP_FLAG(l, IEXTEN)) {
 			if (CMP_CC(VWERASE, c)) {
 				ttydisc_rubword(tp);
 				return (0);
-			} else if (CMP_CC(VREPRINT, c)) {
+			}
+			else if (CMP_CC(VREPRINT, c)) {
 				ttydisc_reprint(tp);
 				return (0);
 			}
@@ -279,17 +306,20 @@ processed:
 	libttydisc_echo(tty, c);
 
 	if (CMP_FLAG(l, ICANON)) {
-		// signal only when the line ends
+		/* signal only when the line ends */
 		if (libttydisc_is_breakchar(tty, c)) {
 			tty->t_flags |= TF_HAVEBREAK;
 
-			if (wake_reader)
+			if (wake_reader != NULL) {
 				*wake_reader = 1;
+			}
 			condSignal(tty->rx_waitq);
 		}
-	} else {
-		if (wake_reader)
+	}
+	else {
+		if (wake_reader != NULL) {
 			*wake_reader = 1;
+		}
 		condSignal(tty->rx_waitq);
 	}
 	mutexUnlock(tty->rx_mutex);
@@ -311,38 +341,40 @@ int libttydisc_write_oproc(libtty_common_t *tty, char c)
 
 #define PRINT_NORMAL() tx_write_ifspace(tty, &c, 1)
 	switch (c) {
-	case CEOF:
-		return PRINT_NORMAL();
+		case CEOF:
+			return PRINT_NORMAL();
 
-	case CTAB:
-		/* Tab expansion. */
-		if (CMP_FLAG(o, TAB3)) {
-			ret = tx_write_ifspace(tty, "        ", 8);
-		} else {
-			ret = PRINT_NORMAL();
-		}
-		return ret;
+		case CTAB:
+			/* Tab expansion. */
+			if (CMP_FLAG(o, TAB3)) {
+				ret = tx_write_ifspace(tty, "        ", 8);
+			}
+			else {
+				ret = PRINT_NORMAL();
+			}
+			return ret;
 
-	case CNL:
-		/* Newline conversion. */
-		if (CMP_FLAG(o, ONLCR)) {
-			/* Convert \n to \r\n. */
-			ret = tx_write_ifspace(tty, "\r\n", 2);
-		} else {
-			ret = PRINT_NORMAL();
-		}
-		return ret;
+		case CNL:
+			/* Newline conversion. */
+			if (CMP_FLAG(o, ONLCR)) {
+				/* Convert \n to \r\n. */
+				ret = tx_write_ifspace(tty, "\r\n", 2);
+			}
+			else {
+				ret = PRINT_NORMAL();
+			}
+			return ret;
 
-	case CCR:
-		/* Carriage return to newline conversion. */
-		if (CMP_FLAG(o, OCRNL))
-			c = CNL;
+		case CCR:
+			/* Carriage return to newline conversion. */
+			if (CMP_FLAG(o, OCRNL))
+				c = CNL;
 #if 0
-		/* Omit carriage returns on column 0. */
-		if (CMP_FLAG(o, ONOCR) && tp->t_column == 0)
-			return (0);
+			/* Omit carriage returns on column 0. */
+			if (CMP_FLAG(o, ONOCR) && tp->t_column == 0)
+				return (0);
 #endif
-		return PRINT_NORMAL();
+			return PRINT_NORMAL();
 	}
 
 	/*
@@ -353,15 +385,15 @@ int libttydisc_write_oproc(libtty_common_t *tty, char c)
 #undef PRINT_NORMAL
 }
 
-ssize_t libttydisc_read_canonical(libtty_common_t *tty, char *data, size_t size, unsigned mode, libtty_read_state_t* st)
+ssize_t libttydisc_read_canonical(libtty_common_t *tty, char *data, size_t size, unsigned mode, libtty_read_state_t *st)
 {
 	char byte = 0xff;
 	size_t len = 0;
 
 	if (st)
-		st->timeout_ms = -1; // default (finished)
+		st->timeout_ms = -1; /* default (finished) */
 
-	// check if we have break char in RX fifo
+	/* check if we have break char in RX fifo */
 	mutexLock(tty->rx_mutex);
 	do {
 		if (tty->t_flags & TF_HAVEBREAK)
@@ -377,30 +409,31 @@ ssize_t libttydisc_read_canonical(libtty_common_t *tty, char *data, size_t size,
 			return -EWOULDBLOCK;
 		}
 
-		if (st) { // nonblocking
-			st->timeout_ms = 0; // wait indefinitely
+		if (st) {               /* nonblocking */
+			st->timeout_ms = 0; /* wait indefinitely */
 			mutexUnlock(tty->rx_mutex);
-			return 0; // read will resume execution at a later time
-		} else {
-			// blocking wait for any of the chars from breakchars to be available in tty->rx_fifo
+			return 0; /* read will resume execution at a later time */
+		}
+		else {
+			/* blocking wait for any of the chars from breakchars to be available in tty->rx_fifo */
 			condWait(tty->rx_waitq, tty->rx_mutex, 0);
 		}
 	} while (1);
 
 	while (len < size) {
-		byte = (char) fifo_pop_back(tty->rx_fifo);
+		byte = (char)fifo_pop_back(tty->rx_fifo);
 		if (CMP_CC(VEOF, byte))
-			break; // EOF - dropping and exiting
+			break; /* EOF - dropping and exiting */
 
 		*data++ = byte;
 		len += 1;
 
 		if (libttydisc_is_breakchar(tty, byte))
-			break; // EOL - exiting after the byte was added
+			break; /* EOL - exiting after the byte was added */
 	}
 
-	if (libttydisc_is_breakchar(tty, byte)) { // loop ended due to breakchar
-		// check if we have another break char in the RX FIFO
+	if (libttydisc_is_breakchar(tty, byte)) { /* loop ended due to breakchar */
+		/* check if we have another break char in the RX FIFO */
 		tty->t_flags &= ~TF_HAVEBREAK;
 		if (CMP_FLAG(l, ICANON)) {
 			if (libttydisc_rx_have_breakchar(tty))
@@ -415,24 +448,25 @@ ssize_t libttydisc_read_canonical(libtty_common_t *tty, char *data, size_t size,
 ssize_t libttydisc_read_raw(libtty_common_t *tty, char *data, size_t size, unsigned mode, libtty_read_state_t *st)
 {
 	size_t vmin = tty->term.c_cc[VMIN];
-	time_t vtime = (time_t)tty->term.c_cc[VTIME] * 100; // deciseconds to ms
+	time_t vtime = (time_t)tty->term.c_cc[VTIME] * 100; /* deciseconds to ms */
 	time_t first_char_timeout = (vmin == 0) ? vtime : 0;
 	ssize_t len = 0;
 
 	if (st && st->timeout_ms >= 0) { /* continuing previous read */
 		int we_wanted_to_sleep_ms = (st->prevlen == 0) ? first_char_timeout : vtime;
 		if (fifo_is_empty(tty->rx_fifo)) {
-			if (we_wanted_to_sleep_ms == 0) // blocking read without timeout
+			if (we_wanted_to_sleep_ms == 0) /* blocking read without timeout */
 				return 0;
-			else if (st->timeout_ms > 0) { // no new data, wait some more time
+			else if (st->timeout_ms > 0) { /* no new data, wait some more time */
 				return 0;
-			} else { // st->timeout == 0, timer expired
+			}
+			else { /* st->timeout == 0, timer expired */
 				st->timeout_ms = -1;
-				return st->prevlen; // first- or interbyte timeout - return what we have
+				return st->prevlen; /* first- or interbyte timeout - return what we have */
 			}
 		}
 
-		st->timeout_ms = -1; // default (finished)
+		st->timeout_ms = -1; /* default (finished) */
 		len = st->prevlen;
 		data += st->prevlen;
 	}
@@ -444,15 +478,18 @@ ssize_t libttydisc_read_raw(libtty_common_t *tty, char *data, size_t size, unsig
 					return -EWOULDBLOCK;
 				else
 					break;
-			} else if (vmin == 0 && vtime == 0) { // polling read
+			}
+			else if (vmin == 0 && vtime == 0) { /* polling read */
 				break;
-			} else { // read until at least vmin with optional initial/interchar timeout
+			}
+			else { /* read until at least vmin with optional initial/interchar timeout */
 				if ((len == 0) || (len < vmin)) {
-					if (st) { // non-blocking wait
+					if (st) { /* non-blocking wait */
 						st->prevlen = len;
 						st->timeout_ms = (len == 0) ? first_char_timeout : vtime;
 						return 0;
-					} else { // blocking wait
+					}
+					else { /* blocking wait */
 						mutexLock(tty->rx_mutex);
 						while (fifo_is_empty(tty->rx_fifo)) {
 							if (tty->t_flags & TF_CLOSING) {
@@ -463,14 +500,14 @@ ssize_t libttydisc_read_raw(libtty_common_t *tty, char *data, size_t size, unsig
 							int ret = condWait(tty->rx_waitq, tty->rx_mutex, ((len == 0) ? first_char_timeout : vtime) * 1000);
 							if (ret == -ETIME) {
 								mutexUnlock(tty->rx_mutex);
-								return len; // timer expired
+								return len; /* timer expired */
 							}
 						}
 						mutexUnlock(tty->rx_mutex);
 					}
 				}
 				else
-					break; // at least vmin chars present
+					break; /* at least vmin chars present */
 			}
 		}
 

--- a/tty/libtty/libtty_disc.h
+++ b/tty/libtty/libtty_disc.h
@@ -24,12 +24,12 @@
 #include <termios.h>
 
 /* termios comparison macro's. */
-#define	CMP_CC(v,c) (tty->term.c_cc[v] != _POSIX_VDISABLE && \
-			tty->term.c_cc[v] == (c))
-#define	CMP_FLAG(field,opt) (tty->term.c_ ## field ## flag & (opt))
+#define CMP_CC(v, c) (tty->term.c_cc[v] != _POSIX_VDISABLE && \
+	tty->term.c_cc[v] == (c))
+#define CMP_FLAG(field, opt) (tty->term.c_##field##flag & (opt))
 
 /* Character is a control character. */
-#define CTL_VALID(c)	((c) == 0x7f || (unsigned char)(c) < 0x20)
+#define CTL_VALID(c) ((c) == 0x7f || (unsigned char)(c) < 0x20)
 
 
 /* maximum amount of chars outputed by libttydisc_write_oproc */
@@ -44,7 +44,7 @@ ssize_t libttydisc_read_raw(libtty_common_t *tty, char *data, size_t size, unsig
 
 static inline int libttydisc_is_breakchar(libtty_common_t *tty, char c)
 {
-	for (char* breakc = tty->breakchars; *breakc; ++breakc)
+	for (char *breakc = tty->breakchars; *breakc; ++breakc)
 		if (c == *breakc)
 			return 1;
 
@@ -53,7 +53,7 @@ static inline int libttydisc_is_breakchar(libtty_common_t *tty, char c)
 
 static inline int libttydisc_rx_have_breakchar(libtty_common_t *tty)
 {
-	char* breakc = tty->breakchars;
+	char *breakc = tty->breakchars;
 	while (*breakc) {
 		if (fifo_has_char(tty->rx_fifo, *breakc))
 			return 1;
@@ -65,4 +65,4 @@ static inline int libttydisc_rx_have_breakchar(libtty_common_t *tty)
 }
 
 
-#endif //_LIBTTY_DISC_H_
+#endif /* _LIBTTY_DISC_H_ */

--- a/tty/libtty/ttydefaults.h
+++ b/tty/libtty/ttydefaults.h
@@ -38,57 +38,57 @@
  * System wide defaults for terminal state.  Linux version.
  */
 #ifndef _TTYDEFAULTS_H_
-#define	_TTYDEFAULTS_H_
+#define _TTYDEFAULTS_H_
 
 /*
  * Defaults on "first" open.
  */
-#define	TTYDEF_IFLAG	(BRKINT | ISTRIP | ICRNL | IMAXBEL)
-#define TTYDEF_OFLAG	(OPOST | ONLCR | CR0 | NL0 | BS0 | TAB3 | VT0 | FF0)
-#define TTYDEF_LFLAG	(ECHO | ICANON | ISIG | IEXTEN | ECHOE|ECHOK|ECHOCTL)
-#define TTYDEF_CFLAG	(CREAD | CS8 | CLOCAL)
-#define TTYDEF_SPEED	(B115200)
+#define TTYDEF_IFLAG (BRKINT | ISTRIP | ICRNL | IMAXBEL)
+#define TTYDEF_OFLAG (OPOST | ONLCR | CR0 | NL0 | BS0 | TAB3 | VT0 | FF0)
+#define TTYDEF_LFLAG (ECHO | ICANON | ISIG | IEXTEN | ECHOE | ECHOK | ECHOCTL)
+#define TTYDEF_CFLAG (CREAD | CS8 | CLOCAL)
+#define TTYDEF_SPEED (B115200)
 
 /*
  * Control Character Defaults
  */
-#define CTRL(x)	(x&037)
-#define	CEOF		CTRL('d')
+#define CTRL(x) (x & 037)
+#define CEOF    CTRL('d')
 #ifdef _POSIX_VDISABLE
-# define CEOL		_POSIX_VDISABLE
+#define CEOL _POSIX_VDISABLE
 #else
-# define CEOL		'\0'		/* XXX avoid _POSIX_VDISABLE */
+#define CEOL '\0' /* XXX avoid _POSIX_VDISABLE */
 #endif
-#define	CERASE		0177
-#define	CERASE2		CTRL('H')
-#define	CINTR		CTRL('c')
+#define CERASE  0177
+#define CERASE2 CTRL('H')
+#define CINTR   CTRL('c')
 #ifdef _POSIX_VDISABLE
-# define CSTATUS	_POSIX_VDISABLE
+#define CSTATUS _POSIX_VDISABLE
 #else
-# define CSTATUS	'\0'		/* XXX avoid _POSIX_VDISABLE */
+#define CSTATUS '\0' /* XXX avoid _POSIX_VDISABLE */
 #endif
-#define	CKILL		CTRL('u')
-#define	CMIN		1
-#define	CQUIT		034		/* FS, ^\ */
-#define	CSUSP		CTRL('z')
-#define	CTIME		0
-#define	CDSUSP		CTRL('y')
-#define	CSTART		CTRL('q')
-#define	CSTOP		CTRL('s')
-#define	CLNEXT		CTRL('v')
-#define	CDISCARD 	CTRL('o')
-#define	CWERASE 	CTRL('w')
-#define	CREPRINT 	CTRL('r')
-#define	CEOT		CEOF
+#define CKILL    CTRL('u')
+#define CMIN     1
+#define CQUIT    034 /* FS, ^\ */
+#define CSUSP    CTRL('z')
+#define CTIME    0
+#define CDSUSP   CTRL('y')
+#define CSTART   CTRL('q')
+#define CSTOP    CTRL('s')
+#define CLNEXT   CTRL('v')
+#define CDISCARD CTRL('o')
+#define CWERASE  CTRL('w')
+#define CREPRINT CTRL('r')
+#define CEOT     CEOF
 /* compat */
-#define	CBRK		CEOL
-#define CRPRNT		CREPRINT
-#define	CFLUSH		CDISCARD
+#define CBRK   CEOL
+#define CRPRNT CREPRINT
+#define CFLUSH CDISCARD
 
 /* Characters that cannot be modified through c_cc. */
-#define CTAB	'\t'
-#define CNL	'\n'
-#define CCR	'\r'
+#define CTAB '\t'
+#define CNL  '\n'
+#define CCR  '\r'
 
 
 /* PROTECTED INCLUSION ENDS HERE */
@@ -98,7 +98,7 @@
  * #define TTYDEFCHARS to include an array of default control characters.
  */
 #ifdef TTYDEFCHARS
-cc_t	ttydefchars[NCCS] = {
+cc_t ttydefchars[NCCS] = {
 	CINTR, CQUIT, CERASE, CKILL, CEOF, CTIME, CMIN,
 	CSTART, CSTOP, CSUSP, CEOL, CREPRINT, CDISCARD,
 	CWERASE, CLNEXT, CERASE2, CEOL


### PR DESCRIPTION
JIRA: DEND-42

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add option to handle tty using DMA. Enablind DMA and buffer sizes are configurable.
UART interface will be done in separate PR.
Tested by sending 2048 characters at once.

## Motivation and Context
Handling using interrupts was too slow and resulted in dropping characters.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: stm32l4x6

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
