### PR TITLE
zynqmp: add option to route CAN via PL

### DIFF
--- a/can/zynqmp-can/zynqmp-can.c
+++ b/can/zynqmp-can/zynqmp-can.c
@@ -278,7 +278,8 @@ static int zynqmpCan_init(unsigned int can_id, int baudrate)
 		return -1;
 	}
 
-	/* Configure MIO pins */
+	/* Configure MIO pins if CAN is not routed via PL subsystem */
+#if (CAN_ROUTED_VIA_PL != 1)
 	if (zynqmpCan_configMio(info[can_id].rxPin) < 0 || zynqmpCan_configMio(info[can_id].txPin) < 0) {
 		fprintf(stderr, "zynqmp-can: failed to initialize MIO pins\n");
 		munmap((void *)can.base, _PAGE_SIZE);
@@ -286,6 +287,9 @@ static int zynqmpCan_init(unsigned int can_id, int baudrate)
 		resourceDestroy(can.lock);
 		return -1;
 	}
+#else
+	(void)zynqmpCan_configMio;
+#endif
 
 	/* Wait for configuration mode */
 	while ((can.base->sr & (1 << 0)) != 1) {


### PR DESCRIPTION
Add an option to route CAN peripheral RX/TX pins via programmable logic subsystem
Tested on autopilot board, it works well

JIRA: PP-271

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
