### PR TITLE
imxrt-flash: support for calulating CRC32 of selected region

### DIFF
--- a/storage/imxrt-flash/flashsrv.c
+++ b/storage/imxrt-flash/flashsrv.c
@@ -249,12 +249,12 @@ static void flashsrv_devCtl(flashsrv_memory_t *memory, msg_t *msg)
 			break;
 
 		case flashsrv_devctl_eraseSector:
-			TRACE("imxrt-flashsrv: flashsrv_devctl_eraseSector - addr: %u, id: %u, port: %u.", idevctl->addr, msg->oid.id, msg->oid.port);
-			if (idevctl->addr >= memory->ctx.properties.size) {
+			TRACE("imxrt-flashsrv: flashsrv_devctl_eraseSector - addr: %u, id: %u, port: %u.", idevctl->erase.addr, msg->oid.id, msg->oid.port);
+			if (idevctl->erase.addr >= memory->ctx.properties.size) {
 				msg->o.err = -EINVAL;
 				break;
 			}
-			flashsrv_eraseSector(memory->fOid.id, idevctl->addr);
+			flashsrv_eraseSector(memory->fOid.id, idevctl->erase.addr);
 			msg->o.err = EOK;
 			break;
 
@@ -266,26 +266,26 @@ static void flashsrv_devCtl(flashsrv_memory_t *memory, msg_t *msg)
 
 		case flashsrv_devctl_directWrite:
 			TRACE("imxrt-flashsrv: flashsrv_devctl_directWrite, addr: %u, size: %u, id: %u, port: %u.",
-				idevctl->addr, msg->i.size, msg->oid.id, msg->oid.port);
+				idevctl->write.addr, msg->i.size, msg->oid.id, msg->oid.port);
 
-			if (idevctl->addr >= memory->ctx.properties.size) {
+			if (idevctl->write.addr >= memory->ctx.properties.size) {
 				msg->o.err = -EINVAL;
 				break;
 			}
 
-			msg->o.err = flashsrv_directWrite(memory->fOid.id, idevctl->addr, msg->i.data, msg->i.size);
+			msg->o.err = flashsrv_directWrite(memory->fOid.id, idevctl->write.addr, msg->i.data, msg->i.size);
 			break;
 
 		case flashsrv_devctl_directRead:
 			TRACE("imxrt-flashsrv: flashsrv_devctl_directRead, addr: %u, size: %u, id: %u, port: %u.",
-				idevctl->addr, msg->o.size, msg->oid.id, msg->oid.port);
+				idevctl->read.addr, msg->o.size, msg->oid.id, msg->oid.port);
 
-			if (idevctl->addr >= memory->ctx.properties.size) {
+			if (idevctl->read.addr >= memory->ctx.properties.size) {
 				msg->o.err = -EINVAL;
 				break;
 			}
 
-			msg->o.err = flashsrv_directRead(memory->fOid.id, idevctl->addr, msg->o.data, msg->o.size);
+			msg->o.err = flashsrv_directRead(memory->fOid.id, idevctl->read.addr, msg->o.data, msg->o.size);
 			break;
 
 		default:
@@ -336,14 +336,14 @@ static void flashsrv_rawCtl(flashsrv_memory_t *memory, msg_t *msg)
 
 		case flashsrv_devctl_eraseSector:
 			TRACE("imxrt-flashsrv: flashsrv_devctl_eraseSector - addr: %u, id: %u, port: %u.",
-				idevctl->addr + memory->parts[partID].pHeader->offset, partID, msg->oid.port);
+				idevctl->erase.addr + memory->parts[partID].pHeader->offset, partID, msg->oid.port);
 
-			if (idevctl->addr >= memory->parts[msg->oid.id].pHeader->size) {
+			if (idevctl->erase.addr >= memory->parts[msg->oid.id].pHeader->size) {
 				msg->o.err = -EINVAL;
 				break;
 			}
 
-			flashsrv_eraseSector(memory->fOid.id, memory->parts[partID].pHeader->offset + idevctl->addr);
+			flashsrv_eraseSector(memory->fOid.id, memory->parts[partID].pHeader->offset + idevctl->erase.addr);
 			msg->o.err = EOK;
 			break;
 
@@ -360,26 +360,26 @@ static void flashsrv_rawCtl(flashsrv_memory_t *memory, msg_t *msg)
 
 		case flashsrv_devctl_directWrite:
 			TRACE("imxrt-flashsrv: flashsrv_devctl_directWrite, addr: %u, size: %u, id: %u, port: %u.",
-				idevctl->addr + memory->parts[partID].pHeader->offset, msg->i.size, msg->oid.id, msg->oid.port);
+				idevctl->write.addr + memory->parts[partID].pHeader->offset, msg->i.size, msg->oid.id, msg->oid.port);
 
-			if (idevctl->addr >= memory->parts[msg->oid.id].pHeader->size) {
+			if (idevctl->write.addr >= memory->parts[msg->oid.id].pHeader->size) {
 				msg->o.err = -EINVAL;
 				break;
 			}
 
-			msg->o.err = flashsrv_directWrite(memory->fOid.id, memory->parts[partID].pHeader->offset + idevctl->addr, msg->i.data, msg->i.size);
+			msg->o.err = flashsrv_directWrite(memory->fOid.id, memory->parts[partID].pHeader->offset + idevctl->write.addr, msg->i.data, msg->i.size);
 			break;
 
 		case flashsrv_devctl_directRead:
 			TRACE("imxrt-flashsrv: flashsrv_devctl_directRead, addr: %u, size: %u, id: %u, port: %u.",
-				idevctl->addr + memory->parts[partID].pHeader->offset, msg->o.size, msg->oid.id, msg->oid.port);
+				idevctl->read.addr + memory->parts[partID].pHeader->offset, msg->o.size, msg->oid.id, msg->oid.port);
 
-			if (idevctl->addr >= memory->parts[msg->oid.id].pHeader->size) {
+			if (idevctl->read.addr >= memory->parts[msg->oid.id].pHeader->size) {
 				msg->o.err = -EINVAL;
 				break;
 			}
 
-			msg->o.err = flashsrv_directRead(memory->fOid.id, memory->parts[partID].pHeader->offset + idevctl->addr, msg->o.data, msg->o.size);
+			msg->o.err = flashsrv_directRead(memory->fOid.id, memory->parts[partID].pHeader->offset + idevctl->read.addr, msg->o.data, msg->o.size);
 			break;
 
 		default:

--- a/storage/imxrt-flash/imxrt-flashsrv.h
+++ b/storage/imxrt-flash/imxrt-flashsrv.h
@@ -29,7 +29,23 @@ enum { flashsrv_devctl_properties = 0, flashsrv_devctl_sync, flashsrv_devctl_era
 
 typedef struct {
 	int type;
-	uint32_t addr;
+
+	union {
+		/* eraseSector */
+		struct {
+			uint32_t addr;
+		} erase;
+
+		/* directWrite */
+		struct {
+			uint32_t addr;
+		} write;
+
+		/* directRead */
+		struct {
+			uint32_t addr;
+		} read;
+	};
 } __attribute__((packed)) flash_i_devctl_t;
 
 
@@ -42,7 +58,9 @@ typedef struct {
 
 
 typedef struct {
-	flashsrv_properties_t properties;
+	union {
+		flashsrv_properties_t properties;
+	};
 } __attribute__((packed)) flash_o_devctl_t;
 
 

--- a/storage/imxrt-flash/imxrt-flashsrv.h
+++ b/storage/imxrt-flash/imxrt-flashsrv.h
@@ -22,7 +22,8 @@
 /* clang-format off */
 
 enum { flashsrv_devctl_properties = 0, flashsrv_devctl_sync, flashsrv_devctl_eraseSector,
-	flashsrv_devctl_erasePartition, flashsrv_devctl_directWrite, flashsrv_devctl_directRead };
+	flashsrv_devctl_erasePartition, flashsrv_devctl_directWrite, flashsrv_devctl_directRead,
+	flashsrv_devctl_calcCrc32 };
 
 /* clang-format on */
 
@@ -45,6 +46,14 @@ typedef struct {
 		struct {
 			uint32_t addr;
 		} read;
+
+		/* calcCrc32 */
+		struct {
+			/* set addr & len to 0 for full range */
+			uint32_t addr;
+			uint32_t len;
+			uint32_t base;
+		} crc32;
 	};
 } __attribute__((packed)) flash_i_devctl_t;
 
@@ -60,6 +69,7 @@ typedef struct {
 typedef struct {
 	union {
 		flashsrv_properties_t properties;
+		uint32_t crc32;
 	};
 } __attribute__((packed)) flash_o_devctl_t;
 
@@ -78,6 +88,7 @@ typedef struct {
 	ssize_t (*write)(uint8_t fID, size_t offset, const void *data, size_t size);
 	int (*eraseSector)(uint8_t fID, uint32_t offs);
 	int (*getProperties)(uint8_t fID, flashsrv_properties_t *p);
+	int (*calcCrc32)(uint8_t fID, size_t offset, size_t len, uint32_t *crc32);
 } flashsrv_partitionOps_t;
 
 


### PR DESCRIPTION
CRC32 can be calulated for selected region of flash memory or raw partition. To calculate automatically CRC32 of whole memory/partition set addr and len to 0.

JIRA: NIL-574

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
