### PR TITLE
stm32l4: drop oldest bytes in case of overrun

### DIFF
--- a/multi/stm32l4-multi/config.h
+++ b/multi/stm32l4-multi/config.h
@@ -104,23 +104,43 @@
 #endif
 
 #ifndef TTY1_DMA_RXSZ
-#define TTY1_DMA_RXSZ 64
+#define TTY1_DMA_RXSZ 32
 #endif
 
 #ifndef TTY2_DMA_RXSZ
-#define TTY2_DMA_RXSZ 64
+#define TTY2_DMA_RXSZ 32
 #endif
 
 #ifndef TTY3_DMA_RXSZ
-#define TTY3_DMA_RXSZ 64
+#define TTY3_DMA_RXSZ 32
 #endif
 
 #ifndef TTY4_DMA_RXSZ
-#define TTY4_DMA_RXSZ 64
+#define TTY4_DMA_RXSZ 32
 #endif
 
 #ifndef TTY5_DMA_RXSZ
-#define TTY5_DMA_RXSZ 64
+#define TTY5_DMA_RXSZ 32
+#endif
+
+#ifndef TTY1_DMA_RXFIFOSZ
+#define TTY1_DMA_RXFIFOSZ 64
+#endif
+
+#ifndef TTY2_DMA_RXFIFOSZ
+#define TTY2_DMA_RXFIFOSZ 64
+#endif
+
+#ifndef TTY3_DMA_RXFIFOSZ
+#define TTY3_DMA_RXFIFOSZ 64
+#endif
+
+#ifndef TTY4_DMA_RXFIFOSZ
+#define TTY4_DMA_RXFIFOSZ 64
+#endif
+
+#ifndef TTY5_DMA_RXFIFOSZ
+#define TTY5_DMA_RXFIFOSZ 64
 #endif
 
 #ifndef TTY1_DMA_TXSZ

--- a/tty/libtty/libtty-lf-fifo.h
+++ b/tty/libtty/libtty-lf-fifo.h
@@ -93,4 +93,13 @@ static inline int lf_fifo_pop(lf_fifo_t *f, uint8_t *byte)
 }
 
 
+static inline int lf_fifo_empty(lf_fifo_t *f)
+{
+	unsigned int headPos = atomic_load_explicit(&f->headPos, memory_order_seq_cst);
+	unsigned int tailPos = atomic_fetch_or_explicit(&f->tail, 1, memory_order_seq_cst) >> 1;
+
+	return headPos == tailPos;
+}
+
+
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/426
- [ ] I will merge this PR by myself when appropriate.
