### PR TITLE
imxrt-multi: CM4_RUN_CORE returns EALREADY if core is running

### DIFF
--- a/multi/imxrt-multi/cm4.c
+++ b/multi/imxrt-multi/cm4.c
@@ -366,6 +366,11 @@ static int runCore(unsigned int offset)
 	platformctl_t pctl;
 	unsigned int vectors = (unsigned int)CM4_MEMORY_START + offset;
 
+	if ((*(m4_common.src + src_scr) & 1) != 0) {
+		/* Core is already running */
+		return -EALREADY;
+	}
+
 	/* Set CM4's VTOR to the start of it's memory */
 	pctl.action = pctl_set;
 	pctl.type = pctl_iolpsrgpr;


### PR DESCRIPTION
Useful when we need to run new code on an already running M4 core. The error code EALREADY allows us to detect this situation, in which case the new code should be started by resetting the M4 core.

DONE: NIL-441

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
