### PR TITLE
imxrt-multi: make fs & uart priority settable also

### DIFF
--- a/multi/imxrt-multi/config.h
+++ b/multi/imxrt-multi/config.h
@@ -26,6 +26,10 @@
 #include "imxrt1060.h"
 #endif
 
+#ifndef IMXRT_MULTI_PRIO
+#define IMXRT_MULTI_PRIO 2
+#endif
+
 /* UART */
 
 #ifndef UART1

--- a/multi/imxrt-multi/fs.c
+++ b/multi/imxrt-multi/fs.c
@@ -158,7 +158,7 @@ int fs_init(void)
 		return -1;
 	}
 
-	if (beginthread(msgthr, 4, fs_common.stack, MSGTHR_STACKSZ, ctx) != EOK) {
+	if (beginthread(msgthr, IMXRT_MULTI_PRIO, fs_common.stack, MSGTHR_STACKSZ, ctx) != EOK) {
 		dummyfs_unmount(ctx);
 		portDestroy(fs_common.port);
 		return -1;

--- a/multi/imxrt-multi/imxrt-multi.c
+++ b/multi/imxrt-multi/imxrt-multi.c
@@ -43,10 +43,6 @@
 #define MULTI_THREADS_NO 2
 #define UART_THREADS_NO 2
 
-#ifndef IMXRT_MULTI_PRIO
-#define IMXRT_MULTI_PRIO 2
-#endif
-
 #define STACKSZ 512
 
 

--- a/multi/imxrt-multi/uart.c
+++ b/multi/imxrt-multi/uart.c
@@ -770,7 +770,7 @@ int uart_init(void)
 		/* Enable TX and RX */
 		*(uart->base + ctrlr) |= (1 << 19) | (1 << 18);
 
-		beginthread(uart_intrThread, 2, &uart->stack, sizeof(uart->stack), uart);
+		beginthread(uart_intrThread, IMXRT_MULTI_PRIO, &uart->stack, sizeof(uart->stack), uart);
 		interrupt(info[dev].irq, uart_handleIntr, (void *)uart, uart->cond, NULL);
 	}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

Allows you to change the priority of `imxrt-multi` (all threads) at once - as desired by the project (board_config using `IMXRT_MULTI_PRIO`). If `libdummyfs` is linked to `imxrt-multi`, it will use its priority (imxrt-multi), this fixes race problem with `imxrt-flash` on write to flash, when `libdummyfs` is used.

JIRA: NIL-459


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
