### PR TITLE
imxrt-flash: optimize opRead/opWrite add cpu yield

### DIFF
--- a/storage/imxrt-flash/fspi.c
+++ b/storage/imxrt-flash/fspi.c
@@ -3,7 +3,7 @@
  *
  * FlexSPI Controller driver
  *
- * Copyright 2021-2022 Phoenix Systems
+ * Copyright 2021-2023 Phoenix Systems
  * Author: Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
@@ -16,6 +16,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
+#include <sys/time.h>
 #include <unistd.h>
 #include "fspi.h"
 
@@ -39,11 +40,33 @@ enum { mcr0 = 0, mcr1, mcr2, ahbcr, inten, intr, lutkey, lutcr, ahbrxbuf0cr0, ah
 
 /* clang-format on */
 
+
+static inline void fspi_schedYield(void)
+{
+	(void)usleep(0);
+	/*
+	 * NOTICE: this schedYield is only valid when used with a scheduler that is able to block FLASH (xip)
+	 * threads from execution (threads with a lower priority than the higher priority RAM code).
+	 * Otherwise, adjust the implementation of this function as needed, following the same principles
+	 * as for the implementation of enter/exit critical sections.
+	 */
+}
+
+
+static time_t fspi_timerGetMillis(void)
+{
+	struct timespec ts;
+	(void)clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (time_t)(((unsigned long long)ts.tv_sec) * 1000uLL + ((unsigned long long)(ts.tv_nsec / 1000000L)));
+}
+
+
 void flexspi_swreset(flexspi_t *fspi)
 {
-	*(fspi->base + mcr0) |= 1;
-	while ((*(fspi->base + mcr0) & 1) != 0)
-		;
+	*(fspi->base + mcr0) |= 1u;
+	while ((*(fspi->base + mcr0) & 1u) != 0u) {
+		fspi_schedYield();
+	}
 }
 
 
@@ -52,8 +75,8 @@ static addr_t flexspi_getAddressByPort(flexspi_t *fspi, uint8_t port, addr_t add
 	unsigned int i;
 
 	/* FlexSPI use the port (chip select) based on an offset of each memory size */
-	for (i = 0; i < port; ++i) {
-		if (fspi->slPortMask & (1 << i)) {
+	for (i = 0u; i < port; ++i) {
+		if (fspi->slPortMask & (1u << i)) {
 			addr += fspi->slFlashSz[i];
 		}
 	}
@@ -64,18 +87,18 @@ static addr_t flexspi_getAddressByPort(flexspi_t *fspi, uint8_t port, addr_t add
 
 static int flexspi_checkFlags(flexspi_t *fspi)
 {
-	uint32_t flags = *(fspi->base + intr) & ((1 << 1) | (1 << 3) | (1 << 11));
+	uint32_t flags = *(fspi->base + intr) & ((1u << 1u) | (1u << 3u) | (1u << 11u));
 
-	if (flags != 0) {
+	if (flags != 0u) {
 		/* Clear flags */
 		*(fspi->base + intr) |= flags;
 
 		/* Reset FIFOs */
-		*(fspi->base + iptxfcr) |= 1;
-		*(fspi->base + iprxfcr) |= 1;
+		*(fspi->base + iptxfcr) |= 1u;
+		*(fspi->base + iprxfcr) |= 1u;
 
 		/* Command grant or sequence execution timeout */
-		if (flags & ((1 << 11) | (1 << 1))) {
+		if (flags & ((1u << 11u) | (1u << 1u))) {
 			return -ETIME;
 		}
 
@@ -89,173 +112,137 @@ static int flexspi_checkFlags(flexspi_t *fspi)
 static ssize_t flexspi_opRead(flexspi_t *fspi, time_t start, struct xferOp *xfer)
 {
 	int res;
-	size_t cnt, ofs, len = xfer->data.read.sz, size = xfer->data.read.sz & ~7;
-	uint8_t *buf = xfer->data.read.ptr;
+	uint8_t *ptr = xfer->data.read.ptr;
+	uint8_t *end = ptr + xfer->data.read.sz;
 
-	/* note: FlexSPI FIFO watermark level is 64bit aligned */
-	for (ofs = 0; ofs < size; ofs += 8, buf += 8, len -= 8) {
+	while (ptr != end) {
+		volatile uint8_t *rfdr = (volatile uint8_t *)(fspi->base + rfdr32); /* 2x */
+
 		/* Wait for rx FIFO available */
-		for (cnt = 0; (*(fspi->base + intr) & (1 << 5)) == 0; ++cnt) {
+		while ((*(fspi->base + intr) & (1u << 5u)) == 0u) {
 			res = flexspi_checkFlags(fspi);
 			if (res != EOK) {
 				return res;
 			}
-			else if (xfer->timeout > 0 && cnt > 10000000) {
+			else if ((xfer->timeout > 0uLL) && ((fspi_timerGetMillis() - start) >= xfer->timeout)) {
 				return -ETIME;
 			}
+			fspi_schedYield();
 		}
 
-		((uint32_t *)buf)[0] = (fspi->base + rfdr32)[0];
-		((uint32_t *)buf)[1] = (fspi->base + rfdr32)[1];
+		/* FlexSPI FIFO watermark level is 64bit aligned */
+		for (size_t n = sizeof(uint64_t); (n != 0u) && (ptr != end); --n) {
+			*(ptr++) = *(rfdr++);
+		}
 
 		/* Move FIFO pointer to watermark level */
-		*(fspi->base + intr) |= 1 << 5;
+		*(fspi->base + intr) |= 1u << 5u;
 	}
 
-	if (ofs < xfer->data.read.sz) {
-		size_t cnt = 0;
-		/* Wait for rx FIFO available */
-		for (cnt = 0; (*(fspi->base + intr) & (1 << 5)) == 0; ++cnt) {
-			res = flexspi_checkFlags(fspi);
-			if (res != EOK) {
-				return res;
-			}
-			else if (xfer->timeout > 0 && cnt > 10000000) {
-				return -ETIME;
-			}
+	while ((*(fspi->base + sts0) & 3u) != 3u) {
+		if (xfer->timeout > 0uLL && (fspi_timerGetMillis() - start) >= xfer->timeout) {
+			return -ETIME;
 		}
-
-		for (ofs = rfdr32; len > 0; ++ofs) {
-			uint32_t tmp = *(fspi->base + ofs); /* is volatile! */
-			size = len < sizeof(tmp) ? len : sizeof(tmp);
-			memcpy(buf, &tmp, size);
-			len -= size;
-			buf += size;
-		}
-		/* Move FIFO pointer to watermark level */
-		*(fspi->base + intr) |= 1 << 5;
+		fspi_schedYield();
 	}
 
-	/* FIXME: delay of ~27us */
-	for (uint32_t i = 0x10000; i > 0; --i) {
-		asm volatile("nop");
-	}
-
-	/* Reset rx FIFO */
-	*(fspi->base + iprxfcr) |= 1;
-
-	return buf - (uint8_t *)xfer->data.read.ptr;
+	return (ssize_t)xfer->data.read.sz;
 }
 
 
 static ssize_t flexspi_opWrite(flexspi_t *fspi, time_t start, struct xferOp *xfer)
 {
 	int res;
-	size_t cnt, ofs, len = xfer->data.write.sz, size = xfer->data.write.sz & ~7;
-	const uint8_t *buf = xfer->data.write.ptr;
+	const uint8_t *ptr = xfer->data.write.ptr;
+	const uint8_t *end = ptr + xfer->data.write.sz;
 
-	/* note: FlexSPI FIFO watermark level is 64bit aligned */
-	for (ofs = 0; ofs < size; ofs += 8, buf += 8, len -= 8) {
+	while (ptr != end) {
+		volatile uint8_t *tfdr = (volatile uint8_t *)(fspi->base + tfdr32); /* 2x */
+
 		/* Wait for tx FIFO available */
-		for (cnt = 0; (*(fspi->base + intr) & (1 << 6)) == 0; ++cnt) {
+		while ((*(fspi->base + intr) & (1u << 6u)) == 0u) {
 			res = flexspi_checkFlags(fspi);
 			if (res != EOK) {
 				return res;
 			}
-			else if (xfer->timeout > 0 && cnt > 10000000) {
+			else if ((xfer->timeout > 0uLL) && ((fspi_timerGetMillis() - start) >= xfer->timeout)) {
 				return -ETIME;
 			}
+			fspi_schedYield();
 		}
 
-		(fspi->base + tfdr32)[0] = ((uint32_t *)buf)[0];
-		(fspi->base + tfdr32)[1] = ((uint32_t *)buf)[1];
+		/* FlexSPI FIFO watermark level is 64bit aligned */
+		for (size_t n = sizeof(uint64_t); (n != 0u) && (ptr != end); --n) {
+			*(tfdr++) = *(ptr++);
+		}
 
 		/* Move tx FIFO pointer to watermark level */
-		*(fspi->base + intr) |= 1 << 6;
+		*(fspi->base + intr) |= 1u << 6u;
 	}
 
-	if (ofs < xfer->data.write.sz) {
-		/* Wait for tx FIFO available */
-		for (cnt = 0; (*(fspi->base + intr) & (1 << 6)) == 0; ++cnt) {
-			res = flexspi_checkFlags(fspi);
-			if (res != EOK) {
-				return res;
-			}
-			else if (xfer->timeout > 0 && cnt > 10000000) {
-				return -ETIME;
-			}
+	while ((*(fspi->base + sts0) & 3u) != 3u) {
+		if (xfer->timeout > 0uLL && (fspi_timerGetMillis() - start) >= xfer->timeout) {
+			return -ETIME;
 		}
-
-		for (ofs = tfdr32; len > 0; ++ofs) {
-			uint32_t tmp;
-			size = len < sizeof(tmp) ? len : sizeof(tmp);
-			memcpy(&tmp, buf, size);
-			*(fspi->base + ofs) = tmp;
-			len -= size;
-			buf += size;
-		}
-		/* Move FIFO pointer to watermark level */
-		*(fspi->base + intr) |= 1 << 6;
+		fspi_schedYield();
 	}
 
-	/* Reset tx FIFO */
-	*(fspi->base + iptxfcr) |= 1;
-
-	return buf - (uint8_t *)xfer->data.write.ptr;
+	return (ssize_t)xfer->data.write.sz;
 }
 
 
 ssize_t flexspi_xferExec(flexspi_t *fspi, struct xferOp *xfer)
 {
-	uint32_t dataSize, cnt;
-	time_t start = 0;
+	uint32_t dataSize;
+	time_t start = fspi_timerGetMillis();
 
 	if (xfer->op == xfer_opRead) {
 		/* For >64k read out the data directly from the AHB buffer (data may be cached) */
-		if (xfer->data.read.sz > 0xffff) {
+		if (xfer->data.read.sz > 0xffffu) {
 			memcpy(xfer->data.read.ptr, fspi->ahbAddr + xfer->addr, xfer->data.read.sz);
 			return EOK;
 		}
 
-		dataSize = xfer->data.read.sz & 0xffff;
+		dataSize = xfer->data.read.sz & 0xffffu;
 	}
 	else if (xfer->op == xfer_opWrite) {
 		/* IP write is limited to IPDATSZ mask */
-		if (xfer->data.read.sz > 0xffff) {
+		if (xfer->data.read.sz > 0xffffu) {
 			return -EPERM;
 		}
 
-		dataSize = xfer->data.write.sz & 0xffff;
+		dataSize = xfer->data.write.sz & 0xffffu;
 	}
 	else {
 		dataSize = 0;
 	}
 
-	/* Wait for AHB & IP bus and sequence controller to be idle */
-	for (cnt = 0; ((*(fspi->base + sts0) & 3) ^ 3) != 0; ++cnt) {
-		if (xfer->timeout > 0 && cnt > 10000000) {
+	/* Wait for either AHB & IP bus ready or sequence controller to be idle */
+	while ((*(fspi->base + sts0) & 3u) != 3u) {
+		if (xfer->timeout > 0uLL && (fspi_timerGetMillis() - start) >= xfer->timeout) {
 			return -ETIME;
 		}
+		fspi_schedYield();
 	}
 
 	/* Clear the instruction pointer */
-	*(fspi->base + flsha1cr2 + xfer->port) |= 1u << 31;
+	*(fspi->base + flsha1cr2 + xfer->port) |= 1u << 31u;
 
 	/* Clear any triggered AHB & IP errors and grant timeouts */
-	*(fspi->base + intr) |= (1 << 4) | (1 << 3) | (1 << 2) | (1 << 1);
+	*(fspi->base + intr) |= (1u << 4u) | (1u << 3u) | (1u << 2u) | (1u << 1u);
 
 	/* Set device's start address of transfer */
 	*(fspi->base + ipcr0) = flexspi_getAddressByPort(fspi, xfer->port, xfer->addr);
 
-	/* Reset tx/rx FIFOs, no DMA */
-	*(fspi->base + iptxfcr) = (*(fspi->base + iptxfcr) & ~3) | 1;
-	*(fspi->base + iprxfcr) = (*(fspi->base + iprxfcr) & ~3) | 1;
+	/* Clear tx/rx FIFOs */
+	*(fspi->base + iptxfcr) |= 1u;
+	*(fspi->base + iprxfcr) |= 1u;
 
 	/* Configure sequence index[number] and set xfer data size using "individual" mode */
-	*(fspi->base + ipcr1) = dataSize | ((xfer->seqIdx & 0xf) << 16) | ((xfer->seqNum & 0x7) << 24);
+	*(fspi->base + ipcr1) = dataSize | ((xfer->seqIdx & 0xfu) << 16u) | ((xfer->seqNum & 0x7u) << 24u);
 
 	/* Trigger an IP transfer now */
-	*(fspi->base + ipcmd) |= 1;
+	*(fspi->base + ipcmd) |= 1u;
 
 	switch (xfer->op) {
 		case xfer_opWrite:
@@ -271,14 +258,15 @@ ssize_t flexspi_xferExec(flexspi_t *fspi, struct xferOp *xfer)
 	}
 
 	/* Wait for IP command complete */
-	for (cnt = 0; (*(fspi->base + intr) & 1) == 0; ++cnt) {
-		if (xfer->timeout > 0 && cnt > 10000000) {
+	while ((*(fspi->base + intr) & 1u) == 0u) {
+		if (xfer->timeout > 0uLL && (fspi_timerGetMillis() - start) >= xfer->timeout) {
 			return -ETIME;
 		}
+		fspi_schedYield();
 	}
 
 	/* Acknowledge */
-	*(fspi->base + intr) |= 1;
+	*(fspi->base + intr) |= 1u;
 
 	return flexspi_checkFlags(fspi);
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

Change replaces busy waits with calls to reschedule (yield) using `usleep(0)`. Applies optimizations to opRead/opWrite, and adds millisecond timer which handles timed out operations.

JIRA: RTOS-678

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`, `imxrt1064-evk`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
