### PR TITLE
gpio: add oid assignment to message in zynq7000 pwm driver

### DIFF
--- a/gpio/zynq7000-pwm/zynq7000-pwm-msg.c
+++ b/gpio/zynq7000-pwm/zynq7000-pwm-msg.c
@@ -32,6 +32,7 @@ int zynq7000pwm_set(oid_t *oid, uint32_t compval[ZYNQ7000_PWM_CHANNELS], uint8_t
 	msg.type = mtDevCtl;
 	i->type = zynq7000pwm_msgSet;
 	i->mask = mask;
+	msg.oid = *oid;
 	memcpy(i->compval, compval, sizeof(i->compval));
 
 	ret = msgSend(oid->port, &msg);
@@ -57,7 +58,7 @@ int zynq7000pwm_get(oid_t *oid, uint32_t compval[ZYNQ7000_PWM_CHANNELS])
 
 	msg.type = mtDevCtl;
 	i->type = zynq7000pwm_msgGet;
-
+	msg.oid = *oid;
 	ret = msgSend(oid->port, &msg);
 	if (ret >= 0) {
 		ret = o->err;


### PR DESCRIPTION
PP-263

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added oid assignment to message structure before sending it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
pwm driver worked improperly without assigning oids to messages.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
