### PR TITLE
imxrt-multi: add support for optional libposixsrv

### DIFF
--- a/multi/imxrt-multi/Makefile
+++ b/multi/imxrt-multi/Makefile
@@ -8,14 +8,14 @@ NAME := imxrt-multi
 
 LOCAL_PATH := $(call my-dir)
 
-LOCAL_SRCS = imxrt-multi.c common.c uart.c gpio.c spi.c fs.c
+LOCAL_SRCS = imxrt-multi.c common.c uart.c gpio.c spi.c fs.c posixsrv.c
 ifneq ($(TARGET_SUBFAMILY), imxrt117x)
   LOCAL_SRCS += i2c.c trng.c
 else
   LOCAL_SRCS += cm4.c
 endif
 DEP_LIBS := libtty libklog libpseudodev
-LIBS := libdummyfs libklog libpseudodev
+LIBS := libdummyfs libklog libpseudodev libposixsrv
 LOCAL_HEADERS := imxrt-multi.h
 
 include $(binary.mk)

--- a/multi/imxrt-multi/imxrt-multi.c
+++ b/multi/imxrt-multi/imxrt-multi.c
@@ -581,6 +581,11 @@ extern int fs_init(void);
 #endif
 
 
+#if BUILTIN_POSIXSRV
+extern int posixsrv_start(void);
+#endif
+
+
 int main(void)
 {
 	int i;
@@ -618,6 +623,10 @@ int main(void)
 
 #if CM4
 	cm4_init();
+#endif
+
+#if BUILTIN_POSIXSRV
+	posixsrv_start();
 #endif
 
 #if PSEUDODEV

--- a/multi/imxrt-multi/posixsrv.c
+++ b/multi/imxrt-multi/posixsrv.c
@@ -1,0 +1,54 @@
+/*
+ * Phoenix-RTOS
+ *
+ * i.MX RT builtin posix server (libposixsrv)
+ *
+ * Copyright 2023-2024 Phoenix Systems
+ * Author: Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <board_config.h>
+#include "config.h"
+
+#if BUILTIN_POSIXSRV
+
+#include <posixsrv.h>
+#include <sys/threads.h>
+
+#ifndef POSIXSRV_PRIO
+#define POSIXSRV_PRIO IMXRT_MULTI_PRIO
+#endif
+
+#ifndef POSIXSRV_THREADS_NO
+#define POSIXSRV_THREADS_NO 1
+#endif
+
+
+struct {
+	char stacks[2 + POSIXSRV_THREADS_NO][_PAGE_SIZE] __attribute__((aligned(8)));
+	unsigned srvPort;
+	unsigned eventPort;
+} libposixsrv_common;
+
+
+int posixsrv_start(void)
+{
+	if (posixsrv_init(&libposixsrv_common.srvPort, &libposixsrv_common.eventPort) < 0) {
+		return -1;
+	}
+
+	beginthread(posixsrv_threadRqTimeout, POSIXSRV_PRIO, libposixsrv_common.stacks[0], sizeof(libposixsrv_common.stacks[0]), NULL);
+	beginthread(posixsrv_threadMain, POSIXSRV_PRIO, libposixsrv_common.stacks[1], sizeof(libposixsrv_common.stacks[1]), (void *)libposixsrv_common.eventPort);
+
+	for (int i = 2; i < sizeof(libposixsrv_common.stacks) / sizeof(libposixsrv_common.stacks[0]); ++i) {
+		beginthread(posixsrv_threadMain, POSIXSRV_PRIO, libposixsrv_common.stacks[i], sizeof(libposixsrv_common.stacks[i]), (void *)libposixsrv_common.srvPort);
+	}
+
+	return 0;
+}
+
+#endif


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

Add optional support for `libposixsrv` on i.MX (`rt1176`, `rt1064`), but use `libpseudodev` on `rt1052`, because of low RAM footprint.

`libpseudeodev` and `libposixsrv` may conflict and shall be used exclusively.

In [board_config.h](https://github.com/phoenix-rtos/phoenix-rtos-project/blob/master/_projects/armv7m7-imxrt117x-evk/board_config.h#L20) comment out `#define PSEUDODEV 1` and add `#define BUILTIN_POSIXSRV 1`

<!--- Provide a general summary of your changes in the Title above -->


![2024-01-26-090611_1508x1232_scrot](https://github.com/phoenix-rtos/phoenix-rtos-devices/assets/141153/fd374851-4a88-441a-b2e6-f5784fc2f9f9)

memory usage (builtin posixsrv, without libpseudodev):
![2024-01-26-090935_1208x670_scrot](https://github.com/phoenix-rtos/phoenix-rtos-devices/assets/141153/2c742b6a-fb1f-4421-ba1e-8af1a59c4cf8)

memory usage (builtin pseudodev, without libposixsrv)
![2024-01-26-091520_1369x651_scrot](https://github.com/phoenix-rtos/phoenix-rtos-devices/assets/141153/d9042fd6-a249-4711-914f-7eb8095a6536)

memory map:
```
0 itcm   262144 bytes
1 dtcm   163840 bytes
2 ocram2 524288 bytes
3 xip1   4194304 bytes
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

mostly ptys, pipes

JIRA: RTOS-641


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `mimxrt1176-evk`, `mimxrt1064-evk`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-build/pull/176
https://github.com/phoenix-rtos/phoenix-rtos-project/pull/984
- [ ] I will merge this PR by myself when appropriate.
