### PR TITLE
imxrt-multi/spi: Fix RX FIFO being read too early

### DIFF
--- a/multi/imxrt-multi/spi.c
+++ b/multi/imxrt-multi/spi.c
@@ -188,13 +188,16 @@ static int spi_performTranscation(int spi, unsigned char cs, const uint8_t *txBu
 		else
 			txFifoBytes = MAX_FIFOSZ_BYTES;
 
+		txWordsCnt = (txFifoBytes + WORD_SIZE - 1) / WORD_SIZE;
+		/* Set rx watermark */
+		*(spi_common[spi].base + spi_fcr) = (*(spi_common[spi].base + spi_fcr) & ~(0xf << 16)) | (((txWordsCnt - 1) & 0xf) << 16);
+
 		/* Fill transmit FIFO */
 		spi_txBytes(spi, txBuff, txFifoBytes);
 		txBuff += txFifoBytes;
 		size -= txFifoBytes;
 
 		/* Transfer data into slave */
-		txWordsCnt = *(spi_common[spi].base + spi_fsr) & 0x1f;
 		spi_initTransmition(spi);
 
 		/* RCV data from slave */


### PR DESCRIPTION
DONE: RTOS-755

<!--- Provide a general summary of your changes in the Title above -->

`spi_transaction` msg may return (read) less bytes than requested (e.g. 8 out of 10). RX FIFO watermark is set to 0 on `spi_config` msg and never changed, meaning that _Receive Data_ event is asserted after putting one word into FIFO. This change sets the RX watermark to an appropriate value so that data is read after it is fully received. 

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt-1170.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
