### PR TITLE
stm32l4-multi/uart: Set txend before setting txbeg for safety

### DIFF
--- a/multi/stm32l4-multi/libmulti/libuart.c
+++ b/multi/stm32l4-multi/libmulti/libuart.c
@@ -262,8 +262,10 @@ static int libuart_irqWrite(libuart_ctx *ctx, const void *buff, unsigned int buf
 
 	keepidle(1);
 
-	ctx->data.irq.txbeg = (void *)((unsigned char *)buff);
+	assert(ctx->data.irq.txbeg == NULL);
+
 	ctx->data.irq.txend = (void *)((unsigned char *)buff + bufflen);
+	ctx->data.irq.txbeg = (void *)((unsigned char *)buff);
 	*(ctx->base + cr1) |= 1 << 7;
 
 	while (ctx->data.irq.txbeg != NULL) {


### PR DESCRIPTION
DONE: RTOS-815

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
