### PR TITLE
ade7913: remove unused part of API

### DIFF
--- a/adc/ade7913/adc-api-ade7913.h
+++ b/adc/ade7913/adc-api-ade7913.h
@@ -3,8 +3,8 @@
  *
  * ADE7913 driver API
  *
- * Copyright 2021 Phoenix Systems
- * Author: Marcin Baran
+ * Copyright 2021, 2023 Phoenix Systems
+ * Author: Marcin Baran, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -21,25 +21,17 @@
 
 #define ADC_DEVICE_FILE_NAME "/dev/ade7913"
 
-typedef enum {
-	adc_dev_ctl__enable,
-	adc_dev_ctl__disable,
-	adc_dev_ctl__reset,
-	adc_dev_ctl__status,
-	adc_dev_ctl__set_adc_mux,
-	adc_dev_ctl__set_config,
-	adc_dev_ctl__get_config,
-	adc_dev_ctl__get_buffers,
-	adc_dev_ctl__set_channel_gain,
-	adc_dev_ctl__get_channel_gain,
-	adc_dev_ctl__set_channel_calib,
-	adc_dev_ctl__get_channel_calib,
-	adc_dev_ctl__set_channel_config,
-	adc_dev_ctl__get_channel_config
-} adc_dev_ctl_type_t;
 
 typedef struct {
-	adc_dev_ctl_type_t type;
+	enum {
+		ade7913_dev_ctl__enable = 0,
+		ade7913_dev_ctl__disable,
+		ade7913_dev_ctl__reset,
+		ade7913_dev_ctl__status,
+		ade7913_dev_ctl__set_config,
+		ade7913_dev_ctl__get_config,
+		ade7913_dev_ctl__get_buffers,
+	} type;
 
 	union {
 		/* buffers */
@@ -52,46 +44,11 @@ typedef struct {
 		/* config */
 		struct {
 			uint32_t sampling_rate;
-			uint8_t channels;
-			uint8_t enabled_ch;
+			uint8_t devices;
 			uint8_t bits;
 		} config;
-
-		/* status */
-		struct {
-			uint8_t ch_status[8];
-			uint8_t dsp_status[4];
-			uint8_t general_err[2];
-			uint8_t status[3];
-		} status;
-
-		/* adc mux */
-		uint8_t mux;
-
-		/* if hardware reset */
-		uint8_t reset_hard;
-
-		/* channel calib */
-		struct {
-			uint32_t offset;
-			uint32_t gain;
-			uint8_t channel;
-		} calib;
-
-		/* channel gain */
-		struct {
-			uint32_t channel;
-			uint8_t val;
-		} gain;
-
-		/* channel config */
-		struct {
-			uint32_t channel;
-			unsigned gain : 6;
-			unsigned meter_rx_mode : 1;
-			unsigned ref_monitor_mode : 1;
-		} ch_config;
 	};
-} adc_dev_ctl_t;
+} ade7913_dev_ctl_t;
+
 
 #endif /* ADC_API_H */


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

After [separating the `API` of `ADE7913` and `AD7779`](https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/351), there is no need to maintain a common API anymore, especially since `ADE7913` does not require channel calibration (in chip) or channel selection (API may be simpler), each ADE7913 device has three channels (I0, V1, V2) by default (no option to disable particular channels). The application receives a stream of data from which it is able to read the device status, CRC along with samples.

JIRA: NIL-452

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

API readability.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1176-nil

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
