### PR TITLE
usbacm: idtree bug fixes

### DIFF
--- a/tty/usbacm/usbacm.c
+++ b/tty/usbacm/usbacm.c
@@ -708,7 +708,7 @@ static int usbacm_handleInsertion(usb_driver_t *drv, usb_devinfo_t *insertion, u
 		oid.port = usbacm_common.msgport;
 		oid.id = idtree_id(&dev->node);
 
-		snprintf(dev->path, sizeof(dev->path), "/dev/usbacm%zu", oid.id);
+		snprintf(dev->path, sizeof(dev->path), "/dev/usbacm%d", idtree_id(&dev->node));
 
 		err = create_dev(&oid, dev->path);
 		if (err != 0) {

--- a/tty/usbacm/usbacm.c
+++ b/tty/usbacm/usbacm.c
@@ -414,7 +414,7 @@ static usbacm_dev_t *_usbacm_devAlloc(void)
 		return NULL;
 	}
 
-	if (idtree_alloc(&usbacm_common.devices, &dev->node) != 0) {
+	if (idtree_alloc(&usbacm_common.devices, &dev->node) < 0) {
 		free(dev);
 		return NULL;
 	}

--- a/tty/usbacm/usbacm.c
+++ b/tty/usbacm/usbacm.c
@@ -566,6 +566,7 @@ static void usbacm_msgthr(void *arg)
 		/* A device can be opened only by one process */
 		/* FIXME: allow mtClose with different PID (files closing on process exit have invalid PID value as of 2023-10-23) */
 		if (((msg.type != mtOpen) && (msg.type != mtClose)) && (msg.pid != dev->clientpid)) {
+			usbacm_put(dev);
 			msg.o.err = -EBUSY;
 			msgRespond(usbacm_common.msgport, &msg, rid);
 			continue;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

First commit fixes mem exception on DTR caused by use-after-free for any nodes with id higher than 0 due to wrong error handling in `_usbacm_devAlloc`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
