### PR TITLE
ade7913: add on/off power supply control, extend flexpwm

### DIFF
--- a/adc/ade7913/adc-api-ade7913.h
+++ b/adc/ade7913/adc-api-ade7913.h
@@ -3,7 +3,7 @@
  *
  * ADE7913 driver API
  *
- * Copyright 2021, 2023 Phoenix Systems
+ * Copyright 2021-2024 Phoenix Systems
  * Author: Marcin Baran, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
@@ -31,6 +31,8 @@ typedef struct {
 		ade7913_dev_ctl__set_config,
 		ade7913_dev_ctl__get_config,
 		ade7913_dev_ctl__get_buffers,
+		ade7913_dev_ctl__pwr_off,
+		ade7913_dev_ctl__pwr_on,
 	} type;
 
 	union {

--- a/adc/ade7913/flexpwm.h
+++ b/adc/ade7913/flexpwm.h
@@ -3,7 +3,7 @@
  *
  * i.MX FlexPWM
  *
- * Copyright 2021-2022 Phoenix Systems
+ * Copyright 2021-2023 Phoenix Systems
  * Author: Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
@@ -14,21 +14,59 @@
 #ifndef FLEXPWM_H
 #define FLEXPWM_H
 
-#include <stdint.h>
+
+/* Flag for use in board config */
+#define FLEXPWM_BOARDCONFIG
 
 
-#define FLEXPWM_CAP_DISABLED     0
-#define FLEXPWM_CAP_EDGE_FALLING 1
-#define FLEXPWM_CAP_EDGE_RISING  2
-#define FLEXPWM_CAP_EDGE_ANY     3
+/* Device selector */
+#define FLEXPWM_PWM1 0u
+#define FLEXPWM_PWM2 1u
+#define FLEXPWM_PWM3 2u
+#define FLEXPWM_PWM4 3u
 
 
-/* Initialize base address */
-void flexpwm_init(void *base);
+/* Input capture edge setup */
+#define FLEXPWM_CAP_DISABLED     0u
+#define FLEXPWM_CAP_EDGE_FALLING 1u
+#define FLEXPWM_CAP_EDGE_RISING  2u
+#define FLEXPWM_CAP_EDGE_ANY     3u
+
+
+/* Submodule */
+#define FLEXPWM_SM0 0u
+#define FLEXPWM_SM1 1u
+#define FLEXPWM_SM2 2u
+#define FLEXPWM_SM3 3u
+
+
+/* PWM pin */
+#define FLEXPWM_PWMX 0u
+#define FLEXPWM_PWMB 1u
+#define FLEXPWM_PWMA 2u
+
+
+/* DMA Requests read/write */
+#define FLEXPWM_DMA_RREQ(dev, sm) (85u + (unsigned)(dev)*8u + (unsigned)(sm) + 0u)
+#define FLEXPWM_DMA_WREQ(dev, sm) (85u + (unsigned)(dev)*8u + (unsigned)(sm) + 4u)
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Initialize base address using dev index */
+int flexpwm_init(unsigned int dev);
 
 
 /* Configure input capture mode */
-int flexpwm_input_capture(unsigned int no, unsigned int cap0_edge, unsigned int cap1_edge);
+int flexpwm_input_capture(unsigned int sm, unsigned int pwm, unsigned int cap0_edge, unsigned int cap1_edge);
+
+
+#ifdef __cplusplus
+};
+#endif
 
 
 #endif /* end of FLEXPWM_H */


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

Changes introduced:
1. Moves DREADY config to board config
2. Adds possibility to setup all FlexPWMs (1-4) each of its submodules (0-3) and input pins A, B, X. In total 48 inputs.
3. Adds the functionality of turning on and off the power supply of ADCs for newer revisions of PCB.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

JIRA: NIL-456

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
