### PR TITLE
stm32l4-multi: Reorganize config, disable defaults

### DIFF
--- a/multi/stm32l4-multi/common.h
+++ b/multi/stm32l4-multi/common.h
@@ -19,8 +19,6 @@
 #include <phoenix/arch/stm32l4.h>
 #include <sys/platform.h>
 
-#include "config.h"
-
 
 #define NELEMS(x) (sizeof(x) / sizeof(x[0]))
 

--- a/multi/stm32l4-multi/config.h
+++ b/multi/stm32l4-multi/config.h
@@ -13,6 +13,9 @@
 #ifndef _CONFIG_H_
 #define _CONFIG_H_
 
+#include <board_config.h>
+
+/* UART */
 #ifndef UART1
 #define UART1 0
 #endif
@@ -46,24 +49,19 @@
 #endif
 
 #ifndef TTY4
-#define TTY4 1
+#define TTY4 0
 #endif
 
 #ifndef TTY5
 #define TTY5 0
 #endif
 
-#if (UART1 && TTY1) || (UART2 && TTY2) || (UART3 && TTY3) || \
-	(UART4 && TTY4) || (UART5 && TTY5)
-#error "Can't use UART as UART and TTY at the same time!"
-#endif
+/* UART_CONSOLE has to be specified in board_config.h */
 
-#ifndef UART_CONSOLE
-#define UART_CONSOLE 4
-#endif
 
+/* SPI */
 #ifndef SPI1
-#define SPI1 1
+#define SPI1 0
 #endif
 
 #ifndef SPI2
@@ -79,13 +77,15 @@
 #endif
 
 #ifndef SPI2_USEDMA
-#define SPI2_USEDMA 1
+#define SPI2_USEDMA 0
 #endif
 
 #ifndef SPI3_USEDMA
 #define SPI3_USEDMA 0
 #endif
 
+
+/* I2C */
 #ifndef I2C1
 #define I2C1 0
 #endif
@@ -102,8 +102,8 @@
 #define I2C4 0
 #endif
 
-#define CONSOLE_IS_TTY ((UART_CONSOLE == 1 && TTY1) || (UART_CONSOLE == 2 && TTY2) || (UART_CONSOLE == 3 && TTY3) || (UART_CONSOLE == 4 && TTY4) || (UART_CONSOLE == 5 && TTY5))
 
+/* dummyfs */
 #ifndef BUILTIN_DUMMYFS
 #define BUILTIN_DUMMYFS 1
 #endif

--- a/multi/stm32l4-multi/fs.c
+++ b/multi/stm32l4-multi/fs.c
@@ -11,7 +11,6 @@
  * %LICENSE%
  */
 
-#include <board_config.h>
 #include "config.h"
 
 #if BUILTIN_DUMMYFS

--- a/multi/stm32l4-multi/i2c.c
+++ b/multi/stm32l4-multi/i2c.c
@@ -21,6 +21,7 @@
 
 #include "stm32l4-multi.h"
 #include "common.h"
+#include "config.h"
 #include "gpio.h"
 #include "i2c.h"
 #include "rcc.h"

--- a/multi/stm32l4-multi/spi.c
+++ b/multi/stm32l4-multi/spi.c
@@ -25,6 +25,7 @@
 
 #include "stm32l4-multi.h"
 #include "common.h"
+#include "config.h"
 #include "rcc.h"
 #include "spi.h"
 

--- a/multi/stm32l4-multi/stm32l4-multi.c
+++ b/multi/stm32l4-multi/stm32l4-multi.c
@@ -24,6 +24,7 @@
 #include <libklog.h>
 
 #include "common.h"
+#include "config.h"
 
 #include "adc.h"
 #include "exti.h"
@@ -39,6 +40,30 @@
 #define THREADS_NO 3
 #define THREADS_PRIORITY 1
 #define STACKSZ 640
+
+
+#if (UART1 && TTY1) || (UART2 && TTY2) || (UART3 && TTY3) || \
+	(UART4 && TTY4) || (UART5 && TTY5)
+#error "Can't use UART as UART and TTY at the same time!"
+#endif
+
+#ifndef UART_CONSOLE
+#error "UART_CONSOLE not specified"
+#endif
+
+#if !(UART_CONSOLE == 1 && (UART1 || TTY1)) && \
+	!(UART_CONSOLE == 2 && (UART2 || TTY2)) && \
+	!(UART_CONSOLE == 3 && (UART3 || TTY3)) && \
+	!(UART_CONSOLE == 4 && (UART4 || TTY4)) && \
+	!(UART_CONSOLE == 5 && (UART5 || TTY5))
+#warning "Console enabled on disabled UART/TTY"
+#endif
+
+#define CONSOLE_IS_TTY ((UART_CONSOLE == 1 && TTY1) || \
+	(UART_CONSOLE == 2 && TTY2) || \
+	(UART_CONSOLE == 3 && TTY3) || \
+	(UART_CONSOLE == 4 && TTY4) || \
+	(UART_CONSOLE == 5 && TTY5))
 
 
 struct {
@@ -306,7 +331,10 @@ int main(void)
 	libklog_init(log_write);
 
 	/* Do this after klog init to keep shell from overtaking klog */
+
+#if CONSOLE_IS_TTY
 	tty_createDev();
+#endif
 
 	portRegister(common.port, "/multi", &oid);
 

--- a/multi/stm32l4-multi/tty.c
+++ b/multi/stm32l4-multi/tty.c
@@ -27,8 +27,8 @@
 #include <libtty-lf-fifo.h>
 
 #include "stm32l4-multi.h"
-#include "config.h"
 #include "common.h"
+#include "config.h"
 #include "gpio.h"
 #include "tty.h"
 #include "rcc.h"
@@ -367,29 +367,24 @@ static void tty_thread(void *arg)
 		priority(THREAD_PRIO);
 	}
 }
-#endif
 
 
 ssize_t tty_log(const char *str, size_t len)
 {
-#if CONSOLE_IS_TTY
 	return libtty_write(&tty_getCtx(0)->tty_common, str, len, 0);
-#endif
-	return 0;
 }
 
 
 void tty_createDev(void)
 {
-#if CONSOLE_IS_TTY
 	oid_t oid;
 
 	oid.port = uart_common.port;
 	oid.id = 0;
 	create_dev(&oid, _PATH_TTY);
 	create_dev(&oid, _PATH_CONSOLE);
-#endif
 }
+#endif
 
 
 int tty_init(void)

--- a/multi/stm32l4-multi/uart.c
+++ b/multi/stm32l4-multi/uart.c
@@ -22,8 +22,8 @@
 #include "libmulti/libuart.h"
 
 #include "stm32l4-multi.h"
-#include "config.h"
 #include "common.h"
+#include "config.h"
 #include "gpio.h"
 #include "uart.h"
 #include "rcc.h"


### PR DESCRIPTION
Peripherial defaults removed from config.h - project shallset required peripheria explicitly in board_config.h.

Added error when UART_CONSOLE is not set and warning on console setted to disabled UART. Moved errors to .c file to not reporting it many times.

Reduce config.h variable propagation by removing unnecessary includes and move computed variables to valid .c file.

JIRA: DEND-32

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better control of enabled/disabled peripheria via board_config
Small clean up.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
Need to define missing variables in case that project rely on that

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7m4-stm32l4x6-nucleo

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
