### PR TITLE
makes: Add imxrt105x-evk support

### DIFF
--- a/_targets/Makefile.armv7m7-imxrt106x
+++ b/_targets/Makefile.armv7m7-imxrt106x
@@ -6,12 +6,12 @@
 # Copyright 2019 Phoenix Systems
 #
 
-DEFAULT_COMPONENTS := imxrt-multi libusbclient imxrt-flash cdc-demo
+DEFAULT_COMPONENTS := imxrt-multi
 
 ifneq (, $(findstring 117, $(TARGET)))
-  DEFAULT_COMPONENTS += imxrt117x-otp libusbehci umass usbacm
+  DEFAULT_COMPONENTS += libusbclient imxrt-flash cdc-demo imxrt117x-otp libusbehci umass usbacm
 else ifneq (, $(findstring 105, $(TARGET)))
   # placeholder
 else ifneq (, $(findstring 106, $(TARGET)))
-  DEFAULT_COMPONENTS += libimxrt-edma libusbehci umass usbacm
+  DEFAULT_COMPONENTS += libusbclient imxrt-flash cdc-demo libimxrt-edma libusbehci umass usbacm
 endif


### PR DESCRIPTION
Currently only imxrt-multi driver is supported on imxrt105x.

JIRA: RTOS-575

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt-1050-evk(a)`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
