### PR TITLE
tty/uart16550: add TDA4VM target

### DIFF
--- a/_targets/Makefile.armv7r5f-tda4vm
+++ b/_targets/Makefile.armv7r5f-tda4vm
@@ -1,0 +1,9 @@
+#
+# Makefile for Phoenix-RTOS 3 device drivers
+#
+# TDA4VM drivers
+#
+# Copyright 2025 Phoenix Systems
+#
+
+DEFAULT_COMPONENTS := uart16550

--- a/tty/uart16550/Makefile
+++ b/tty/uart16550/Makefile
@@ -16,6 +16,8 @@ else ifeq ($(TARGET_SUBFAMILY),zynq7000)
   LOCAL_SRCS += uarthw-zynq.c
 else ifeq ($(TARGET_SUBFAMILY),zynqmp)
   LOCAL_SRCS += uarthw-zynq.c
+else ifeq ($(TARGET_SUBFAMILY),tda4vm)
+  LOCAL_SRCS += uarthw-tda4vm.c
 endif
 
 DEP_LIBS := libtty libklog

--- a/tty/uart16550/uart16550.c
+++ b/tty/uart16550/uart16550.c
@@ -13,6 +13,7 @@
  */
 
 #include <errno.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -36,8 +37,12 @@
 
 #define KMSG_CTRL_ID 100
 
+#define SW_BUF_SIZE 64
+
 typedef struct {
 	uint8_t hwctx[64];
+	uint8_t buf[SW_BUF_SIZE];
+	volatile unsigned int buf_i;
 
 	unsigned int init;
 	unsigned int clk;
@@ -129,46 +134,99 @@ static void set_cflag(void *_uart, tcflag_t *cflag)
 static void signal_txready(void *arg)
 {
 	uart_t *uart = (uart_t *)arg;
-
-	uarthw_write(uart->hwctx, REG_IMR, IMR_THRE | IMR_DR);
 	condSignal(uart->intcond);
 }
 
 #ifdef __TARGET_RISCV64
-__attribute__((section(".interrupt"), aligned(0x1000)))
-#endif
-static int
-uart_interrupt(unsigned int n, void *arg)
+__attribute__((section(".interrupt"), aligned(0x1000))) static int uart_interrupt(unsigned int n, void *arg)
 {
-	return ((uart_t *)arg)->intcond;
+	/* RISC-V platform is very special in how it handles memory during interrupts.
+	 * Due to this the uart_interrupt function cannot call uarthw_* functions.
+	 * Fortunately the UART IRQ on this platform is edge-triggered so we can just
+	 * exit interrupt, signal uart->intcond and main thread will handle the rest.
+	 */
+	uart_t *uart = (uart_t *)arg;
+	return uart->intcond;
 }
+#else
+static int uart_interrupt(unsigned int n, void *arg)
+{
+	uart_t *uart = (uart_t *)arg;
+
+	/* Caution: implementation-dependent behavior!
+	 * On some UARTs masking interrupts after an interrupt has been asserted
+	 * does not de-assert the IRQ line. In this case it is necessary to handle
+	 * the interrupt's cause fully within the ISR (e.g. reading the whole FIFO).
+	 * On other UARTs masking interrupts de-asserts IRQ and changes the value of IIR.
+	 * To handle this case we read IIR before masking interrupts. Note that in this
+	 * case the FIFO will not be fully read within the ISR.
+	 */
+	uint8_t iir = uarthw_read(uart->hwctx, REG_IIR);
+	uarthw_write(uart->hwctx, REG_IMR, 0);
+	unsigned int i = uart->buf_i;
+	do {
+		uint8_t intr_type = (iir >> 1) & 0x7;
+		if ((intr_type == IIR_CODE_DR) || (intr_type == IIR_CODE_RTO)) {
+			uint8_t c = uarthw_read(uart->hwctx, REG_RBR);
+			if (i < SW_BUF_SIZE) {
+				uart->buf[i] = c;
+				i++;
+			}
+		}
+		else if (intr_type == IIR_CODE_LS) {
+			uarthw_read(uart->hwctx, REG_LSR);
+		}
+		else if (intr_type == IIR_CODE_MS) {
+			uarthw_read(uart->hwctx, REG_MSR);
+		}
+
+		iir = uarthw_read(uart->hwctx, REG_IIR);
+	} while ((iir & IIR_IRQPEND) == 0);
+
+	uart->buf_i = i;
+	return uart->intcond;
+}
+#endif
 
 
 static void uart_intthr(void *arg)
 {
 	uart_t *uart = (uart_t *)arg;
-	uint8_t iir;
+	uint8_t target_imr = IMR_DR;
 
 	mutexLock(uart->mutex);
 	for (;;) {
-		while ((iir = uarthw_read(uart->hwctx, REG_IIR)) & IIR_IRQPEND) {
-			condWait(uart->intcond, uart->mutex, 0);
+		uarthw_write(uart->hwctx, REG_IMR, target_imr);
+		condWait(uart->intcond, uart->mutex, 0);
+		/* For the following part the interrupt needs to be masked */
+		uarthw_write(uart->hwctx, REG_IMR, 0);
+
+		/* Empty received buffer */
+		unsigned int buf_i = uart->buf_i;
+		for (unsigned int i = 0; i < buf_i; i++) {
+			libtty_putchar(&uart->tty, uart->buf[i], NULL);
 		}
 
-		/* Receive */
-		if (iir & IIR_DR) {
-			while (uarthw_read(uart->hwctx, REG_LSR) & 0x1) {
-				libtty_putchar(&uart->tty, uarthw_read(uart->hwctx, REG_RBR), NULL);
-			}
+		uart->buf_i = 0;
+		/* Depending on implementation we may have more characters in hardware FIFO */
+		while ((uarthw_read(uart->hwctx, REG_LSR) & LSR_DR) != 0) {
+			libtty_putchar(&uart->tty, uarthw_read(uart->hwctx, REG_RBR), NULL);
 		}
 
-		/* Transmit */
-		if (iir & IIR_THRE) {
-			if (libtty_txready(&uart->tty)) {
-				uarthw_write(uart->hwctx, REG_THR, libtty_getchar(&uart->tty, NULL));
+		/* Check for transmit */
+		while (1) {
+			if (libtty_txready(&uart->tty) != 0) {
+				if ((uarthw_read(uart->hwctx, REG_LSR) & LSR_THRE) != 0) {
+					uarthw_write(uart->hwctx, REG_THR, libtty_getchar(&uart->tty, NULL));
+				}
+				else {
+					target_imr |= IMR_THRE;
+					break;
+				}
 			}
 			else {
-				uarthw_write(uart->hwctx, REG_IMR, IMR_DR);
+				target_imr &= ~IMR_THRE;
+				break;
 			}
 		}
 	}
@@ -342,6 +400,7 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed)
 		return err;
 	}
 
+	uart->buf_i = 0;
 	condCreate(&uart->intcond);
 	mutexCreate(&uart->mutex);
 
@@ -363,7 +422,7 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed)
 	uarthw_write(uart->hwctx, REG_MCR, MCR_OUT2);
 
 	/* Set interrupt mask */
-	uarthw_write(uart->hwctx, REG_IMR, IMR_DR);
+	uarthw_write(uart->hwctx, REG_IMR, 0);
 
 	return EOK;
 }

--- a/tty/uart16550/uart16550.h
+++ b/tty/uart16550/uart16550.h
@@ -15,9 +15,6 @@
 #ifndef _DEV_SERIAL_H_
 #define _DEV_SERIAL_H_
 
-#define SIZE_SERIALS      2
-#define SIZE_SERIAL_CHUNK 256
-
 
 /* UART registers */
 #define REG_RBR 0
@@ -38,15 +35,21 @@
 #define IMR_THRE 0x02
 #define IMR_DR   0x01
 
-#define IIR_IRQPEND 0x01
-#define IIR_THRE    0x02
-#define IIR_DR      0x04
+#define IIR_IRQPEND   0x01
+#define IIR_CODE_MS   0x00 /* Modem Status */
+#define IIR_CODE_THRE 0x01 /* Transmitter Holding Register Empty */
+#define IIR_CODE_DR   0x02 /* Received Data Ready */
+#define IIR_CODE_LS   0x03 /* Receiver Line Status */
+#define IIR_CODE_RTO  0x06 /* Reception Timeout */
 
 #define LCR_DLAB 0x80
 #define LCR_D8N1 0x03
 #define LCR_D8N2 0x07
 
 #define MCR_OUT2 0x08
+#define MCR_OUT1 0x04
+#define MCR_RTS  0x02
+#define MCR_DTR  0x01
 
 #define LSR_DR   0x01
 #define LSR_THRE 0x20

--- a/tty/uart16550/uarthw-tda4vm.c
+++ b/tty/uart16550/uarthw-tda4vm.c
@@ -1,0 +1,281 @@
+/*
+ * Phoenix-RTOS
+ *
+ * UART 16550 device driver
+ *
+ * Hardware abstraction layer (TDA4VM)
+ *
+ * Copyright 2025 Phoenix Systems
+ * Author: Aleksander Kaminski, Jacek Maksymowicz
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <sys/platform.h>
+#include <board_config.h>
+#include <phoenix/arch/armv7r/tda4vm/tda4vm.h>
+#include <phoenix/arch/armv7r/tda4vm/tda4vm_pins.h>
+
+#include "uart16550.h"
+
+/* UART extension registers */
+#define REG_EFR  2 /* Enhanced feature register */
+#define REG_MDR1 8 /* Mode definition register 1 */
+#define REG_MDR2 9 /* Mode definition register 2 */
+
+
+#define MCU_UART0_BASE_ADDR ((void *)0x40a00000)
+#define MCU_UART0_IRQ       30
+
+#define MAIN_UART0_BASE_ADDR ((void *)0x02800000)
+#define MAIN_UART1_BASE_ADDR ((void *)0x02810000)
+#define MAIN_UART2_BASE_ADDR ((void *)0x02820000)
+#define MAIN_UART3_BASE_ADDR ((void *)0x02830000)
+#define MAIN_UART4_BASE_ADDR ((void *)0x02840000)
+#define MAIN_UART5_BASE_ADDR ((void *)0x02850000)
+#define MAIN_UART6_BASE_ADDR ((void *)0x02860000)
+#define MAIN_UART7_BASE_ADDR ((void *)0x02870000)
+#define MAIN_UART8_BASE_ADDR ((void *)0x02880000)
+#define MAIN_UART9_BASE_ADDR ((void *)0x02890000)
+
+#ifndef MAIN_UART0_IRQ
+#define MAIN_UART0_IRQ -1
+#endif
+
+#ifndef MAIN_UART1_IRQ
+#define MAIN_UART1_IRQ -1
+#endif
+
+#ifndef MAIN_UART2_IRQ
+#define MAIN_UART2_IRQ -1
+#endif
+
+#ifndef MAIN_UART3_IRQ
+#define MAIN_UART3_IRQ -1
+#endif
+
+#ifndef MAIN_UART4_IRQ
+#define MAIN_UART4_IRQ -1
+#endif
+
+#ifndef MAIN_UART5_IRQ
+#define MAIN_UART5_IRQ -1
+#endif
+
+#ifndef MAIN_UART6_IRQ
+#define MAIN_UART6_IRQ -1
+#endif
+
+#ifndef MAIN_UART7_IRQ
+#define MAIN_UART7_IRQ -1
+#endif
+
+#ifndef MAIN_UART8_IRQ
+#define MAIN_UART8_IRQ -1
+#endif
+
+#ifndef MAIN_UART9_IRQ
+#define MAIN_UART9_IRQ -1
+#endif
+
+
+#define MAX_PINS_PER_UART 6
+typedef struct {
+	volatile uint32_t *base;
+	struct {
+		int16_t clksel; /* Value of < 0 means this UART has no CLKSEL */
+		uint8_t clksel_val;
+	};
+	int16_t clkdiv;
+	uint8_t divisor;
+	uint8_t pll;
+	uint8_t hsdiv;
+	int irq;
+	struct {
+		int16_t pin; /* Value of < 0 signals end of list */
+		uint8_t muxSetting;
+		uint8_t isTx;
+	} pins[MAX_PINS_PER_UART];
+	struct {
+		uint32_t tx;
+		uint32_t rx;
+	} pins_selected;
+} tda4vm_uart_info_t;
+
+
+static const tda4vm_uart_info_t uarthw_info[] = {
+	{
+		.base = MCU_UART0_BASE_ADDR,
+		.clksel = clksel_mcu_usart,
+		.clksel_val = 0, /* CLKSEL set to MCU_PLL1_HSDIV3_CLKOUT */
+		.clkdiv = -1,
+		.divisor = 1,
+		.pll = clk_mcu_per_pll1,
+		.hsdiv = 3,
+		.irq = MCU_UART0_IRQ,
+		.pins = {
+			{ pin_mcu_ospi1_d2, 4, 1 },
+			{ pin_wkup_gpio0_10, 2, 1 },
+			{ pin_wkup_gpio0_12, 0, 1 },
+			{ pin_mcu_ospi1_d1, 4, 0 },
+			{ pin_wkup_gpio0_11, 2, 0 },
+			{ pin_wkup_gpio0_13, 0, 0 },
+		},
+		.pins_selected = {
+			.tx = UART0_TX,
+			.rx = UART0_RX,
+		},
+	},
+};
+
+
+typedef struct {
+	volatile uint32_t *base;
+	unsigned int irq;
+} uarthw_ctx_t;
+
+
+uint8_t uarthw_read(void *hwctx, unsigned int reg)
+{
+	volatile uint32_t *p = (((uarthw_ctx_t *)hwctx)->base + reg);
+
+	return ((uint8_t)(*p));
+}
+
+
+void uarthw_write(void *hwctx, unsigned int reg, uint8_t val)
+{
+	volatile uint32_t *p = (((uarthw_ctx_t *)hwctx)->base + reg);
+
+	*p = val;
+}
+
+
+char *uarthw_dump(void *hwctx, char *s, size_t sz)
+{
+	snprintf(s, sz, "base=0x%p irq=%u", (volatile void *)(((uarthw_ctx_t *)hwctx)->base), ((uarthw_ctx_t *)hwctx)->irq);
+	return s;
+}
+
+
+unsigned int uarthw_irq(void *hwctx)
+{
+	return ((uarthw_ctx_t *)hwctx)->irq;
+}
+
+
+static int uarthw_setPin(const tda4vm_uart_info_t *info, uint32_t pin)
+{
+	platformctl_t pctl;
+	pctl.action = pctl_set;
+	pctl.type = pctl_pinconfig;
+
+	for (size_t i = 0; i < MAX_PINS_PER_UART; i++) {
+		if (info->pins[i].pin < 0) {
+			return -EINVAL;
+		}
+
+		if (info->pins[i].pin == pin) {
+			pctl.pin_config.pin_num = pin;
+			pctl.pin_config.debounce_idx = 0;
+			pctl.pin_config.mux = info->pins[i].muxSetting;
+			if (info->pins[i].isTx) {
+				pctl.pin_config.flags = TDA4VM_GPIO_PULL_DISABLE;
+			}
+			else {
+				pctl.pin_config.flags = TDA4VM_GPIO_RX_EN | TDA4VM_GPIO_PULL_DISABLE;
+			}
+
+			return platformctl(&pctl);
+		}
+	}
+
+	return -EINVAL;
+}
+
+
+int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, unsigned int *fclk)
+{
+	void *base;
+	platformctl_t pctl;
+	int ret;
+	if (hwctxsz < sizeof(uarthw_ctx_t)) {
+		return -EINVAL;
+	}
+
+	if ((uartn >= sizeof(uarthw_info) / sizeof(uarthw_info[0]))) {
+		return -ENODEV;
+	}
+
+	const tda4vm_uart_info_t *info = &uarthw_info[uartn];
+	if ((info->base == 0) || (info->irq < 0)) {
+		return -EINVAL;
+	}
+
+	if (info->clksel >= 0) {
+		pctl.action = pctl_set;
+		pctl.type = pctl_clksel;
+		pctl.clksel_clkdiv.sel = info->clksel;
+		pctl.clksel_clkdiv.val = info->clksel_val;
+		if (platformctl(&pctl) < 0) {
+			return -EIO;
+		}
+	}
+
+	if (info->clkdiv >= 0) {
+		pctl.action = pctl_set;
+		pctl.type = pctl_clkdiv;
+		pctl.clksel_clkdiv.sel = info->clkdiv;
+		pctl.clksel_clkdiv.val = info->divisor;
+		if (platformctl(&pctl) < 0) {
+			return -EIO;
+		}
+	}
+
+	pctl.action = pctl_get;
+	pctl.type = pctl_frequency;
+	pctl.frequency.pll_num = info->pll;
+	pctl.frequency.hsdiv = info->hsdiv;
+
+	if (platformctl(&pctl) < 0) {
+		return -EIO;
+	}
+
+	if ((pctl.frequency.val == 0) || (pctl.frequency.val > UINT32_MAX)) {
+		return -EIO;
+	}
+
+	*fclk = (unsigned int)pctl.frequency.val / info->divisor;
+	ret = uarthw_setPin(info, info->pins_selected.tx);
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = uarthw_setPin(info, info->pins_selected.rx);
+	if (ret < 0) {
+		return ret;
+	}
+
+	base = mmap(NULL, _PAGE_SIZE, PROT_WRITE | PROT_READ, MAP_DEVICE | MAP_PHYSMEM | MAP_ANONYMOUS, -1, (addr_t)info->base);
+	if (base == MAP_FAILED) {
+		return -ENOMEM;
+	}
+
+	((uarthw_ctx_t *)hwctx)->base = base;
+	((uarthw_ctx_t *)hwctx)->irq = info->irq;
+
+	/* Put into UART x16 mode */
+	uarthw_write(hwctx, REG_MDR1, 0x0);
+
+	/* Enable enhanced functions */
+	uarthw_write(hwctx, REG_LCR, 0xbf);
+	uarthw_write(hwctx, REG_EFR, 1 << 4);
+	uarthw_write(hwctx, REG_LCR, 0x0);
+
+	return EOK;
+}


### PR DESCRIPTION
## Description
Added hardware abstraction files for TDA4VM target.

To make the `uart16550` driver compatible with the UART on TDA4VM some changes had to be made concerning interrupt handling. On that platform the UART interrupt is level-triggered and cannot be reconfigured to be edge-triggered. Additionally, trying to mask the data ready interrupt in the `IMR` register has no effect after the interrupt has been asserted. To solve this, the hardware FIFO is read into a buffer until the data ready interrupt flag is down.

Code has been tested on `ia32-generic-qemu` and `riscv64-generic-qemu` and found to work. It also achieves better performance because it reads FIFO fully before re-enabling the interrupt (thus avoiding interrupt handling overhead).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7r5f-tda4vm-som, ia32-generic-qemu, riscv64-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
