### PR TITLE
storage/imxrt-flash: meterfs: lock mutex during meterfs_init

### DIFF
--- a/storage/imxrt-flash/flashsrv.c
+++ b/storage/imxrt-flash/flashsrv.c
@@ -732,6 +732,7 @@ static void flashsrv_devThread(void *arg)
 
 static int flashsrv_initMeterfs(flashsrv_partition_t *part)
 {
+	int res;
 	meterfs_ctx_t *ctx;
 
 	part->fsCtx = calloc(1, sizeof(meterfs_ctx_t));
@@ -759,7 +760,11 @@ static int flashsrv_initMeterfs(flashsrv_partition_t *part)
 
 	ctx->keyInit = false;
 
-	if (meterfs_init(ctx) < 0) {
+	mutexLock(flashsrv_common.flash_memories[part->fID].lock);
+	res = meterfs_init(ctx);
+	mutexUnlock(flashsrv_common.flash_memories[part->fID].lock);
+
+	if (res < 0) {
 		LOG_ERROR("imxrt-flashsrv: init meterfs at flash: %u, partition: %u.", part->fID, part->oid.id);
 		return -1;
 	}


### PR DESCRIPTION
Added a flash mutex lock during meterfs_init as it may involve sector erasure.

DONE: NIL-584

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
