### PR TITLE
imxrt-multi: fix unhandled gpio 10-13 on rt117x

### DIFF
--- a/multi/imxrt-multi/imxrt-multi.c
+++ b/multi/imxrt-multi/imxrt-multi.c
@@ -79,6 +79,35 @@ static id_t multi_getID(msg_t *msg)
 }
 
 
+static void multi_handleError(msg_t *msg, int err)
+{
+	multi_o_t *omsg = (multi_o_t *)msg->o.raw;
+
+	switch (msg->type) {
+		case mtSetAttr:
+		case mtGetAttr:
+			msg->o.attr.err = err;
+			break;
+
+		case mtCreate:
+			msg->o.create.err = err;
+			break;
+
+		case mtLookup:
+			msg->o.lookup.err = err;
+			break;
+
+		case mtDevCtl:
+			omsg->err = err;
+			break;
+
+		default:
+			msg->o.io.err = err;
+			break;
+	}
+}
+
+
 static void multi_dispatchMsg(msg_t *msg)
 {
 	id_t id;
@@ -137,6 +166,9 @@ static void multi_dispatchMsg(msg_t *msg)
 			trng_handleMsg(msg);
 			break;
 #endif
+		default:
+			multi_handleError(msg, -ENODEV);
+			break;
 	}
 }
 

--- a/multi/imxrt-multi/imxrt-multi.c
+++ b/multi/imxrt-multi/imxrt-multi.c
@@ -131,6 +131,12 @@ static void multi_dispatchMsg(msg_t *msg)
 		case id_gpio7:
 		case id_gpio8:
 		case id_gpio9:
+#ifdef __CPU_IMXRT117X
+		case id_gpio10:
+		case id_gpio11:
+		case id_gpio12:
+		case id_gpio13:
+#endif
 			gpio_handleMsg(msg, id);
 			break;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

* Add default handler in case of unhandled device. The lack of a handler for gpio 10-13 resulted in an incorrect error return value.
* Fix unhandled GPIO no. 10-13 on i.MX RT117x target

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

JIRA: RTOS-601

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
