### PR TITLE
zynq7000: fixes and improvements for QEMU

### DIFF
--- a/storage/zynq7000-sdcard/sdstorage_dev.c
+++ b/storage/zynq7000-sdcard/sdstorage_dev.c
@@ -524,7 +524,7 @@ int sdstorage_handleInsertion(unsigned int slot)
 	strg->dev->mtd->type = mtd_norFlash;
 	strg->dev->mtd->name = "SD CARD";
 	strg->dev->mtd->erasesz = (eraseSize < MTD_DEFAULT_ERASESZ) ? MTD_DEFAULT_ERASESZ : eraseSize;
-	strg->dev->mtd->writesz = SDCARD_BLOCKLEN;
+	strg->dev->mtd->writesz = 1;
 	strg->dev->mtd->writeBuffsz = SDCARD_BLOCKLEN;
 	strg->dev->mtd->metaSize = 0;
 	strg->dev->mtd->oobSize = 0;


### PR DESCRIPTION
Fix for SD card driver to work on QEMU, small improvement in NOR flash driver performance, 

## Description
* SD card: SD host controller on QEMU works a bit differently from the one on physical hardware and needed a small adjustment.
* SD card: Set emulated MTD device minimum write size to 1 so that existing rootfs images can be mounted.
* NOR flash: Small improvement in QSPI transfer performance by locking mutex once per function call instead of once per loop iteration.

## Motivation and Context
SD card driver is useful under QEMU because it is much faster than the emulated NOR flash driver. It may be desirable to mount rootfs from the emulated SD card.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a9-zynq7000-zturn, armv7a9-zynq7000-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
