### PR TITLE
Fixes to allow enabling -Wundef, except imxrt-multi

### DIFF
--- a/can/zynqmp-can/zynqmp-can.c
+++ b/can/zynqmp-can/zynqmp-can.c
@@ -30,6 +30,10 @@
 #include "zynqmp-can-priv.h"
 #include "zynqmp-can-if.h"
 
+#ifndef CAN_ROUTED_VIA_PL
+#define CAN_ROUTED_VIA_PL 0
+#endif
+
 /**
  * Watermark configuration for "TX FIFO empty elements above watermark" interrupt.
  * Setting this to low values (e.g., 1) reduces the blocking time for the sending function

--- a/multi/grlib-multi/grlib-multi.c
+++ b/multi/grlib-multi/grlib-multi.c
@@ -30,6 +30,10 @@
 
 #include <phoenix/ioctl.h>
 
+#ifndef PSEUDODEV
+#define PSEUDODEV 0
+#endif
+
 #if PSEUDODEV
 #include <pseudodev.h>
 #endif

--- a/tty/zynq-uart/zynq-uart.c
+++ b/tty/zynq-uart/zynq-uart.c
@@ -44,6 +44,9 @@
 #error "Unsupported platform"
 #endif
 
+#ifndef UART_CONSOLE_ROUTED_VIA_PL
+#define UART_CONSOLE_ROUTED_VIA_PL 0
+#endif
 
 #define UARTS_MAX_CNT 2
 #define UART_REF_CLK  50000000 /* 50 MHz */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
There are some useful warning flags, which are enabled in internal projects, like `-Wundef` and `-Wshadow`.

This commit allow phoenix-rtos-devices to be build with `-Wundef` without warnings along with https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/554

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To enable `-Wundef` flag in the future

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: Build on every target, not tested really.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
