### PR TITLE
sensors: add local sensors API

### DIFF
--- a/sensors/Makefile
+++ b/sensors/Makefile
@@ -10,7 +10,7 @@ LOCAL_PATH := $(call my-dir)
 # FIXME: need platform specific dependency of libzynq7000-gpio-msg
 NAME := libsensors
 LOCAL_HEADERS_DIR := server-include
-SRCS := $(wildcard $(LOCAL_PATH)common/*/*.c)
+SRCS := $(wildcard $(LOCAL_PATH)common/*/*.c) $(LOCAL_PATH)locsensor.c
 DEPS := libzynq7000-gpio-msg libspi-msg libsensorsclient
 include $(static-lib.mk)
 

--- a/sensors/locsensor.c
+++ b/sensors/locsensor.c
@@ -1,0 +1,174 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Sensor Manager local implementation
+ *
+ * Copyright 2025 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#ifndef SENSORS_MAX
+#define SENSORS_MAX 8
+#endif
+
+#define ERRSTR "locsensors"
+
+#include <string.h>
+
+#include <libsensors/sensor.h>
+#include <libsensors/client.h>
+
+
+struct {
+	/* sensor auto-registration storage */
+	const sensor_drv_t *drv[SENSORS_MAX];
+	int ndrv;
+
+	/* sensor allocation storage */
+	sensor_info_t dev[SENSORS_MAX];
+	int ndev;
+} locsensors_common;
+
+
+/**
+ * Searches for sensor with `name` through auto-registered sensors.
+ *
+ * Returns index of auto-registered driver structure in locsensors_common.drv[] array.
+ * Returns -1 if no `name` sensor is not registered.
+ */
+static int sensor_nameSearch(const char *name)
+{
+	for (int i = 0; i < locsensors_common.ndrv; i++) {
+		if (strcmp(locsensors_common.drv[i]->name, name) == 0) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+
+int locsensor_read(const sensor_info_t *info, const sensor_event_t **evt)
+{
+	return locsensors_common.drv[info->id]->read(info, evt);
+}
+
+
+const sensor_info_t *locsensor_find(int types, int n)
+{
+	for (int i = 0; i < locsensors_common.ndev; i++) {
+		if (locsensors_common.dev[i].types == types && n == 0) {
+			return &locsensors_common.dev[i];
+		}
+	}
+
+	return NULL;
+}
+
+
+void locsensor_dealloc(void)
+{
+	const sensor_drv_t *drv;
+	sensor_info_t *info;
+
+	for (int i = 0; i < locsensors_common.ndev; i++) {
+		info = &locsensors_common.dev[i];
+		drv = locsensors_common.drv[info->id];
+
+		drv->dealloc(info);
+	}
+}
+
+
+int locsensors_publish(unsigned int devId, const sensor_event_t *event)
+{
+	/* Empty implementation, just to match the "libsensors/sensor.h:sensors_publish" */
+	return 0;
+}
+
+
+void locsensors_register(const sensor_drv_t *drv)
+{
+	if (locsensors_common.ndrv >= SENSORS_MAX) {
+		printf("locsensors: no register space: %s\n", drv->name);
+		return;
+	}
+
+	locsensors_common.drv[locsensors_common.ndrv++] = drv;
+}
+
+
+int locsensor_alloc(char *args)
+{
+	const char *sensorNames[SENSORS_MAX];
+	const char *sensorArgs[SENSORS_MAX];
+	char *ptr;
+	int argc = 0;
+
+	/* Get per-sensor tokens with "<name>:<arg1>:(...):<argN>" structure with sttrok() */
+	ptr = strtok(args, " ");
+	if (ptr == NULL) {
+		fprintf(stderr, "%s: wrong arguments: %s\n", ERRSTR, args);
+		return -1;
+	}
+
+	while (ptr != NULL && argc < locsensors_common.ndrv) {
+		sensorNames[argc] = ptr;
+		ptr = strtok(NULL, " ");
+		argc++;
+	}
+
+	/* Check if all sensors from args are registered */
+	for (int i = 0; i < argc; i++) {
+		ptr = strchr(sensorNames[i], ':');
+		if (ptr == NULL) {
+			fprintf(stderr, "%s: no args for %s\n", ERRSTR, sensorNames[i]);
+			return -1;
+		}
+
+		/**
+		 * Split <name> and <arg1>:(...):<argN> parts.
+		 * If there is only ':' after sensor name, sensorArgs will point to '\0'.
+		 */
+		*ptr = '\0';
+		sensorArgs[i] = ptr + 1;
+
+		/* Find sensor driver and prepare sensor device with it */
+		sensor_info_t *info = &locsensors_common.dev[i];
+		int drvIdx = sensor_nameSearch(sensorNames[i]);
+		if (drvIdx < 0) {
+			fprintf(stderr, "%s: unknown sensor %s\n", ERRSTR, sensorNames[i]);
+			return -1;
+		}
+		info->id = drvIdx;
+		info->drv = locsensors_common.drv[drvIdx]->name;
+	}
+
+	/* allocate valid sensors */
+	for (int i = 0; i < argc; i++) {
+		int err = 0;
+		sensor_info_t *info = &locsensors_common.dev[i];
+		const sensor_drv_t *drv = locsensors_common.drv[info->id];
+
+		err = drv->alloc(info, sensorArgs[i]);
+		if (err != 0) {
+			fprintf(stderr, "%s: alloc failed: %s\n", ERRSTR, sensorNames[i]);
+			for (int j = 0; j < i; ++j) {
+				info = &locsensors_common.dev[j];
+				drv = locsensors_common.drv[info->id];
+
+				drv->dealloc(info);
+			}
+			return -1;
+		}
+	}
+
+	locsensors_common.ndev = argc;
+
+	return 0;
+}

--- a/sensors/server-include/libsensors/local/sensors.h
+++ b/sensors/server-include/libsensors/local/sensors.h
@@ -1,0 +1,65 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Sensor Manager local implementation
+ *
+ * Copyright 2025 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#ifndef _SENSORS_LOCAL_H
+#define _SENSORS_LOCAL_H
+
+#include <libsensors/sensor.h>
+
+
+/**
+ * Performs a read  operation on sensors specified by `info`.
+ */
+int locsensor_read(const sensor_info_t *info, const sensor_event_t **evt);
+
+
+/**
+ * Finds a sensor of specific type (e.g SENSOR_TYPE_ACCEL | SENSOR_TYPE_GYRO for 6dof IMU).
+ */
+const sensor_info_t *locsensor_find(int types, int n);
+
+
+/**
+ * Deallocates all allocated local sensors
+ */
+void locsensor_dealloc(void);
+
+
+/**
+ * Allocates all local sensors from `args` which are auto-registered from
+ * sensor libraries dependencies.
+ *
+ * Returns 0 on successful allocation of all sensors specified by "args".
+ * Returns -1 on error.
+ */
+int locsensor_alloc(char *args);
+
+
+/**
+ * Function digests `event` from an `devId` sensor.
+ * Function meant to be used as remapping from generic "sensor_register()"
+ *
+ * #TODO: This function is stub-implemented, no publishig is done!
+ */
+int locsensors_publish(unsigned int devId, const sensor_event_t *event);
+
+
+/**
+ * Function registers "drv" as local driver.
+ * Function meant to be used as remapping from generic "sensor_register()"
+ */
+void locsensors_register(const sensor_drv_t *drv);
+
+
+#endif

--- a/sensors/server-include/libsensors/sensor.h
+++ b/sensors/server-include/libsensors/sensor.h
@@ -39,7 +39,15 @@ typedef struct {
 typedef struct {
 	char name[16];                                       /* device name */
 	int (*alloc)(sensor_info_t *info, const char *args); /* alloc sensor and initialize driver */
+	int (*dealloc)(sensor_info_t *info);                 /* deallocate sensor */
 	int (*start)(sensor_info_t *info);                   /* start measurement thread */
+
+	/**
+	 * Reads data from the device. Pointer to read data is stored in evt.
+	 * Returns number of read data samples, or -1 on error.
+	 */
+	int (*read)(const sensor_info_t *info, const sensor_event_t **evt);
+
 	rbnode_t node;
 } sensor_drv_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR changes (incrementally) sensors registration API. Now it is possible to use sensors libraries both in sensorhub (as a separate sensor data server) and in local binaries (as locally allocated sensors). Though it is not possible to use them both at the same time.

`libsensors/local/sensor.h` serves an API for standalone application to use sensors. Sensor registration process is still auto-magic through constructors. The `locsensor` user should redirect its own `sensor_register()` and `sensor_publish()` to the locsensor functions. `locsensor_publish()` is stub-implemented (there is no possibility now for establishing local thread with server. 

An entry implementation was done with `mpu6000` sensor. Additional commits that restructure each sensor has to follow.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
