### PR TITLE
sensors: lis2mdl right-handness fix

### DIFF
--- a/sensors/mag/lis2mdl.c
+++ b/sensors/mag/lis2mdl.c
@@ -147,7 +147,7 @@ static void lis2mdl_threadPublish(void *data)
 		if (err >= 0) {
 			gettime(&(ctx->evt.timestamp), NULL);
 			ctx->evt.mag.magX = translateMag(ibuf[1], ibuf[0]);
-			ctx->evt.mag.magY = translateMag(ibuf[3], ibuf[2]);
+			ctx->evt.mag.magY = -translateMag(ibuf[3], ibuf[2]); /* minus accounts for non right-handness of measurement */
 			ctx->evt.mag.magZ = translateMag(ibuf[5], ibuf[4]);
 			sensors_publish(info->id, &ctx->evt);
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Inverting Y axis of lis2mdl measurement so that final measurement is in right-hand correct frame of reference.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Lis2mdl, by default, does not return data in frame of reference that follows the right-hand rule. Inverting its Y axis fixes the problem. Below is the screenshot of lis2mdl datasheet Rev 5, section 1.2 which presents the default axis directions:
![image](https://github.com/phoenix-rtos/phoenix-rtos-devices/assets/80880689/11d2d521-949f-4a0b-800b-093faaafdfd0)

Current code followed the lsm9ds1 magnetometer driver code which **did** follow the right hand rule, thus the fix needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zturn drone.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
