### PR TITLE
imxrt-flash: add custom flashsrv init option

### DIFF
--- a/storage/imxrt-flash/imxrt-flashsrv.h
+++ b/storage/imxrt-flash/imxrt-flashsrv.h
@@ -35,16 +35,36 @@ typedef struct {
 
 
 typedef struct {
+	uint32_t size;
+	uint32_t psize;
+	uint32_t ssize;
+	uint32_t offs;
+} flashsrv_properties_t;
+
+
+typedef struct {
 	int err;
 
-	struct {
-		uint32_t size;
-		uint32_t psize;
-		uint32_t ssize;
-		uint32_t offs;
-	} properties;
+	flashsrv_properties_t properties;
 
 } __attribute__((packed)) flash_o_devctl_t;
+
+
+/*
+ * Device/partition operations
+ *
+ * Includes parameters and callbacks which allow to perform direct operations (read/write/sector erase) on specific
+ * device/partition. Callbacks are initialized by flashsrv. User should provide *fID* inside flashsrv_customIntInit()
+ * call. It should be passed as the first argument to callbacks.
+ */
+typedef struct {
+	uint8_t fID;
+
+	ssize_t (*read)(uint8_t fID, size_t offset, void *data, size_t size);
+	ssize_t (*write)(uint8_t fID, size_t offset, const void *data, size_t size);
+	int (*eraseSector)(uint8_t fID, uint32_t offs);
+	int (*getProperties)(uint8_t fID, flashsrv_properties_t *p);
+} flashsrv_partitionOps_t;
 
 
 #endif


### PR DESCRIPTION
Allows to perform direct operations (read/write/sector erase) on specific device/partition from user code.

JIRA:NIL-471

<!--- Provide a general summary of your changes in the Title above -->

## Description
as above

## Motivation and Context
Overriding custom init function and utilizing internal flashsrv functions creates a safe way for operating on partitions with sensitive data (e.g. program code). Message interface for such partition can be stripped of write/read/erase functions to increase safety.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7m7-imxrt117x-nil

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
