### PR TITLE
pc-tty: add PS/2 mouse support and kbd/mouse vdevs

### DIFF
--- a/tty/pc-tty/event_queue.c
+++ b/tty/pc-tty/event_queue.c
@@ -1,0 +1,210 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Simple circular buffer for enqueueing PS/2 events
+ *
+ * Copyright 2024 Phoenix Systems
+ * Author: Adam Greloch
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/threads.h>
+#include <sys/minmax.h>
+
+#include "event_queue.h"
+
+
+int event_queue_init(event_queue_t *eq)
+{
+	int err;
+
+	if (eq == NULL) {
+		return -EINVAL;
+	}
+
+	(void)memset(eq, 0, sizeof(event_queue_t));
+
+	err = mutexCreate(&eq->mutex);
+	if (err < 0) {
+		return err;
+	}
+
+	err = condCreate(&eq->waitq);
+	if (err < 0) {
+		resourceDestroy(eq->mutex);
+		return err;
+	}
+
+	return EOK;
+}
+
+
+int event_queue_put(event_queue_t *eq, unsigned char event, unsigned int notify_cnt)
+{
+	if (eq == NULL) {
+		return -EINVAL;
+	}
+
+	int bytes = 0;
+
+	mutexLock(eq->mutex);
+	if (eq->cnt < TTYPC_EQBUF_SIZE) {
+		eq->buf[eq->w] = event;
+		eq->w = (eq->w + 1u) % TTYPC_EQBUF_SIZE;
+		eq->cnt++;
+		if (eq->cnt >= notify_cnt) {
+			condSignal(eq->waitq);
+		}
+		bytes = 1;
+	}
+	mutexUnlock(eq->mutex);
+
+	return bytes;
+}
+
+
+static int _event_queue_get(event_queue_t *eq, void *dest, unsigned int size, unsigned int minsize, unsigned int flags)
+{
+	int err;
+	unsigned int bytes;
+
+	if ((flags & O_NONBLOCK) != 0 && eq->cnt < minsize) {
+		return -EWOULDBLOCK;
+	}
+
+	while (eq->cnt < minsize) {
+		condWait(eq->waitq, eq->mutex, 0);
+	}
+
+	if (size > eq->cnt) {
+		size = eq->cnt;
+	}
+
+	if (eq->w > eq->r) {
+		bytes = size;
+	}
+	else {
+		bytes = min(size, TTYPC_EQBUF_SIZE - eq->r);
+	}
+
+	(void)memcpy(dest, eq->buf + eq->r, bytes);
+
+	if (bytes < size) {
+		size -= bytes;
+		(void)memcpy((char *)dest + bytes, eq->buf, size);
+		bytes += size;
+	}
+
+	eq->r = (eq->r + bytes) % TTYPC_EQBUF_SIZE;
+	eq->cnt -= bytes;
+
+	err = bytes;
+
+	return err;
+}
+
+
+int event_queue_get(event_queue_t *eq, char *dest, unsigned int size, unsigned int minsize, unsigned int flags)
+{
+	int err;
+
+	if (eq == NULL || dest == NULL || size < minsize) {
+		return -EINVAL;
+	}
+
+	if (size == 0u) {
+		return 0;
+	}
+
+	mutexLock(eq->mutex);
+	err = _event_queue_get(eq, dest, size, minsize, flags);
+	mutexUnlock(eq->mutex);
+
+	return err;
+}
+
+
+int event_queue_get_mouse(event_queue_t *meq, char *dest, unsigned int size, unsigned int flags)
+{
+	int res, total = 0;
+
+	if (meq == NULL || dest == NULL) {
+		return -EINVAL;
+	}
+
+	if (size < 3) {
+		/*
+		 * Pretend there's nothing to read. We don't want someone to read partial mouse
+		 * packets - this would mess up byte ordering and confuse recipients.
+		 */
+		return 0;
+	}
+
+	mutexLock(meq->mutex);
+
+	if (size > meq->cnt) {
+		size = meq->cnt;
+	}
+
+	/* read only multiples of 3 */
+	size = size - (size % 3);
+
+	while (total < size) {
+		/* find first package byte */
+		do {
+			/* 3rd bit should be set in the first byte of mouse package */
+			res = _event_queue_get(meq, dest + total, 1, 1, flags);
+			if (res < 1) {
+				mutexUnlock(meq->mutex);
+				return res;
+			}
+		} while ((dest[0] & (1 << 3)) == 0);
+
+		/* found the first byte, get the other two */
+		res = _event_queue_get(meq, dest + total + 1, 2, 2, flags);
+		if (res != 2) {
+			break;
+		}
+
+		total += 3;
+	};
+
+	mutexUnlock(meq->mutex);
+
+	return total;
+}
+
+
+int event_queue_count(const event_queue_t *eq)
+{
+	int res;
+
+	if (eq == NULL) {
+		return -EINVAL;
+	}
+
+	mutexLock(eq->mutex);
+	res = eq->cnt;
+	mutexUnlock(eq->mutex);
+
+	return res;
+}
+
+
+void event_queue_destroy(const event_queue_t *eq)
+{
+	if (eq == NULL) {
+		return;
+	}
+
+	resourceDestroy(eq->waitq);
+	resourceDestroy(eq->mutex);
+}

--- a/tty/pc-tty/event_queue.h
+++ b/tty/pc-tty/event_queue.h
@@ -1,0 +1,56 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Simple circular buffer for enqueueing PS/2 events
+ *
+ * Copyright 2024 Phoenix Systems
+ * Author: Adam Greloch
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#ifndef _EVENT_QUEUE_H_
+#define _EVENT_QUEUE_H_
+
+#include <sys/threads.h>
+
+#define TTYPC_EQBUF_SIZE 256u
+
+typedef struct _event_queue_t {
+	unsigned char buf[TTYPC_EQBUF_SIZE];
+	unsigned int cnt;
+	unsigned int r;
+	unsigned int w;
+	handle_t mutex;
+	handle_t waitq;
+} event_queue_t;
+
+
+/* Initializes event queue */
+extern int event_queue_init(event_queue_t *eq);
+
+
+/* Puts a byte into event queue */
+extern int event_queue_put(event_queue_t *eq, unsigned char event, unsigned int notify_cnt);
+
+
+/* Reads data from event queue */
+extern int event_queue_get(event_queue_t *eq, char *dest, unsigned int size, unsigned int minsize, unsigned int flags);
+
+
+/* Reads 3-byte mouse packets from event queue */
+extern int event_queue_get_mouse(event_queue_t *meq, char *dest, unsigned int size, unsigned int flags);
+
+
+/* Retrieves number of bytes stored in event queue */
+extern int event_queue_count(const event_queue_t *eq);
+
+
+/* Destroys event queue */
+extern void event_queue_destroy(const event_queue_t *eq);
+
+
+#endif

--- a/tty/pc-tty/ttypc.h
+++ b/tty/pc-tty/ttypc.h
@@ -25,28 +25,29 @@
 
 
 /* Keyboard types */
-enum { KBD_BIOS, KBD_PS2 };
+enum { KBD_BIOS,
+	KBD_PS2 };
 
 
 /* Keyboard key types */
 enum {
-	KB_NONE    = 0x0000,
-	KB_CTL     = 0x0001,
-	KB_SHIFT   = 0x0002,
-	KB_ALT     = 0x0004,
-	KB_ALTGR   = 0x0008,
-	KB_SCROLL  = 0x0010,
-	KB_NUM     = 0x0020,
-	KB_CAPS    = 0x0040,
-	KB_FUNC    = 0x0080,
-	KB_ASCII   = 0x0100,
-	KB_KP      = 0x0200,
-	KB_EXT     = 0x0400
+	KB_NONE = 0x0000,
+	KB_CTL = 0x0001,
+	KB_SHIFT = 0x0002,
+	KB_ALT = 0x0004,
+	KB_ALTGR = 0x0008,
+	KB_SCROLL = 0x0010,
+	KB_NUM = 0x0020,
+	KB_CAPS = 0x0040,
+	KB_FUNC = 0x0080,
+	KB_ASCII = 0x0100,
+	KB_KP = 0x0200,
+	KB_EXT = 0x0400
 };
 
 
 struct _ttypc_t {
-	unsigned int port;     /* Driver port */
+	unsigned int port; /* Driver port */
 
 	/* VGA */
 	volatile void *vga;    /* VGA screen memory */
@@ -65,11 +66,11 @@ struct _ttypc_t {
 	handle_t kinth;        /* Interrupt handle */
 
 	/* Virtual terminals */
-	ttypc_vt_t *vt;        /* Active virtual terminal */
-	ttypc_vt_t vts[NVTS];  /* Virtual Terminals */
+	ttypc_vt_t *vt;       /* Active virtual terminal */
+	ttypc_vt_t vts[NVTS]; /* Virtual Terminals */
 
 	/* Synchronization */
-	handle_t lock;         /* Access mutex */
+	handle_t lock; /* Access mutex */
 
 	/* Thread stacks */
 	char kstack[2048] __attribute__ ((aligned(8)));

--- a/tty/pc-tty/ttypc_kbd.c
+++ b/tty/pc-tty/ttypc_kbd.c
@@ -38,6 +38,7 @@ typedef struct {
 
 
 /* U.S 101 keys keyboard map */
+/* clang-format off */
 static const ttypc_kbd_keymap_t scodes[] = {
 	/*type       unshift    shift      ctl        altgr      shift_altgr scancode */
 	{ KB_NONE,   "",        "",        "",        "",        "" },    /* 0 unused */
@@ -169,6 +170,7 @@ static const ttypc_kbd_keymap_t scodes[] = {
 	{ KB_NONE,   "",        "",        "",        "",        "" },    /* 126 */
 	{ KB_NONE,   "",        "",        "",        "",        "" }     /* 127 */
 };
+/* clang-format on */
 
 
 /* KB_KP (keypad keys) modifiers map */
@@ -213,36 +215,36 @@ static char *_ttypc_kbd_get(ttypc_t *ttypc)
 		dt &= 0x7f;
 
 		switch (scodes[dt].type) {
-		case KB_SCROLL:
-			if (!ext)
-				ttypc->shiftst &= ~KB_SCROLL;
-			break;
+			case KB_SCROLL:
+				if (!ext)
+					ttypc->shiftst &= ~KB_SCROLL;
+				break;
 
-		case KB_NUM:
-			if (!ext)
-				ttypc->shiftst &= ~KB_NUM;
-			break;
+			case KB_NUM:
+				if (!ext)
+					ttypc->shiftst &= ~KB_NUM;
+				break;
 
-		case KB_CAPS:
-			if (!ext)
-				ttypc->shiftst &= ~KB_CAPS;
-			break;
+			case KB_CAPS:
+				if (!ext)
+					ttypc->shiftst &= ~KB_CAPS;
+				break;
 
-		case KB_CTL:
-			ttypc->shiftst &= ~KB_CTL;
-			break;
+			case KB_CTL:
+				ttypc->shiftst &= ~KB_CTL;
+				break;
 
-		case KB_SHIFT:
-			if (!ext)
-				ttypc->shiftst &= ~KB_SHIFT;
-			break;
+			case KB_SHIFT:
+				if (!ext)
+					ttypc->shiftst &= ~KB_SHIFT;
+				break;
 
-		case KB_ALT:
-			if (ext)
-				ttypc->shiftst &= ~KB_ALTGR;
-			else
-				ttypc->shiftst &= ~KB_ALT;
-			break;
+			case KB_ALT:
+				if (ext)
+					ttypc->shiftst &= ~KB_ALTGR;
+				else
+					ttypc->shiftst &= ~KB_ALT;
+				break;
 		}
 
 		/* Last key released */
@@ -255,123 +257,123 @@ static char *_ttypc_kbd_get(ttypc_t *ttypc)
 	/* Key is pressed */
 	else {
 		switch (scodes[dt].type) {
-		/* Lock keys - Scroll, Num, Caps */
-		case KB_SCROLL:
-			if (ttypc->shiftst & KB_SCROLL)
+			/* Lock keys - Scroll, Num, Caps */
+			case KB_SCROLL:
+				if (ttypc->shiftst & KB_SCROLL)
+					break;
+				ttypc->shiftst |= KB_SCROLL;
+				ttypc->lockst ^= KB_SCROLL;
+				_ttypc_kbd_updateled(ttypc);
 				break;
-			ttypc->shiftst |= KB_SCROLL;
-			ttypc->lockst ^= KB_SCROLL;
-			_ttypc_kbd_updateled(ttypc);
-			break;
 
-		case KB_NUM:
-			if (ttypc->shiftst & KB_NUM)
+			case KB_NUM:
+				if (ttypc->shiftst & KB_NUM)
+					break;
+				ttypc->shiftst |= KB_NUM;
+				ttypc->lockst ^= KB_NUM;
+				_ttypc_kbd_updateled(ttypc);
 				break;
-			ttypc->shiftst |= KB_NUM;
-			ttypc->lockst ^= KB_NUM;
-			_ttypc_kbd_updateled(ttypc);
-			break;
 
-		case KB_CAPS:
-			if (ttypc->shiftst & KB_CAPS)
+			case KB_CAPS:
+				if (ttypc->shiftst & KB_CAPS)
+					break;
+				ttypc->shiftst |= KB_CAPS;
+				ttypc->lockst ^= KB_CAPS;
+				_ttypc_kbd_updateled(ttypc);
 				break;
-			ttypc->shiftst |= KB_CAPS;
-			ttypc->lockst ^= KB_CAPS;
-			_ttypc_kbd_updateled(ttypc);
-			break;
 
-		/* Shift keys - Ctl, Shift, Alt */
-		case KB_CTL:
-			ttypc->shiftst |= KB_CTL;
-			break;
-
-		case KB_SHIFT:
-			ttypc->shiftst |= KB_SHIFT;
-			break;
-
-		case KB_ALT:
-			if (ext)
-				ttypc->shiftst |= KB_ALTGR;
-			else
-				ttypc->shiftst |= KB_ALT;
-			break;
-
-		/* Function keys */
-		case KB_FUNC:
-		/* Regular ASCII */
-		case KB_ASCII:
-			/* Keys with extended scan codes don't depend on any modifiers */
-			if (ext) {
-				/* Handles keypad '/' key */
-				s = scodes[dt].unshift;
+			/* Shift keys - Ctl, Shift, Alt */
+			case KB_CTL:
+				ttypc->shiftst |= KB_CTL;
 				break;
-			}
-			/* Control modifier */
-			if (ttypc->shiftst & KB_CTL) {
-				s = scodes[dt].ctl;
-				break;
-			}
 
-			/* Right alt and right alt with shift modifiers */
-			if (ttypc->shiftst & KB_ALTGR) {
-				if (ttypc->shiftst & KB_SHIFT)
-					s = scodes[dt].shift_altgr;
+			case KB_SHIFT:
+				ttypc->shiftst |= KB_SHIFT;
+				break;
+
+			case KB_ALT:
+				if (ext)
+					ttypc->shiftst |= KB_ALTGR;
 				else
-					s = scodes[dt].altgr;
-			}
-			/* Shift modifier */
-			else if (ttypc->shiftst & KB_SHIFT) {
-				s = scodes[dt].shift;
-			}
-			/* No modifiers */
-			else {
-				s = scodes[dt].unshift;
-			}
-
-			/* Caps lock */
-			if ((ttypc->lockst & KB_CAPS) && (*scodes[dt].unshift >= 'a') && (*scodes[dt].unshift <= 'z')) {
-				if (s == scodes[dt].altgr)
-					s = scodes[dt].shift_altgr;
-				else if (s == scodes[dt].shift_altgr)
-					s = scodes[dt].altgr;
-				else if (s == scodes[dt].shift)
-					s = scodes[dt].unshift;
-				else if (s == scodes[dt].unshift)
-					s = scodes[dt].shift;
-			}
-			break;
-
-		/* Keys without meaning */
-		case KB_NONE:
-			break;
-
-		/* Keypad */
-		case KB_KP:
-			/* Keys with extended scan codes don't depend on any modifiers */
-			if (ext) {
-				/* Handles DEL, HOME, END, PU, PD and arrow (non keypad) keys */
-				s = scodes[dt].shift;
+					ttypc->shiftst |= KB_ALT;
 				break;
-			}
 
-			/* Shift modifier */
-			if (ttypc->shiftst & KB_SHIFT)
-				s = scodes[dt].shift;
-			/* Control modifier */
-			else if (ttypc->shiftst & KB_CTL)
-				s = scodes[dt].ctl;
-			/* No modifiers */
-			else
-				s = scodes[dt].unshift;
-
-			/* Num lock */
-			if (ttypc->lockst & KB_NUM) {
-				if (s == scodes[dt].shift)
+			/* Function keys */
+			case KB_FUNC:
+			/* Regular ASCII */
+			case KB_ASCII:
+				/* Keys with extended scan codes don't depend on any modifiers */
+				if (ext) {
+					/* Handles keypad '/' key */
 					s = scodes[dt].unshift;
-				else if ((s == scodes[dt].ctl) || (s == scodes[dt].unshift))
+					break;
+				}
+				/* Control modifier */
+				if (ttypc->shiftst & KB_CTL) {
+					s = scodes[dt].ctl;
+					break;
+				}
+
+				/* Right alt and right alt with shift modifiers */
+				if (ttypc->shiftst & KB_ALTGR) {
+					if (ttypc->shiftst & KB_SHIFT)
+						s = scodes[dt].shift_altgr;
+					else
+						s = scodes[dt].altgr;
+				}
+				/* Shift modifier */
+				else if (ttypc->shiftst & KB_SHIFT) {
 					s = scodes[dt].shift;
-			}
-			break;
+				}
+				/* No modifiers */
+				else {
+					s = scodes[dt].unshift;
+				}
+
+				/* Caps lock */
+				if ((ttypc->lockst & KB_CAPS) && (*scodes[dt].unshift >= 'a') && (*scodes[dt].unshift <= 'z')) {
+					if (s == scodes[dt].altgr)
+						s = scodes[dt].shift_altgr;
+					else if (s == scodes[dt].shift_altgr)
+						s = scodes[dt].altgr;
+					else if (s == scodes[dt].shift)
+						s = scodes[dt].unshift;
+					else if (s == scodes[dt].unshift)
+						s = scodes[dt].shift;
+				}
+				break;
+
+			/* Keys without meaning */
+			case KB_NONE:
+				break;
+
+			/* Keypad */
+			case KB_KP:
+				/* Keys with extended scan codes don't depend on any modifiers */
+				if (ext) {
+					/* Handles DEL, HOME, END, PU, PD and arrow (non keypad) keys */
+					s = scodes[dt].shift;
+					break;
+				}
+
+				/* Shift modifier */
+				if (ttypc->shiftst & KB_SHIFT)
+					s = scodes[dt].shift;
+				/* Control modifier */
+				else if (ttypc->shiftst & KB_CTL)
+					s = scodes[dt].ctl;
+				/* No modifiers */
+				else
+					s = scodes[dt].unshift;
+
+				/* Num lock */
+				if (ttypc->lockst & KB_NUM) {
+					if (s == scodes[dt].shift)
+						s = scodes[dt].unshift;
+					else if ((s == scodes[dt].ctl) || (s == scodes[dt].unshift))
+						s = scodes[dt].shift;
+				}
+				break;
 		}
 	}
 

--- a/tty/pc-tty/ttypc_kbd.c
+++ b/tty/pc-tty/ttypc_kbd.c
@@ -29,6 +29,8 @@
 #include <fcntl.h>
 #include <posix/utils.h>
 
+#include <board_config.h>
+
 #include "ttypc_kbd.h"
 #include "ttypc_mouse.h"
 #include "ttypc_vga.h"
@@ -36,8 +38,13 @@
 #include "event_queue.h"
 
 
-#define CTL_THREAD_PRIORITY  1
-#define POOL_THREAD_PRIORITY 1
+#ifndef TTYPC_KBD_CTL_PRIO
+#define TTYPC_KBD_CTL_PRIO 1
+#endif
+
+#ifndef TTYPC_KBD_POOL_PRIO
+#define TTYPC_KBD_POOL_PRIO 1
+#endif
 
 
 /* Keyboard key map entry */
@@ -725,14 +732,14 @@ int ttypc_kbd_init(ttypc_t *ttypc)
 		}
 
 		/* Launch keyboard/mouse control thread */
-		err = beginthread(ttypc_ps2_ctlthr, CTL_THREAD_PRIORITY, ttypc->kstack, sizeof(ttypc->kstack), ttypc);
+		err = beginthread(ttypc_ps2_ctlthr, TTYPC_KBD_CTL_PRIO, ttypc->kstack, sizeof(ttypc->kstack), ttypc);
 		if (err < 0) {
 			break;
 		}
 
 #if PC_TTY_CREATE_PS2_VDEVS
 		/* Launch keyboard pool thread */
-		err = beginthread(ttypc_kbd_poolthr, POOL_THREAD_PRIORITY, ttypc->kpstack, sizeof(ttypc->kpstack), ttypc);
+		err = beginthread(ttypc_kbd_poolthr, TTYPC_KBD_POOL_PRIO, ttypc->kpstack, sizeof(ttypc->kpstack), ttypc);
 		if (err < 0) {
 			break;
 		}

--- a/tty/pc-tty/ttypc_mouse.c
+++ b/tty/pc-tty/ttypc_mouse.c
@@ -1,0 +1,332 @@
+/*
+ * Phoenix-RTOS
+ *
+ * PS/2 3-button mouse
+ *
+ * Copyright 2024 Phoenix Systems
+ * Author: Adam Greloch
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <errno.h>
+
+#include "board_config.h"
+#include "ttypc_mouse.h"
+
+#if PC_TTY_MOUSE_ENABLE
+
+#include <poll.h>
+#include <unistd.h>
+
+#include <sys/file.h>
+#include <sys/interrupt.h>
+#include <sys/io.h>
+#include <sys/threads.h>
+
+#include <libklog.h>
+#include <posix/utils.h>
+
+#include "event_queue.h"
+#include "ttypc_ps2.h"
+
+
+#define POOL_THREAD_PRIORITY 1
+
+#ifndef PC_TTY_MOUSE_SKIP_CONFIG
+#define PC_TTY_MOUSE_SKIP_CONFIG 0
+#endif
+
+
+static int _ttypc_mouse_setup(ttypc_t *ttypc)
+{
+	unsigned char status;
+	int err;
+
+	do {
+/*
+ * Some BIOS-es do this part of configuration already when emulating PS/2 and
+ * redoing it may not be necessary or could even hang the PS/2 controller
+ * completely (as is the case on ThinkPad/Phoenix BIOS 2.26)
+ */
+#if !PC_TTY_MOUSE_SKIP_CONFIG
+		/* Enable mouse. Should receive ACK (0xFA) afterwards */
+		err = ttypc_ps2_write_ctrl(ttypc, 0xA8);
+		if (err < 0) {
+			break;
+		}
+		err = ttypc_ps2_read(ttypc);
+		if (err != 0xFA) {
+			(void)fprintf(stderr, "pc-tty: mouse not found\n");
+			err = -1;
+			break;
+		}
+
+		/* Get compaq status byte */
+		err = ttypc_ps2_write_ctrl(ttypc, 0x20);
+		if (err < 0) {
+			break;
+		}
+
+		status = ttypc_ps2_read(ttypc);
+		status |= (1u << 1u); /* Enable IRQ12 interrupt */
+
+/*
+ * Some sources say the bit 5 should be unset for proper functioning, but on QEMU
+ * and real hardware it is not necessary
+ */
+#if 0
+		status &= ~(1u << 5u); /* Enable mouse clock (unset bit 5) */
+#endif
+
+		/* Set compaq status byte */
+		err = ttypc_ps2_write_ctrl(ttypc, 0x60);
+		if (err < 0) {
+			break;
+		}
+		err = ttypc_ps2_write(ttypc, status);
+		if (err < 0) {
+			break;
+		}
+#endif /* !PC_TTY_MOUSE_SKIP_CONFIG */
+
+		/* Set defaults. Should receive ACK afterwards */
+		err = ttypc_ps2_write_ctrl(ttypc, 0xD4);
+		if (err < 0) {
+			break;
+		}
+		err = ttypc_ps2_write(ttypc, 0xF6);
+		if (err < 0) {
+			break;
+		}
+		err = ttypc_ps2_read(ttypc);
+		if (err != 0xFA) {
+			(void)fprintf(stderr, "pc-tty: mouse initialization failed - no ACK after setting defaults\n");
+			err = -1;
+			break;
+		}
+
+		/* Send mouse cmd - enable packet streaming. Should receive ACK afterwards */
+		err = ttypc_ps2_write_ctrl(ttypc, 0xD4);
+		if (err < 0) {
+			break;
+		}
+		err = ttypc_ps2_write(ttypc, 0xF4);
+		if (err < 0) {
+			break;
+		}
+		err = ttypc_ps2_read(ttypc);
+		if (err != 0xFA) {
+			(void)fprintf(stderr, "pc-tty: mouse initialization failed - no ACK after enable packet streaming cmd\n");
+			err = -1;
+			break;
+		}
+	} while (0);
+
+	if (err < 0) {
+		(void)fprintf(stderr, "pc-tty: failed to initialize mouse\n");
+		return -1;
+	}
+
+	return EOK;
+}
+
+
+#if PC_TTY_CREATE_PS2_VDEVS
+static void ttypc_mouse_poolthr(void *arg)
+{
+	ttypc_t *ttypc = (ttypc_t *)arg;
+	msg_rid_t rid;
+	msg_t msg;
+	int rv;
+
+	for (;;) {
+		rv = msgRecv(ttypc->mport, &msg, &rid);
+		if (rv < 0) {
+			continue;
+		}
+
+		rv = libklog_ctrlHandle(ttypc->mport, &msg, rid);
+		if (rv == 0) {
+			/* msg has been handled by libklog */
+			continue;
+		}
+
+		switch (msg.type) {
+			case mtOpen:
+				msg.o.err = EOK;
+				break;
+
+			case mtRead:
+				msg.o.err = event_queue_get_mouse(&ttypc->meq, msg.o.data, msg.o.size, msg.i.io.mode);
+				break;
+
+			case mtWrite:
+				rv = ttypc_ps2_write(ttypc, ((unsigned char *)msg.i.data)[0]);
+				if (rv < 0) {
+					msg.o.err = -EINVAL;
+					break;
+				}
+				msg.o.err = 1;
+				break;
+
+			case mtGetAttr:
+				if (msg.i.attr.type != atPollStatus) {
+					msg.o.err = -EINVAL;
+					break;
+				}
+
+				msg.o.attr.val = 0;
+				rv = event_queue_count(&ttypc->meq);
+				if (rv >= 3) {
+					msg.o.attr.val |= POLLIN;
+				}
+
+				msg.o.err = EOK;
+				break;
+
+			case mtClose:
+				msg.o.err = EOK;
+				break;
+
+			default:
+				msg.o.err = -ENOSYS;
+				break;
+		}
+
+		msgRespond(ttypc->mport, &msg, rid);
+	}
+}
+#endif /* PC_TTY_CREATE_PS2_VDEVS */
+
+
+/* Mouse interrupt handler */
+static int _ttypc_mouse_interrupt(unsigned int n, void *arg)
+{
+	return 0;
+}
+
+
+int ttypc_mouse_init(ttypc_t *ttypc)
+{
+	int err;
+
+	do {
+		err = _ttypc_mouse_setup(ttypc);
+		if (err < 0) {
+			break;
+		}
+
+#if PC_TTY_CREATE_PS2_VDEVS
+		oid_t oid;
+
+		/* Create virtual mouse device. Assumes the filesystem is available already */
+		err = portCreate(&ttypc->mport);
+		if (err < 0) {
+			(void)fprintf(stderr, "pc-tty: failed to create mouse port\n");
+			break;
+		}
+		oid.port = ttypc->mport;
+		oid.id = 0;
+
+		err = create_dev(&oid, "/dev/mouse");
+		if (err < 0) {
+			(void)fprintf(stderr, "pc-tty: failed to register mouse device\n");
+			portDestroy(ttypc->mport);
+			break;
+		}
+
+		err = event_queue_init(&ttypc->meq);
+		if (err < 0) {
+			portDestroy(ttypc->mport);
+			break;
+		}
+#endif
+
+		/* Attach KIRQ12 (mouse event) interrupt handle */
+		ttypc->mirq = 12;
+		err = interrupt(ttypc->mirq, _ttypc_mouse_interrupt, ttypc, ttypc->kmcond, &ttypc->minth);
+		if (err < 0) {
+#if PC_TTY_CREATE_PS2_VDEVS
+			portDestroy(ttypc->mport);
+			event_queue_destroy(&ttypc->meq);
+#endif
+			break;
+		}
+
+#if PC_TTY_CREATE_PS2_VDEVS
+		/* Launch mouse pool thread */
+		err = beginthread(ttypc_mouse_poolthr, POOL_THREAD_PRIORITY, ttypc->mpstack, sizeof(ttypc->mpstack), ttypc);
+		if (err < 0) {
+			portDestroy(ttypc->mport);
+			event_queue_destroy(&ttypc->meq);
+			resourceDestroy(ttypc->minth);
+			break;
+		}
+#endif
+	} while (0);
+
+	if (err < 0) {
+		/*
+		 * If mouse initialization has failed at any point, it's better to disable
+		 * mouse so that it doesn't clutter the I/O port with events we won't handle
+		 */
+
+		/* Disable mouse */
+		err = ttypc_ps2_write_ctrl(ttypc, 0xA7);
+		if (err < 0) {
+			return err;
+		}
+
+		/*
+		 * Read a byte in case mouse responded. This could be ACK (0xFA) or something
+		 * else if mouse is broken. Ignore return value - if read fails, it's ok.
+		 */
+		(void)ttypc_ps2_read(ttypc);
+	}
+
+	return err;
+}
+
+
+int ttypc_mouse_handle_event(ttypc_t *ttypc, unsigned char b)
+{
+#if PC_TTY_CREATE_PS2_VDEVS
+	return event_queue_put(&ttypc->meq, b, 3);
+#else
+	return EOK;
+#endif
+}
+
+
+void ttypc_mouse_destroy(ttypc_t *ttypc)
+{
+	resourceDestroy(ttypc->minth);
+#if PC_TTY_CREATE_PS2_VDEVS
+	event_queue_destroy(&ttypc->meq);
+	portDestroy(ttypc->mport);
+#endif
+}
+
+#else /* PC_TTY_ENABLE_MOUSE */
+
+int ttypc_mouse_handle_event(ttypc_t *ttypc, unsigned char b)
+{
+	fprintf(stderr, "pc-tty: ttypc_mouse_handle_event() called while mouse disabled\n");
+	return -1;
+}
+
+
+int ttypc_mouse_init(ttypc_t *ttypc)
+{
+	return EOK;
+}
+
+
+void ttypc_mouse_destroy(ttypc_t *ttypc)
+{
+}
+
+#endif /* PC_TTY_ENABLE_MOUSE */

--- a/tty/pc-tty/ttypc_mouse.c
+++ b/tty/pc-tty/ttypc_mouse.c
@@ -13,7 +13,8 @@
 
 #include <errno.h>
 
-#include "board_config.h"
+#include <board_config.h>
+
 #include "ttypc_mouse.h"
 
 #if PC_TTY_MOUSE_ENABLE
@@ -32,8 +33,9 @@
 #include "event_queue.h"
 #include "ttypc_ps2.h"
 
-
-#define POOL_THREAD_PRIORITY 1
+#ifndef TTYPC_MOUSE_POOL_PRIO
+#define TTYPC_MOUSE_POOL_PRIO 1
+#endif
 
 #ifndef PC_TTY_MOUSE_SKIP_CONFIG
 #define PC_TTY_MOUSE_SKIP_CONFIG 0
@@ -258,7 +260,7 @@ int ttypc_mouse_init(ttypc_t *ttypc)
 
 #if PC_TTY_CREATE_PS2_VDEVS
 		/* Launch mouse pool thread */
-		err = beginthread(ttypc_mouse_poolthr, POOL_THREAD_PRIORITY, ttypc->mpstack, sizeof(ttypc->mpstack), ttypc);
+		err = beginthread(ttypc_mouse_poolthr, TTYPC_MOUSE_POOL_PRIO, ttypc->mpstack, sizeof(ttypc->mpstack), ttypc);
 		if (err < 0) {
 			portDestroy(ttypc->mport);
 			event_queue_destroy(&ttypc->meq);

--- a/tty/pc-tty/ttypc_mouse.h
+++ b/tty/pc-tty/ttypc_mouse.h
@@ -1,0 +1,32 @@
+/*
+ * Phoenix-RTOS
+ *
+ * PS/2 3-button mouse
+ *
+ * Copyright 2024 Phoenix Systems
+ * Author: Adam Greloch
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _TTYPC_MOUSE_H_
+#define _TTYPC_MOUSE_H_
+
+#include "ttypc_vt.h"
+
+
+/* Initializes PS/2 mouse */
+extern int ttypc_mouse_init(ttypc_t *ttypc);
+
+
+/* Reads a mouse event from I/O buffer and handles it */
+extern int ttypc_mouse_handle_event(ttypc_t *ttypc, unsigned char b);
+
+
+/* Destroys PS/2 mouse */
+extern void ttypc_mouse_destroy(ttypc_t *ttypc);
+
+
+#endif

--- a/tty/pc-tty/ttypc_ps2.c
+++ b/tty/pc-tty/ttypc_ps2.c
@@ -1,0 +1,100 @@
+/*
+ * Phoenix-RTOS
+ *
+ * PS/2 common utilities
+ *
+ * Copyright 2024 Phoenix Systems
+ * Author: Adam Greloch
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <errno.h>
+#include <unistd.h>
+
+#include <sys/io.h>
+#include <sys/minmax.h>
+
+#include "ttypc_vt.h"
+
+
+#define SLEEP_MS               10u
+#define MAX_TIMEOUT_DEFAULT_MS 10000u
+
+
+/* Waits for PS/2 controller status bit with small timeout */
+static int _ttypc_ps2_waitstatus(ttypc_t *ttypc, unsigned int bit, unsigned int state, unsigned int max_timeout)
+{
+	unsigned int i, b, rounds;
+
+	if (max_timeout == 0u) {
+		max_timeout = MAX_TIMEOUT_DEFAULT_MS;
+	}
+
+	rounds = max(1, max_timeout / SLEEP_MS);
+
+	for (i = 0; i < rounds; i++) {
+		b = inb((void *)((uintptr_t)ttypc->kbd + 4u));
+
+		b &= (1u << bit) ^ (state << bit);
+		if (b == 0u) {
+			return EOK;
+		}
+
+		if (i < rounds - 1u) {
+			usleep(SLEEP_MS * 1000);
+		}
+	}
+
+	return -ETIMEDOUT;
+}
+
+
+static int _ttypc_ps2_write_to_port(ttypc_t *ttypc, void *port, unsigned char byte)
+{
+	int err;
+
+	/* Wait for input buffer to be empty */
+	err = _ttypc_ps2_waitstatus(ttypc, 1, 0, 0);
+	if (err < 0) {
+		return err;
+	}
+
+	outb(port, byte);
+
+	return EOK;
+}
+
+
+int ttypc_ps2_write(ttypc_t *ttypc, unsigned char byte)
+{
+	return _ttypc_ps2_write_to_port(ttypc, (void *)ttypc->kbd, byte);
+}
+
+
+int ttypc_ps2_read(ttypc_t *ttypc)
+{
+	int err;
+
+	/* Wait for output buffer not to be empty */
+	err = _ttypc_ps2_waitstatus(ttypc, 0, 1, 0);
+	if (err < 0) {
+		return err;
+	}
+
+	return inb((void *)ttypc->kbd);
+}
+
+
+int ttypc_ps2_write_ctrl(ttypc_t *ttypc, unsigned char byte)
+{
+	return _ttypc_ps2_write_to_port(ttypc, (void *)((uintptr_t)ttypc->kbd + 4u), byte);
+}
+
+
+unsigned char ttypc_ps2_read_ctrl(ttypc_t *ttypc)
+{
+	return inb((void *)((uintptr_t)ttypc->kbd + 4u));
+}

--- a/tty/pc-tty/ttypc_ps2.h
+++ b/tty/pc-tty/ttypc_ps2.h
@@ -1,0 +1,36 @@
+/*
+ * Phoenix-RTOS
+ *
+ * PS/2 common utilities
+ *
+ * Copyright 2024 Phoenix Systems
+ * Author: Adam Greloch
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _TTYPC_PS2_H_
+#define _TTYPC_PS2_H_
+
+#include "ttypc_vt.h"
+
+
+/* Writes a byte to PS/2 control buffer */
+extern int ttypc_ps2_write_ctrl(ttypc_t *ttypc, unsigned char byte);
+
+
+/* Reads a byte from PS/2 I/O buffer */
+extern int ttypc_ps2_read(ttypc_t *ttypc);
+
+
+/* Writes a byte to PS/2 I/O buffer */
+extern int ttypc_ps2_write(ttypc_t *ttypc, unsigned char byte);
+
+
+/* Reads a byte from PS/2 control buffer */
+extern unsigned char ttypc_ps2_read_ctrl(ttypc_t *ttypc);
+
+
+#endif


### PR DESCRIPTION
JIRA: RTOS-896, RTOS-864

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Adds PS/2 mouse support. Because PS/2 keyboard and mouse share the same I/O port, this required some heavy refactoring of ttypc_kbd driver. It also adds `/dev/kbd` and `/dev/mouse` virtual devices, which can be used for input event capturing by applications, for instance by an X server, as part of RTOS-864.

 Mouse support and virtual devices are opt-in and can be enabled via `board_config.h`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: ia32-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-project/pull/1135
- [ ] I will merge this PR by myself when appropriate.
