### PR TITLE
imxrt-flash: implement read from window buffer

### DIFF
--- a/storage/imxrt-flash/flashdrv.c
+++ b/storage/imxrt-flash/flashdrv.c
@@ -3,7 +3,7 @@
  *
  * i.MX RT Flash driver
  *
- * Copyright 2019-2023 Phoenix Systems
+ * Copyright 2019-2024 Phoenix Systems
  * Author: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
@@ -96,7 +96,6 @@ static ssize_t bufferSync(flash_context_t *ctx, uint32_t dstAddr, int isLast)
 
 		if (ctx->properties.sector_size <= dstAddr) {
 			ctx->prevAddr = (uint32_t)-1;
-			ctx->syncAddr = (uint32_t)-1;
 		}
 
 		if (isLast != 0) {
@@ -229,7 +228,7 @@ int flash_sync(flash_context_t *ctx)
 		return EOK;
 	}
 
-	if ((ctx->prevAddr == ctx->syncAddr) && (ctx->isDirty == 0)) {
+	if (ctx->isDirty == 0) {
 		return EOK;
 	}
 
@@ -274,7 +273,6 @@ int flash_sync(flash_context_t *ctx)
 	 * to AHB reads during XIP which is cached, and the cache should be invalidated.
 	 */
 
-	ctx->syncAddr = ctx->prevAddr;
 	ctx->isDirty = 0;
 
 	return EOK;
@@ -319,7 +317,6 @@ int flash_init(flash_context_t *ctx)
 	int res = EOK;
 
 	ctx->prevAddr = (uint32_t)-1;
-	ctx->syncAddr = (uint32_t)-1;
 	ctx->isDirty = 0;
 	ctx->buff = NULL;
 

--- a/storage/imxrt-flash/flashdrv.h
+++ b/storage/imxrt-flash/flashdrv.h
@@ -41,7 +41,6 @@ typedef struct {
 	time_t timeout;
 
 	uint32_t prevAddr;
-	uint32_t syncAddr;
 
 	uint8_t *buff;
 } flash_context_t;

--- a/storage/imxrt-flash/flashdrv.h
+++ b/storage/imxrt-flash/flashdrv.h
@@ -3,8 +3,8 @@
  *
  * i.MX RT Flash driver
  *
- * Copyright 2019, 2020 Phoenix Systems
- * Author: Hubert Buczynski
+ * Copyright 2019, 2020, 2023 Phoenix Systems
+ * Author: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -33,6 +33,7 @@ typedef struct {
 	flash_properties_t properties;
 	flexspi_t fspi;
 	uint8_t port;
+	uint8_t isDirty;
 
 	uint32_t address;
 	uint32_t instance;
@@ -42,17 +43,20 @@ typedef struct {
 	uint32_t prevAddr;
 	uint32_t syncAddr;
 
-	char *buff;
+	uint8_t *buff;
 } flash_context_t;
 
 
-ssize_t flash_readData(flash_context_t *ctx, uint32_t offset, void *buff, size_t size);
+ssize_t flash_directRead(flash_context_t *ctx, uint32_t offset, void *buff, size_t size);
 
 
-ssize_t flash_directBytesWrite(flash_context_t *ctx, uint32_t offset, const void *buff, size_t size);
+ssize_t flash_directWrite(flash_context_t *ctx, uint32_t offset, const void *buff, size_t size);
 
 
-ssize_t flash_bufferedPagesWrite(flash_context_t *ctx, uint32_t offset, const void *buff, size_t size);
+ssize_t flash_bufferedRead(flash_context_t *ctx, uint32_t srcAddr, void *dstPtr, size_t size);
+
+
+ssize_t flash_bufferedWrite(flash_context_t *ctx, uint32_t offset, const void *buff, size_t size);
 
 
 int flash_sync(flash_context_t *ctx);

--- a/storage/imxrt-flash/flashsrv.c
+++ b/storage/imxrt-flash/flashsrv.c
@@ -274,6 +274,18 @@ static void flashsrv_devCtl(flash_memory_t *memory, msg_t *msg)
 			odevctl->err = flashsrv_directWrite(memory->fOid.id, idevctl->addr, msg->i.data, msg->i.size);
 			break;
 
+		case flashsrv_devctl_directRead:
+			TRACE("imxrt-flashsrv: flashsrv_devctl_directRead, addr: %u, size: %u, id: %u, port: %u.",
+				idevctl->addr, msg->o.size, idevctl->oid.id, idevctl->oid.port);
+
+			if (idevctl->addr >= memory->ctx.properties.size) {
+				odevctl->err = -EINVAL;
+				break;
+			}
+
+			odevctl->err = flashsrv_directRead(memory->fOid.id, idevctl->addr, msg->o.data, msg->o.size);
+			break;
+
 		default:
 			odevctl->err = -EINVAL;
 			break;

--- a/storage/imxrt-flash/imxrt-flashsrv.h
+++ b/storage/imxrt-flash/imxrt-flashsrv.h
@@ -19,7 +19,12 @@
 #include <sys/msg.h>
 
 
-enum { flashsrv_devctl_properties = 0, flashsrv_devctl_sync, flashsrv_devctl_eraseSector, flashsrv_devctl_erasePartition, flashsrv_devctl_directWrite };
+/* clang-format off */
+
+enum { flashsrv_devctl_properties = 0, flashsrv_devctl_sync, flashsrv_devctl_eraseSector,
+	flashsrv_devctl_erasePartition, flashsrv_devctl_directWrite, flashsrv_devctl_directRead };
+
+/* clang-format on */
 
 
 typedef struct {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

The change implements reading from the window of write buffer while the source area is overlapping with window of write buffer space. The goal of this implementation is to make reads consistent with the buffered write mechanism through posix API (open, read/write, close) and to force write of pending buffer data using sync.

The change adjusts the naming of functions used internally (directRead/Write vs bufferedRead/Write)

API changes: direct reading of raw partition is moved to devctl. Using posix (read/write) it is possible to use buffered reads and writes only.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

JIRA: NIL-479

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
