### PR TITLE
uarthw-riscv: fix format warning

### DIFF
--- a/tty/uart16550/uarthw-riscv.c
+++ b/tty/uart16550/uarthw-riscv.c
@@ -44,7 +44,7 @@ void uarthw_write(void *hwctx, unsigned int reg, uint8_t val)
 
 char *uarthw_dump(void *hwctx, char *s, size_t sz)
 {
-	snprintf(s, sz, "base=%p irq=%u", ((uarthw_ctx_t *)hwctx)->base, ((uarthw_ctx_t *)hwctx)->irq);
+	snprintf(s, sz, "base=%p irq=%u", (void *)((uarthw_ctx_t *)hwctx)->base, ((uarthw_ctx_t *)hwctx)->irq);
 	return s;
 }
 


### PR DESCRIPTION
Fixes warning:

![2024-01-26-120010_1887x755_scrot](https://github.com/phoenix-rtos/phoenix-rtos-devices/assets/141153/0c686a74-ee50-4d89-a5d5-d9d87f67487f)


JIRA: RTOS-555

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
