### PR TITLE
stm32l4-multi: fix warning in libdma

### DIFF
--- a/multi/stm32l4-multi/libmulti/libdma.c
+++ b/multi/stm32l4-multi/libmulti/libdma.c
@@ -241,7 +241,7 @@ static int libdma_transferTimeout(int dma, int channel, void *maddr, size_t len,
 	libdma_prepareTransfer(dma, channel, maddr, len, DMA_TCIE_FLAG);
 
 	condTimeout = timeout;
-	if (timeout > 0) {
+	if (timeout != 0) {
 		gettime(&now, NULL);
 		end = now + timeout;
 	}


### PR DESCRIPTION
JIRA: RTOS-1104

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/phoenix-rtos/phoenix-rtos-kernel/actions/runs/17038867085/job/48297615874?pr=688

 /github/workspace/.buildroot/phoenix-rtos-project/phoenix-rtos-devices/multi/stm32l4-multi/libmulti/libdma.c: In function 'libdma_transferTimeout':
Error: /github/workspace/.buildroot/phoenix-rtos-project/phoenix-rtos-devices/multi/stm32l4-multi/libmulti/libdma.c:257:28: error: 'end' may be used uninitialized [-Werror=maybe-uninitialized]
  257 |                         if (end <= now) {
      |                            ^
/github/workspace/.buildroot/phoenix-rtos-project/phoenix-rtos-devices/multi/stm32l4-multi/libmulti/libdma.c:235:21: note: 'end' was declared here
  235 |         time_t now, end, condTimeout;
      |                     ^~~

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
