### PR TITLE
imxrt-flash: add port and bus mask enums

### DIFF
--- a/storage/imxrt-flash/fspi.h
+++ b/storage/imxrt-flash/fspi.h
@@ -17,6 +17,19 @@
 #ifndef _FLEXSPI_H_
 #define _FLEXSPI_H_
 
+/* clang-format off */
+
+/*
+ * Use to construct (FLEXSPIx_PORT_MASK) consisting of one or more slave buses per flexspi instance x
+ */
+enum { flexspi_slBusA1 = 0x1, flexspi_slBusA2 = 0x2, flexspi_slBusB1 = 0x4, flexspi_slBusB2 = 0x8 };
+
+/* Select particular slave bus during xferExec */
+enum { flexspi_portA1 = 0, flexspi_portA2, flexspi_portB1, flexspi_portB2 };
+
+/* clang-format on */
+
+
 #if defined(__CPU_IMXRT106X)
 
 #ifndef FLEXSPI_COUNT
@@ -32,7 +45,7 @@
 #define FLEXSPI1_XIP 1
 #endif
 #ifndef FLEXSPI1_PORT
-#define FLEXSPI1_PORT 0
+#define FLEXSPI1_PORT flexspi_portA1
 #endif
 #ifndef FLEXSPI1_PORT_MASK
 #define FLEXSPI1_PORT_MASK 1
@@ -41,10 +54,10 @@
 #define FLEXSPI2_XIP 0
 #endif
 #ifndef FLEXSPI2_PORT
-#define FLEXSPI2_PORT 0
+#define FLEXSPI2_PORT flexspi_portA1
 #endif
 #ifndef FLEXSPI2_PORT_MASK
-#define FLEXSPI2_PORT_MASK 1
+#define FLEXSPI2_PORT_MASK flexspi_slBusA1
 #endif
 
 #elif defined(__CPU_IMXRT117X)
@@ -62,19 +75,19 @@
 #define FLEXSPI1_XIP 1
 #endif
 #ifndef FLEXSPI1_PORT
-#define FLEXSPI1_PORT 0
+#define FLEXSPI1_PORT flexspi_portA1
 #endif
 #ifndef FLEXSPI1_PORT_MASK
-#define FLEXSPI1_PORT_MASK 1
+#define FLEXSPI1_PORT_MASK flexspi_slBusA1
 #endif
 #ifndef FLEXSPI2_XIP
 #define FLEXSPI2_XIP 0
 #endif
 #ifndef FLEXSPI2_PORT
-#define FLEXSPI2_PORT 0
+#define FLEXSPI2_PORT flexspi_portA1
 #endif
 #ifndef FLEXSPI2_PORT_MASK
-#define FLEXSPI2_PORT_MASK 1
+#define FLEXSPI2_PORT_MASK flexspi_slBusA1
 #endif
 
 #else


### PR DESCRIPTION
## Description

Adds enums common to the plo implementation, so that it can be used in per project `board_config.h` instead of using magic numbers.

e.g.:
`#define FLEXSPI2_PORT_MASK (flexspi_slBusA1 | flexspi_slBusA2 | flexspi_slBusB2)`
instead of magic numbers:
`#define FLEXSPI2_PORT_MASK (1 | 2 | 8)`

JIRA: NIL-539

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
