### PR TITLE
Makefile: Remove BOARD_CONFIG from CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@
 
 include ../phoenix-rtos-build/Makefile.common
 
-# TODO: replace BOARD_CONFIG usage with board_config.h
-CFLAGS += $(BOARD_CONFIG)
-
 .DEFAULT_GOAL := all
 
 # should define DEFAULT_COMPONENTS and target-specific variables


### PR DESCRIPTION
JIRA: DEND-32

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Removed passing BOARD_CONFIG via CFLAGS.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
BOARD_CONFIG env is deprectaed, new implementation should use board_config.h
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
Removed 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
