### PR TITLE
stm32l4-multi: fix STM32N6 dshot driver to detect non DMA timers

### DIFF
--- a/multi/stm32l4-multi/pwm_n6.c
+++ b/multi/stm32l4-multi/pwm_n6.c
@@ -670,6 +670,9 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 	if (nbits > MAX_DSHOT_DMA) {
 		return -EINVAL;
 	}
+	if (((PWM_TIM_DMA >> timer) & 1) == 0) {
+		return -EINVAL;
+	}
 
 	mutexLock(pwm_common.dmalock);
 

--- a/multi/stm32l4-multi/pwm_n6.h
+++ b/multi/stm32l4-multi/pwm_n6.h
@@ -55,6 +55,7 @@
 #define PWM_TIM_GP2             ((1 << pwm_tim9) | (1 << pwm_tim12) | (1 << pwm_tim15))
 #define PWM_TIM_NO_MASTER_SLAVE ((1 << pwm_tim10) | (1 << pwm_tim11) | (1 << pwm_tim13) | (1 << pwm_tim14) | (1 << pwm_tim16) | (1 << pwm_tim17))
 #define PWM_TIM_32BIT           ((1 << pwm_tim2) | (1 << pwm_tim3) | (1 << pwm_tim4) | (1 << pwm_tim5))
+#define PWM_TIM_DMA             ((1 << pwm_tim1) | (1 << pwm_tim2) | (1 << pwm_tim3) | (1 << pwm_tim4) | (1 << pwm_tim5) | (1 << pwm_tim8) | (1 << pwm_tim15) | (1 << pwm_tim16) | (1 << pwm_tim17))
 
 
 /* Get the base clock frequency for a given timer. Returns 0 upon error. */


### PR DESCRIPTION
JIRA: RTOS-1102

<!--- Provide a general summary of your changes in the Title above -->
Small fix to include guarding against using a non DMA compatible TIMx peripheral for DSHOT.

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv8m55-stm32n6-nucram).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
