### PR TITLE
imxrt-multi: fix bug in spi initialization

### DIFF
--- a/multi/imxrt-multi/spi.c
+++ b/multi/imxrt-multi/spi.c
@@ -394,9 +394,8 @@ static int spi_getIsel(int mux, int *isel, int *val)
 
 static int spi_muxVal(int spi, int mux)
 {
-	if ((mux >= pctl_mux_gpio_lpsr_06 &&
-					mux <= pctl_mux_gpio_lpsr_08) ||
-					mux == pctl_mux_gpio_lpsr_12) {
+	if ((mux >= pctl_mux_gpio_lpsr_06 && mux <= pctl_mux_gpio_lpsr_08) ||
+		mux == pctl_mux_gpio_lpsr_12) {
 		/*
 		 * Note that SPIs are numbered from zero in the configuration structure.
 		 * Physical SPI5 corresponds to SPI4 in SPI init struct and
@@ -414,78 +413,78 @@ static int spi_muxVal(int spi, int mux)
 	}
 
 	switch (mux) {
-		case pctl_mux_gpio_ad_28 :
-		case pctl_mux_gpio_ad_29 :
-		case pctl_mux_gpio_ad_30 :
-		case pctl_mux_gpio_ad_31 :
+		case pctl_mux_gpio_ad_28:
+		case pctl_mux_gpio_ad_29:
+		case pctl_mux_gpio_ad_30:
+		case pctl_mux_gpio_ad_31:
 			return 0;
 
-		case pctl_mux_gpio_ad_24 :
-		case pctl_mux_gpio_ad_25 :
-		case pctl_mux_gpio_ad_26 :
-		case pctl_mux_gpio_ad_27 :
-		case pctl_mux_gpio_lpsr_02 :
-		case pctl_mux_gpio_lpsr_03 :
-		case pctl_mux_gpio_lpsr_04 :
-		case pctl_mux_gpio_lpsr_05 :
+		case pctl_mux_gpio_ad_24:
+		case pctl_mux_gpio_ad_25:
+		case pctl_mux_gpio_ad_26:
+		case pctl_mux_gpio_ad_27:
+		case pctl_mux_gpio_lpsr_02:
+		case pctl_mux_gpio_lpsr_03:
+		case pctl_mux_gpio_lpsr_04:
+		case pctl_mux_gpio_lpsr_05:
 			return 1;
 
-		case pctl_mux_gpio_ad_18 :
-		case pctl_mux_gpio_ad_19 :
-		case pctl_mux_gpio_ad_20 :
-		case pctl_mux_gpio_ad_21 :
-		case pctl_mux_gpio_ad_22 :
-		case pctl_mux_gpio_ad_23 :
+		case pctl_mux_gpio_ad_18:
+		case pctl_mux_gpio_ad_19:
+		case pctl_mux_gpio_ad_20:
+		case pctl_mux_gpio_ad_21:
+		case pctl_mux_gpio_ad_22:
+		case pctl_mux_gpio_ad_23:
 			return 2;
 
-		case pctl_mux_gpio_sd_b2_06 :
+		case pctl_mux_gpio_sd_b2_06:
 			return 3;
 
-		case pctl_mux_gpio_sd_b2_00 :
-		case pctl_mux_gpio_sd_b2_01 :
-		case pctl_mux_gpio_sd_b2_02 :
-		case pctl_mux_gpio_sd_b2_03 :
-		case pctl_mux_gpio_sd_b2_04 :
-		case pctl_mux_gpio_sd_b2_05 :
-		case pctl_mux_gpio_lpsr_09 :
-		case pctl_mux_gpio_lpsr_10 :
-		case pctl_mux_gpio_lpsr_11 :
+		case pctl_mux_gpio_sd_b2_00:
+		case pctl_mux_gpio_sd_b2_01:
+		case pctl_mux_gpio_sd_b2_02:
+		case pctl_mux_gpio_sd_b2_03:
+		case pctl_mux_gpio_sd_b2_04:
+		case pctl_mux_gpio_sd_b2_05:
+		case pctl_mux_gpio_lpsr_09:
+		case pctl_mux_gpio_lpsr_10:
+		case pctl_mux_gpio_lpsr_11:
 			return 4;
 
-		case pctl_mux_gpio_sd_b2_07 :
-		case pctl_mux_gpio_sd_b2_08 :
-		case pctl_mux_gpio_sd_b2_09 :
-		case pctl_mux_gpio_sd_b2_10 :
-		case pctl_mux_gpio_sd_b2_11 :
+		case pctl_mux_gpio_sd_b2_07:
+		case pctl_mux_gpio_sd_b2_08:
+		case pctl_mux_gpio_sd_b2_09:
+		case pctl_mux_gpio_sd_b2_10:
+		case pctl_mux_gpio_sd_b2_11:
 			return 6;
 
-		case pctl_mux_gpio_emc_b2_00 :
-		case pctl_mux_gpio_emc_b2_01 :
-		case pctl_mux_gpio_emc_b2_02 :
-		case pctl_mux_gpio_emc_b2_03 :
-		case pctl_mux_gpio_emc_b2_04 :
-		case pctl_mux_gpio_emc_b2_05 :
-		case pctl_mux_gpio_emc_b2_06 :
-		case pctl_mux_gpio_emc_b2_07 :
-		case pctl_mux_gpio_emc_b2_08 :
-		case pctl_mux_gpio_emc_b2_09 :
-		case pctl_mux_gpio_emc_b2_10 :
-		case pctl_mux_gpio_lpsr_13 :
-		case pctl_mux_gpio_lpsr_14 :
-		case pctl_mux_gpio_lpsr_15 :
+		case pctl_mux_gpio_emc_b2_00:
+		case pctl_mux_gpio_emc_b2_01:
+		case pctl_mux_gpio_emc_b2_02:
+		case pctl_mux_gpio_emc_b2_03:
+		case pctl_mux_gpio_emc_b2_04:
+		case pctl_mux_gpio_emc_b2_05:
+		case pctl_mux_gpio_emc_b2_06:
+		case pctl_mux_gpio_emc_b2_07:
+		case pctl_mux_gpio_emc_b2_08:
+		case pctl_mux_gpio_emc_b2_09:
+		case pctl_mux_gpio_emc_b2_10:
+		case pctl_mux_gpio_lpsr_13:
+		case pctl_mux_gpio_lpsr_14:
+		case pctl_mux_gpio_lpsr_15:
 			return 8;
 
-		case pctl_mux_gpio_disp_b1_04 :
-		case pctl_mux_gpio_disp_b1_05 :
-		case pctl_mux_gpio_disp_b1_06 :
-		case pctl_mux_gpio_disp_b1_07 :
-		case pctl_mux_gpio_disp_b1_08 :
-		case pctl_mux_gpio_disp_b1_09 :
-		case pctl_mux_gpio_disp_b1_10 :
-		case pctl_mux_gpio_disp_b2_12 :
-		case pctl_mux_gpio_disp_b2_13 :
-		case pctl_mux_gpio_disp_b2_14 :
-		case pctl_mux_gpio_disp_b2_15 :
+		case pctl_mux_gpio_disp_b1_04:
+		case pctl_mux_gpio_disp_b1_05:
+		case pctl_mux_gpio_disp_b1_06:
+		case pctl_mux_gpio_disp_b1_07:
+		case pctl_mux_gpio_disp_b1_08:
+		case pctl_mux_gpio_disp_b1_09:
+		case pctl_mux_gpio_disp_b1_10:
+		case pctl_mux_gpio_disp_b2_12:
+		case pctl_mux_gpio_disp_b2_13:
+		case pctl_mux_gpio_disp_b2_14:
+		case pctl_mux_gpio_disp_b2_15:
 			return 9;
 
 		default :


### PR DESCRIPTION
# imxrt-multi/spi: fix invalid mux initialization

## Description
These changes prevent unwanted gpio initialization in the absence of spi settings and fix initialization swap for spi5 and spi6.

## Motivation and Context
This solves the problem of reconfiguring mux gpio for pctl_mux_gpio_emc_b1_00 in case of lack initialization settings for all spi pins for IMXRT117X. pctl_mux_gpio_emc_b1_00 is seen in the code as 0 which corresponds to no spi initialization. gpio mux pctl_mux_gpio_emc_b1_00 is not valid for any spi interface. Any invalid mux for spi is marked with a forbidden value of mux to prevent unwanted initialization. This change is required in case of use gpio_emc_b1_00 as simple gpio for example.
Next solved problem is swap mux value for spi5 and spi6. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (IMXRT1176).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
