### PR TITLE
imxrt-multi/uart: add intermediate rx fifo between irq handler and thread

### DIFF
--- a/multi/imxrt-multi/config.h
+++ b/multi/imxrt-multi/config.h
@@ -193,9 +193,11 @@
 #define UART12_BAUDRATE 0
 #endif
 
+/* clang-format off */
+
 #define UART_BAUDRATES \
 	UART1_BAUDRATE, \
-	UART3_BAUDRATE, \
+	UART2_BAUDRATE, \
 	UART3_BAUDRATE, \
 	UART4_BAUDRATE, \
 	UART5_BAUDRATE, \
@@ -206,6 +208,8 @@
 	UART10_BAUDRATE, \
 	UART11_BAUDRATE, \
 	UART12_BAUDRATE
+
+/* clang-format on */
 
 #ifndef UART_CONSOLE
 #if defined(__CPU_IMXRT105X)

--- a/multi/imxrt-multi/config.h
+++ b/multi/imxrt-multi/config.h
@@ -32,8 +32,16 @@
 
 /* UART */
 
+#ifndef UART_BUFSIZE
+#define UART_BUFSIZE 512
+#endif
+
 #ifndef UART1
 #define UART1 1
+#endif
+
+#ifndef UART1_BUFSIZE
+#define UART1_BUFSIZE UART_BUFSIZE
 #endif
 
 #ifndef UART1_HW_FLOWCTRL
@@ -48,6 +56,10 @@
 #define UART2 0
 #endif
 
+#ifndef UART2_BUFSIZE
+#define UART2_BUFSIZE UART_BUFSIZE
+#endif
+
 #ifndef UART2_HW_FLOWCTRL
 #define UART2_HW_FLOWCTRL 0
 #endif
@@ -58,6 +70,10 @@
 
 #ifndef UART3
 #define UART3 0
+#endif
+
+#ifndef UART3_BUFSIZE
+#define UART3_BUFSIZE UART_BUFSIZE
 #endif
 
 #ifndef UART3_HW_FLOWCTRL
@@ -72,6 +88,10 @@
 #define UART4 0
 #endif
 
+#ifndef UART4_BUFSIZE
+#define UART4_BUFSIZE UART_BUFSIZE
+#endif
+
 #ifndef UART4_HW_FLOWCTRL
 #define UART4_HW_FLOWCTRL 0
 #endif
@@ -82,6 +102,10 @@
 
 #ifndef UART5
 #define UART5 0
+#endif
+
+#ifndef UART5_BUFSIZE
+#define UART5_BUFSIZE UART_BUFSIZE
 #endif
 
 #ifndef UART5_HW_FLOWCTRL
@@ -96,6 +120,10 @@
 #define UART6 0
 #endif
 
+#ifndef UART6_BUFSIZE
+#define UART6_BUFSIZE UART_BUFSIZE
+#endif
+
 #ifndef UART6_HW_FLOWCTRL
 #define UART6_HW_FLOWCTRL 0
 #endif
@@ -108,6 +136,10 @@
 #define UART7 0
 #endif
 
+#ifndef UART7_BUFSIZE
+#define UART7_BUFSIZE UART_BUFSIZE
+#endif
+
 #ifndef UART7_HW_FLOWCTRL
 #define UART7_HW_FLOWCTRL 0
 #endif
@@ -118,6 +150,10 @@
 
 #ifndef UART8
 #define UART8 0
+#endif
+
+#ifndef UART8_BUFSIZE
+#define UART8_BUFSIZE UART_BUFSIZE
 #endif
 
 #ifndef UART8_HW_FLOWCTRL
@@ -134,6 +170,10 @@
 #define UART9 0
 #endif
 
+#ifndef UART9_BUFSIZE
+#define UART9_BUFSIZE UART_BUFSIZE
+#endif
+
 #ifndef UART9_HW_FLOWCTRL
 #define UART9_HW_FLOWCTRL 0
 #endif
@@ -144,6 +184,10 @@
 
 #ifndef UART10
 #define UART10 0
+#endif
+
+#ifndef UART10_BUFSIZE
+#define UART10_BUFSIZE UART_BUFSIZE
 #endif
 
 #ifndef UART10_HW_FLOWCTRL
@@ -158,6 +202,10 @@
 #define UART11 1
 #endif
 
+#ifndef UART11_BUFSIZE
+#define UART11_BUFSIZE UART_BUFSIZE
+#endif
+
 #ifndef UART11_HW_FLOWCTRL
 #define UART11_HW_FLOWCTRL 0
 #endif
@@ -170,6 +218,10 @@
 #define UART12 0
 #endif
 
+#ifndef UART12_BUFSIZE
+#define UART12_BUFSIZE UART_BUFSIZE
+#endif
+
 #ifndef UART12_HW_FLOWCTRL
 #define UART12_HW_FLOWCTRL 0
 #endif
@@ -180,15 +232,19 @@
 
 #else
 #define UART9 0
+#define UART9_BUFSIZE      0
 #define UART9_HW_FLOWCTRL 0
 #define UART9_BAUDRATE 0
 #define UART10 0
+#define UART10_BUFSIZE     0
 #define UART10_HW_FLOWCTRL 0
 #define UART10_BAUDRATE 0
 #define UART11 0
+#define UART11_BUFSIZE     0
 #define UART11_HW_FLOWCTRL 0
 #define UART11_BAUDRATE 0
 #define UART12 0
+#define UART12_BUFSIZE     0
 #define UART12_HW_FLOWCTRL 0
 #define UART12_BAUDRATE 0
 #endif
@@ -208,6 +264,20 @@
 	UART10_BAUDRATE, \
 	UART11_BAUDRATE, \
 	UART12_BAUDRATE
+
+#define UART_BUFSIZES \
+	UART1_BUFSIZE, \
+	UART2_BUFSIZE, \
+	UART3_BUFSIZE, \
+	UART4_BUFSIZE, \
+	UART5_BUFSIZE, \
+	UART6_BUFSIZE, \
+	UART7_BUFSIZE, \
+	UART8_BUFSIZE, \
+	UART9_BUFSIZE, \
+	UART10_BUFSIZE, \
+	UART11_BUFSIZE, \
+	UART12_BUFSIZE
 
 /* clang-format on */
 

--- a/multi/imxrt-multi/uart.c
+++ b/multi/imxrt-multi/uart.c
@@ -48,9 +48,6 @@
 
 #define UART_CNT (UART1 + UART2 + UART3 + UART4 + UART5 + UART6 + UART7 + UART8 + UART9 + UART10 + UART11 + UART12)
 
-#ifndef UART_BUFSIZE
-#define UART_BUFSIZE 512
-#endif
 
 #ifndef UART_RXFIFOSIZE
 #define UART_RXFIFOSIZE 128
@@ -738,6 +735,7 @@ int uart_init(void)
 	uart_initPins();
 
 	const uint32_t default_baud[] = { UART_BAUDRATES };
+	const uint32_t tty_bufsz[] = { UART_BUFSIZES };
 
 	for (i = 0, dev = 0; dev < sizeof(uartConfig) / sizeof(uartConfig[0]); ++dev) {
 		if (!uartConfig[dev])
@@ -760,8 +758,9 @@ int uart_init(void)
 		callbacks.set_cflag = set_cflag;
 		callbacks.signal_txready = signal_txready;
 
-		if (libtty_init(&uart->tty_common, &callbacks, UART_BUFSIZE, libtty_int_to_baudrate(default_baud[dev])) < 0)
+		if (libtty_init(&uart->tty_common, &callbacks, tty_bufsz[dev], libtty_int_to_baudrate(default_baud[dev])) < 0) {
 			return -1;
+		}
 
 		lf_fifo_init(&uart->rxFifoCtx, uart->rxFifoData, sizeof(uart->rxFifoData));
 

--- a/multi/imxrt-multi/uart.c
+++ b/multi/imxrt-multi/uart.c
@@ -72,7 +72,6 @@ typedef struct uart_s {
 
 struct {
 	uart_t uarts[UART_CNT];
-	unsigned int port;
 } uart_common;
 
 
@@ -715,7 +714,7 @@ int uart_init(void)
 		uart->base = info[dev].base;
 
 #ifdef __CPU_IMXRT117X
-		common_setClock(info[dev].dev, 0, 0, 0, 0, 1);
+		common_setClock(info[dev].dev, -1, -1, -1, -1, 1);
 #else
 		common_setClock(info[dev].dev, clk_state_run);
 #endif


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

#### imxrt-multi/uart: add intermediate rxfifo (irq-thread)
    
The rx overrun flag is cleared in the interrupt handler. The hardware fifo turns out to be too small (four octets) and cannot be increased (read only register on imxrt1176). RX bytes were lost in irq handler. To solve the issue this change adds small FIFO between the interrupt and the thread to improve performance significantly. "Lock-free FIFO" from libtty implementation used to accomplish this.
    
Additionally, statistics regarding the counting of (software and hardware) overrun events are introduced.

Removed unused variable in uart_common, and corrected clock settings for imxrt1176 to behave like on imxrt10xx (just make clock run).

#### imxrt-multi/uart: allow per instance UARTx_BUFSIZE

This change allows to set libtty buffers for each uart instance separately. By default, the UART_BUFSIZE setting for an instance will be overridden by the UARTx_BUFSIZE (x - instance number) setting when defined in the board configuration.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
