### PR TITLE
 storage/flashdrv: increase stack size on STM32N6

### DIFF
--- a/_targets/Makefile.armv8m55-stm32n6
+++ b/_targets/Makefile.armv8m55-stm32n6
@@ -6,4 +6,4 @@
 # Copyright 2019, 2020 Phoenix Systems
 #
 
-DEFAULT_COMPONENTS := stm32l4-multi libspi-msg libusbclient cdc-demo usbacm libusbdrv-usbacm
+DEFAULT_COMPONENTS := stm32l4-multi libspi-msg flashdrv libusbclient cdc-demo usbacm libusbdrv-usbacm

--- a/storage/flashdrv/Makefile
+++ b/storage/flashdrv/Makefile
@@ -14,8 +14,9 @@ ifneq ($(filter $(TARGET_SUBFAMILY), grfpga gr712rc gr740),)
 else ifneq ($(filter $(TARGET_SUBFAMILY), stm32n6),)
 # Set stack size - on ARMv8-M targets the default stack size given by the kernel may be too small
 # when filesystem support is added
-	LOCAL_LDFLAGS := -z stack-size=2048 -z noexecstack
-	LOCAL_CFLAGS += -DFLASHSRV_STORAGE_STACK_SIZE=2048
+	FLASHSRV_STORAGE_STACK_SIZE := 4096
+	LOCAL_LDFLAGS += -z stack-size=$(FLASHSRV_STORAGE_STACK_SIZE) -z noexecstack
+	LOCAL_CFLAGS += -DFLASHSRV_STORAGE_STACK_SIZE=$(FLASHSRV_STORAGE_STACK_SIZE)
 	DEP_LIBS := libstm32_extflash
 	LOCAL_CFLAGS += -DFLASHSRV_ENABLE_LITTLEFS=1
 	LIBS += liblfs


### PR DESCRIPTION
## Description
The previous stack size for `flashdrv` proved to be insufficient in some code paths when `DEBUG` was set to 1.

## Motivation and Context
JIRA: RTOS-1216

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
