### PR TITLE
zynq7000-uart: fix race condition

### DIFF
--- a/tty/zynq7000-uart/zynq7000-uart.c
+++ b/tty/zynq7000-uart/zynq7000-uart.c
@@ -126,8 +126,8 @@ static void uart_intThread(void *arg)
 			libtty_wake_writer(&uart->tty);
 		}
 
-		/* RX Trigger IRQ occurred */
-		if (*(uart->base + isr) & (1 << 0)) {
+		/* RX Trigger IRQ occurred and turned off the interrupt */
+		if ((*(uart->base + imr) & (1 << 0)) == 0) {
 			*(uart->base + isr) = (1 << 0); /* RX Trigger status can be cleared after getting data from RX FIFO */
 			*(uart->base + ier) = (1 << 0); /* Enable RX Trigger irq which has been disabled in uart irq handler */
 		}


### PR DESCRIPTION
## Description
Here is how the race condition could happen:

![image](https://github.com/phoenix-rtos/phoenix-rtos-devices/assets/145347563/03e619df-f950-4254-b7c0-55a2cd269df3)

This race happens because of the assumption that if the IRQ is active, then the IRQ is already disabled. However, in the case above it is not disabled yet and will be disabled a bit later - and never re-enabled, because IRQ was cleared.

This race could not happen in single-core configuration because in ISR checking the IRQ active register and disabling IRQ could never be interrupted (and was effectively atomic). However, when SMP is enabled the thread and ISR can be scheduled on different cores and can interleave in the way described.

After the change the IRQ mask register is checked. In this handler code, the only way RX threshold IRQ can be disabled is if the IRQ is active and the ISR has completed. Updating the mask register is atomic and no race condition can happen.

This race condition would only happen on physical hardware, not on QEMU with SMP enabled.

## Motivation and Context
This is needed to merge https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/548. Without it UART can randomly stop taking user input and this was shown in CI testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a9-zynq7000-zturn

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
