### PR TITLE
usb/ehci: fix root hub descriptors

### DIFF
--- a/usb/ehci/ehci-hub.c
+++ b/usb/ehci/ehci-hub.c
@@ -35,7 +35,7 @@ static const struct {
 	const char manufacturer[16];
 } __attribute__((packed)) ehci_descs = {
 	{
-		.bLength = 18,
+		.bLength = sizeof(ehci_descs.dev),
 		.bcdUSB = 0x0200,
 		.bDeviceClass = USB_CLASS_HUB,
 		.bDeviceSubClass = 0,
@@ -50,9 +50,9 @@ static const struct {
 		.bNumConfigurations = 1,
 	},
 	{
-		.bLength = 9,
+		.bLength = sizeof(ehci_descs.cfg),
 		.bDescriptorType = USB_DESC_CONFIG,
-		.wTotalLength = 40,
+		.wTotalLength = sizeof(ehci_descs.cfg) + sizeof(ehci_descs.iface) + sizeof(ehci_descs.ep),
 		.bNumInterfaces = 1,
 		.bConfigurationValue = 1,
 		.iConfiguration = 0,
@@ -60,8 +60,8 @@ static const struct {
 		.bMaxPower = 0,
 	},
 	{
-		.bLength = 9,
-		.bDescriptorType = USB_DESC_CONFIG,
+		.bLength = sizeof(ehci_descs.iface),
+		.bDescriptorType = USB_DESC_INTERFACE,
 		.bInterfaceNumber = 0,
 		.bAlternateSetting = 0,
 		.bNumEndpoints = 1,
@@ -71,7 +71,7 @@ static const struct {
 		.iInterface = 0,
 	},
 	{
-		.bLength = 7,
+		.bLength = sizeof(ehci_descs.ep),
 		.bDescriptorType = USB_DESC_ENDPOINT,
 		.bEndpointAddress = USB_ENDPT_DIR_IN | (1 << 7),
 		.bmAttributes = USB_ENDPT_TYPE_INTR,
@@ -290,11 +290,11 @@ static int ehci_getDesc(usb_dev_t *hub, int type, int index, char *buf, size_t s
 
 	switch (type) {
 		case USB_DESC_DEVICE:
-			bytes = min(size, sizeof(ehci_descs.dev));
+			bytes = min(size, ehci_descs.dev.bLength);
 			memcpy(buf, &ehci_descs.dev, bytes);
 			break;
 		case USB_DESC_CONFIG:
-			bytes = min(size, sizeof(ehci_descs.dev) + sizeof(ehci_descs.iface) + sizeof(ehci_descs.ep));
+			bytes = min(size, ehci_descs.cfg.wTotalLength);
 			memcpy(buf, &ehci_descs.cfg, bytes);
 			break;
 		case USB_DESC_STRING:


### PR DESCRIPTION

## Description
EHCI root hub currently returns incorrect data (and incorrect amount of data) when queried for the configuration descriptor. This PR fixes the problem.

## Motivation and Context
Currently the code [parsing configuration descriptors](https://github.com/phoenix-rtos/phoenix-rtos-usb/blob/7358b3f44e0bbb66606381618f49437fd5f3cc75/usb/dev.c#L238) in phoenix-rtos-usb requires a special case for the root hub because the descriptor cannot be parsed otherwise.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7m7-imxrt106x-evk

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
