### PR TITLE
imxrt-multi: Fix -Wundef warnings with a few macros

### DIFF
--- a/multi/imxrt-multi/config.h
+++ b/multi/imxrt-multi/config.h
@@ -30,6 +30,15 @@
 
 #include <board_config.h>
 
+/*
+ * In this config file, ISEMPTY() macro is used with tokens which are never
+ * defined on their own as they are used later in token-paste macros (for
+ * example: `ISEMPTY(UART1_TX_PIN)`). Thus, they will emit -Wundef warnings.
+ * For a "temporary" workaround, they are silenced in this file.
+ * Using #pragma only for ISEMPTY() macro definition is not enough.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundef"
 
 #ifndef IMXRT_MULTI_PRIO
 #define IMXRT_MULTI_PRIO 2
@@ -705,7 +714,23 @@
 #endif /* #if UART12 */
 
 
-#else
+#else /* #ifdef __CPU_IMXRT117X */
+
+#ifdef UART9
+#error "UART9 is only available on IMXRT117x"
+#endif
+
+#ifdef UART10
+#error "UART10 is only available on IMXRT117x"
+#endif
+
+#ifdef UART11
+#error "UART11 is only available on IMXRT117x"
+#endif
+
+#ifdef UART12
+#error "UART12 is only available on IMXRT117x"
+#endif
 
 #define UART9           0
 #define UART9_BUFSIZE   0
@@ -1219,8 +1244,15 @@
 
 #endif /* #if SPI6 */
 
+#else /* #ifdef __CPU_IMXRT117X */
 
-#else
+#ifdef SPI5
+#error "SPI5 is only available on IMXRT117x"
+#endif
+
+#ifdef SPI6
+#error "SPI6 is only available on IMXRT117x"
+#endif
 
 #define SPI5 0
 #define SPI6 0
@@ -1267,6 +1299,19 @@
 #elif !ISBOOLEAN(I2C6)
 #error "I2C6 must have a value of 0, 1, or be undefined"
 #endif
+
+#else
+
+#ifdef I2C5
+#error "I2C5 is only available on IMXRT117x"
+#endif
+
+#ifdef I2C6
+#error "I2C6 is only available on IMXRT117x"
+#endif
+
+#define I2C5 0
+#define I2C6 0
 
 #endif /* #ifdef __CPU_IMXRT117X */
 
@@ -1325,9 +1370,20 @@
 
 #ifndef TRNG
 #define TRNG 0
+#elif !ISBOOLEAN(TRNG)
+#error "TRNG must have a value of 0, 1, or be undefined"
 #endif
 
+#else
+
+#ifdef TRNG
+#error "TRNG is not available on IMXRT117x"
+#endif
+
+#define TRNG 0
+
 #endif /* #ifndef __CPU_IMXRT117X */
+
 
 /* Temperature */
 
@@ -1341,10 +1397,6 @@
 #error "PCT2075_DEV_ADDR must be defined"
 #endif
 
-/* libdummyfs */
-#ifndef BUILTIN_DUMMYFS
-#define BUILTIN_DUMMYFS 0
-#endif
 
 /* Cortex M4 */
 
@@ -1352,8 +1404,48 @@
 
 #ifndef CM4
 #define CM4 1
+#elif !ISBOOLEAN(CM4)
+#error "CM4 must have a value of 0, 1, or be undefined"
 #endif
 
+#else
+
+#ifdef CM4
+#error "CM4 is only available on IMXRT117x"
 #endif
+
+#define CM4 0
+
+#endif /* #ifdef __CPU_IMXRT117X */
+
+
+/* libdummyfs */
+
+#ifndef BUILTIN_DUMMYFS
+#define BUILTIN_DUMMYFS 0
+#elif !ISBOOLEAN(BUILTIN_DUMMYFS)
+#error "BUILTIN_DUMMYFS must have a value of 0, 1, or be undefined"
+#endif
+
+
+/* libposixsrv */
+
+#ifndef BUILTIN_POSIXSRV
+#define BUILTIN_POSIXSRV 0
+#elif !ISBOOLEAN(BUILTIN_POSIXSRV)
+#error "BUILTIN_POSIXSRV must have a value of 0, 1, or be undefined"
+#endif
+
+
+/* Pseudodev */
+
+#ifndef PSEUDODEV
+#define PSEUDODEV 0
+#elif !ISBOOLEAN(PSEUDODEV)
+#error "PSEUDODEV must have a value of 0, 1, or be undefined"
+#endif
+
+
+#pragma GCC diagnostic pop
 
 #endif

--- a/multi/imxrt-multi/imxrt-multi.c
+++ b/multi/imxrt-multi/imxrt-multi.c
@@ -114,12 +114,14 @@ static void multi_dispatchMsg(msg_t *msg)
 			spi_handleMsg(msg, id);
 			break;
 
+#if CM4
 		case id_cm4_0:
 		case id_cm4_1:
 		case id_cm4_2:
 		case id_cm4_3:
 			cm4_handleMsg(msg);
 			break;
+#endif
 #endif
 
 		case id_i2c1:
@@ -133,7 +135,7 @@ static void multi_dispatchMsg(msg_t *msg)
 			i2c_handleMsg(msg, id);
 			break;
 
-#ifndef __CPU_IMXRT117X
+#if !defined(__CPU_IMXRT117X) && TRNG
 		case id_trng:
 			trng_handleMsg(msg);
 			break;
@@ -396,8 +398,6 @@ static int createDevFiles(void)
 	}
 #endif
 
-#ifdef __CPU_IMXRT117X
-
 #if SPI5
 	if (mkFile(&dir, id_spi5, "spi5", multi_port) < 0) {
 		return -1;
@@ -418,8 +418,6 @@ static int createDevFiles(void)
 			return -1;
 		}
 	}
-#endif
-
 #endif
 
 
@@ -448,9 +446,6 @@ static int createDevFiles(void)
 	}
 #endif
 
-
-#ifdef __CPU_IMXRT117X
-
 #if I2C5
 	if (mkFile(&dir, id_i2c5, "i2c5", multi_port) < 0) {
 		return -1;
@@ -463,10 +458,6 @@ static int createDevFiles(void)
 	}
 #endif
 
-#endif
-
-#ifndef __CPU_IMXRT117X
-
 #if TRNG
 	if (mkFile(&dir, id_trng, "random", multi_port) < 0) {
 		return -1;
@@ -476,8 +467,6 @@ static int createDevFiles(void)
 	if (mkFile(&dir, id_trng, "trng", multi_port) < 0) {
 		return -1;
 	}
-#endif
-
 #endif
 
 #if PCT2075


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt117x.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
