### PR TITLE
uart16550: place irq handler in .interrupt section on riscv64

### DIFF
--- a/tty/uart16550/uart16550.c
+++ b/tty/uart16550/uart16550.c
@@ -129,7 +129,9 @@ static void signal_txready(void *arg)
 	condSignal(uart->intcond);
 }
 
-
+#ifdef __TARGET_RISCV64
+__attribute__((section(".interrupt"), aligned(0x1000)))
+#endif
 static int uart_interrupt(unsigned int n, void *arg)
 {
 	return ((uart_t *)arg)->intcond;


### PR DESCRIPTION
On RV64 systems interrupt handler is remapped before executing interrupt. On mulicore system, without this change, the remap influences all cores, which may be executing nearby code, causing page fault.

JIRA: RTOS-813

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
