### PR TITLE
stm32l4-multi: add support for optional libposixsrv

### DIFF
--- a/multi/stm32l4-multi/Makefile
+++ b/multi/stm32l4-multi/Makefile
@@ -10,6 +10,6 @@ NAME := stm32l4-multi
 SRCS := $(wildcard $(LOCAL_PATH)*.c)
 LOCAL_HEADERS := stm32l4-multi.h
 DEP_LIBS := libstm32l4-multi libtty libklog
-LIBS := libdummyfs libklog
+LIBS := libdummyfs libklog libposixsrv
 
 include $(binary.mk)

--- a/multi/stm32l4-multi/config.h
+++ b/multi/stm32l4-multi/config.h
@@ -253,4 +253,10 @@
 #define BUILTIN_DUMMYFS 1
 #endif
 
+/* libposixsrv (disabled by default) */
+#ifndef BUILTIN_POSIXSRV
+#define BUILTIN_POSIXSRV 0
+#endif
+
+
 #endif

--- a/multi/stm32l4-multi/posixsrv.c
+++ b/multi/stm32l4-multi/posixsrv.c
@@ -1,0 +1,53 @@
+/*
+ * Phoenix-RTOS
+ *
+ * STM32L4 builtin posix server (libposixsrv)
+ *
+ * Copyright 2024 Phoenix Systems
+ * Author: Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "config.h"
+
+#if BUILTIN_POSIXSRV
+
+#include <posixsrv.h>
+#include <sys/threads.h>
+
+#ifndef POSIXSRV_PRIO
+#define POSIXSRV_PRIO 4
+#endif
+
+#ifndef POSIXSRV_THREADS_NO
+#define POSIXSRV_THREADS_NO 1
+#endif
+
+
+struct {
+	char stacks[2 + POSIXSRV_THREADS_NO][_PAGE_SIZE] __attribute__((aligned(8)));
+	unsigned srvPort;
+	unsigned eventPort;
+} libposixsrv_common;
+
+
+int posixsrv_start(void)
+{
+	if (posixsrv_init(&libposixsrv_common.srvPort, &libposixsrv_common.eventPort) < 0) {
+		return -1;
+	}
+
+	beginthread(posixsrv_threadRqTimeout, POSIXSRV_PRIO, libposixsrv_common.stacks[0], sizeof(libposixsrv_common.stacks[0]), NULL);
+	beginthread(posixsrv_threadMain, POSIXSRV_PRIO, libposixsrv_common.stacks[1], sizeof(libposixsrv_common.stacks[1]), (void *)libposixsrv_common.eventPort);
+
+	for (int i = 2; i < sizeof(libposixsrv_common.stacks) / sizeof(libposixsrv_common.stacks[0]); ++i) {
+		beginthread(posixsrv_threadMain, POSIXSRV_PRIO, libposixsrv_common.stacks[i], sizeof(libposixsrv_common.stacks[i]), (void *)libposixsrv_common.srvPort);
+	}
+
+	return 0;
+}
+
+#endif

--- a/multi/stm32l4-multi/stm32l4-multi.c
+++ b/multi/stm32l4-multi/stm32l4-multi.c
@@ -306,6 +306,11 @@ extern int fs_init(void);
 #endif
 
 
+#if BUILTIN_POSIXSRV
+extern int posixsrv_start(void);
+#endif
+
+
 int main(void)
 {
 	int i;
@@ -335,6 +340,10 @@ int main(void)
 	uart_init();
 	rng_init();
 	libklog_init(log_write);
+
+#if BUILTIN_POSIXSRV
+	posixsrv_start();
+#endif
 
 	/* Do this after klog init to keep shell from overtaking klog */
 


### PR DESCRIPTION
This change adds `libposixsrv` to stm32l4-multi (`stm32l4-nucleo` target). The use of `libposixsrv` is optional and can be enabled by defining `BUILTIN_POSIXSRV` in `boardconfig.h` per project.

Requires update in phoenix-rtos-build 
https://github.com/phoenix-rtos/phoenix-rtos-build/pull/179
and in phoenix-rtos-project
https://github.com/phoenix-rtos/phoenix-rtos-project/pull/1019

![2024-02-16-192626_1404x1501_scrot](https://github.com/phoenix-rtos/phoenix-rtos-devices/assets/141153/844382a1-b31b-49c7-a19e-152fb7ec1ea5)

JIRA: RTOS-641

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `stm32l4a6-nucleo`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-build/pull/179
- [ ] I will merge this PR by myself when appropriate.
