### PR TITLE
imxrt-flash: allow exclusive access to raw partitions 

### DIFF
--- a/storage/imxrt-flash/flashsrv.c
+++ b/storage/imxrt-flash/flashsrv.c
@@ -74,7 +74,7 @@ typedef struct {
 
 	uint32_t pCnt;
 	uint8_t fStatus;
-	uint8_t rawActive;
+	bool rawActive;
 
 	oid_t fOid;
 	uint32_t rawPort;
@@ -770,7 +770,7 @@ static int flashsrv_mountPart(flashsrv_partition_t *part)
 			}
 
 			if (!flashsrv_common.flash_memories[part->fID].rawActive) {
-				flashsrv_common.flash_memories[part->fID].rawActive = 1;
+				flashsrv_common.flash_memories[part->fID].rawActive = true;
 
 				mem = malloc(THREAD_STACKSZ);
 				if (mem == NULL) {
@@ -961,7 +961,7 @@ static int flashsrv_flashMemoriesInit(void)
 			return err;
 		}
 
-		memory->rawActive = 0;
+		memory->rawActive = false;
 		memory->pCnt = 0;
 
 		err = create_dev(&memory->fOid, path);

--- a/storage/imxrt-flash/flashsrv.c
+++ b/storage/imxrt-flash/flashsrv.c
@@ -70,7 +70,6 @@ typedef struct {
 
 	uint32_t pCnt;
 	uint8_t fStatus;
-	uint8_t currPart;
 	uint8_t rawActive;
 
 	oid_t fOid;
@@ -497,34 +496,28 @@ static void flashsrv_meterfsThread(void *arg)
 
 		switch (msg.type) {
 			case mtRead:
-				flashsrv_common.flash_memories[part->fID].currPart = part->oid.id;
 				msg.o.err = meterfs_readFile(msg.oid.id, msg.i.io.offs, msg.o.data, msg.o.size, (meterfs_ctx_t *)part->fsCtx);
 				break;
 
 			case mtWrite:
-				flashsrv_common.flash_memories[part->fID].currPart = part->oid.id;
 				msg.o.err = meterfs_writeFile(msg.oid.id, msg.i.data, msg.i.size, (meterfs_ctx_t *)part->fsCtx);
 				break;
 
 			case mtLookup:
-				flashsrv_common.flash_memories[part->fID].currPart = part->oid.id;
 				msg.o.err = meterfs_lookup(msg.i.data, &msg.o.lookup.fil.id, (meterfs_ctx_t *)part->fsCtx);
 				msg.o.lookup.fil.port = part->oid.port;
 				memcpy(&msg.o.lookup.dev, &msg.o.lookup.fil, sizeof(oid_t));
 				break;
 
 			case mtOpen:
-				flashsrv_common.flash_memories[part->fID].currPart = part->oid.id;
 				msg.o.err = meterfs_open(msg.oid.id, (meterfs_ctx_t *)part->fsCtx);
 				break;
 
 			case mtClose:
-				flashsrv_common.flash_memories[part->fID].currPart = part->oid.id;
 				msg.o.err = meterfs_close(msg.oid.id, (meterfs_ctx_t *)part->fsCtx);
 				break;
 
 			case mtDevCtl:
-				flashsrv_common.flash_memories[part->fID].currPart = part->oid.id;
 				msg.o.err = meterfs_devctl(idevctl, odevctl, (meterfs_ctx_t *)part->fsCtx);
 				break;
 

--- a/storage/imxrt-flash/flashsrv.c
+++ b/storage/imxrt-flash/flashsrv.c
@@ -35,7 +35,7 @@
 #define TRACE(str, ...) do { if (0) fprintf(stderr, __FILE__  ":%d trace: " str "\n", __LINE__, ##__VA_ARGS__); } while (0)
 /* clang-format on */
 
-#define METERFS_STACKSZ   1024
+#define METERFS_STACKSZ   1280
 #define THREAD_STACKSZ    1024
 #define FLASH_MEMORIES_NO (FLEXSPI_COUNT)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Meterfs stack size needs to be increased as it overflows (happened when flash was empty and files were to be created)
Add exclusive access for single PID. According to POSIX behavior of O_EXCL mode of open (when O_CREAT is unset) is undefined. This change interprets O_EXCL flag as exclusive access for a process that performs `open` on partition until `close`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adding exclusive access to partition is an easy, probably temporary solution to restrict access to sensitive memory spaces 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1176.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
