### PR TITLE
ade7913: remove strerror to reduce memory footprint

### DIFF
--- a/adc/ade7913/ade7913-driver.c
+++ b/adc/ade7913/ade7913-driver.c
@@ -386,7 +386,7 @@ static int adc_init(int hard)
 
 	res = ade7913_sync(&common.ade7913_spi, common.order, common.devcnt, 0);
 	if (res < 0) {
-		log_error("Could not synchronize ADE7913 devices: %s", strerror(res));
+		log_error("Could not synchronize ADE7913 devices (%d)", res);
 		return -1;
 	}
 


### PR DESCRIPTION
The ade7913 driver is run from RAM (dtcm), strerror messages are not needed to decode the reported error, it is more important to save memory.

JIRA: NIL-452

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: nil-imxrt1176

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
