### PR TITLE
grlib-multi: initialize CGU on GR740

### DIFF
--- a/multi/grlib-multi/uart.c
+++ b/multi/grlib-multi/uart.c
@@ -362,6 +362,32 @@ static int uart_cguInit(unsigned int n)
 	pctl.task.cguctrl.cgudev = cguinfo[n];
 
 	return platformctl(&pctl);
+#elif defined(__CPU_GR740)
+	static const unsigned int cguinfo[] = {
+		cgudev_apbuart0,
+		cgudev_apbuart1
+	};
+	platformctl_t ctl = {
+		.action = pctl_get,
+		.type = pctl_cguctrl,
+		.task.cguctrl.cgudev = cguinfo[n]
+	};
+
+	if (platformctl(&ctl) < 0) {
+		return -1;
+	}
+
+	if (ctl.task.cguctrl.v.stateVal == 1) {
+		return 0;
+	}
+
+	ctl.action = pctl_set;
+	ctl.type = pctl_cguctrl;
+
+	ctl.task.cguctrl.v.state = enable;
+	ctl.task.cguctrl.cgudev = cguinfo[n];
+
+	return platformctl(&ctl);
 #else
 	return 0;
 #endif


### PR DESCRIPTION
JIRA: RTOS-883

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Initialize UART clock if necessary on the GR740.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This worked previously because the clock is already inintialized in kernel, but would be necessary in case of different UART use.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `sparcv8leon-gr740-mini`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
