### PR TITLE
improve stm32l4 IRQ uart driver

### DIFF
--- a/multi/stm32l4-multi/libmulti/include/libmulti/libuart.h
+++ b/multi/stm32l4-multi/libmulti/include/libmulti/libuart.h
@@ -36,6 +36,7 @@ typedef struct {
 
 			char *volatile rxdfifo;
 			size_t rxdfifosz;
+			volatile unsigned int rxnblock; /* set to 1 to read imdiately available bytes only */
 			volatile unsigned int rxdr;
 			volatile unsigned int rxdw;
 			volatile char *volatile rxbeg;

--- a/multi/stm32l4-multi/libmulti/include/libmulti/libuart.h
+++ b/multi/stm32l4-multi/libmulti/include/libmulti/libuart.h
@@ -85,6 +85,7 @@ int libuart_configure(libuart_ctx *ctx, char bits, char parity, unsigned int bau
 int libuart_write(libuart_ctx *ctx, const void *buff, unsigned int bufflen);
 
 
+/* timeout in milliseconds - zero disables timeout */
 int libuart_read(libuart_ctx *ctx, void *buff, unsigned int count, char mode, unsigned int timeout);
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change improves IRQ uart performance. Changing inter octet timeout to absolute timeout allows passing bigger read buffers without risk of long block.

## Motivation and Context
Currently IRQ uart does not work reliably on _redacted_ project that uses STM32 with limited CPU clock. Problems seem to appear mostly when both TX and RX are used. With this changes 9600 seems to be working without issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to change)