### PR TITLE
libusbclient/stm32n6: fix DAINT handling

### DIFF
--- a/usb/libusbclient/stm32n6-usbc/client.h
+++ b/usb/libusbclient/stm32n6-usbc/client.h
@@ -130,7 +130,7 @@ typedef struct _usb_dc_t {
 	uint8_t ep0State;
 
 	uint32_t pending_event;
-	uint32_t daintClear;
+	_Atomic uint32_t daintClear;
 	uint32_t irqPendingDIEPINT[ENDPOINTS_NUMBER];
 	uint32_t irqPendingDOEPINT[ENDPOINTS_NUMBER];
 	uint32_t diepmsk;

--- a/usb/libusbclient/stm32n6-usbc/controller.c
+++ b/usb/libusbclient/stm32n6-usbc/controller.c
@@ -82,8 +82,9 @@ void ctrl_hifiq_handler(uint32_t *irqStatus)
 		daintClear = USB_REG(DAINT);
 		daintClear &= USB_REG(DAINTMSK);
 		daintClear &= 0xFFFF0000UL;
+		ctrl_common.dc->daintClear |= daintClear;
+
 		daintClear >>= 16;
-		ctrl_common.dc->daintClear = daintClear;
 
 		while (daintClear != 0U) {
 			if ((daintClear & 0x1U) != 0U) {
@@ -107,7 +108,7 @@ void ctrl_hifiq_handler(uint32_t *irqStatus)
 		daintClear = USB_REG(DAINT);
 		daintClear &= USB_REG(DAINTMSK);
 		daintClear &= 0xFFFFUL;
-		ctrl_common.dc->daintClear = daintClear;
+		ctrl_common.dc->daintClear |= daintClear;
 
 		while (daintClear != 0U) {
 			if ((daintClear & 0x1U) != 0U) {

--- a/usb/libusbclient/stm32n6-usbc/controller_callbacks.c
+++ b/usb/libusbclient/stm32n6-usbc/controller_callbacks.c
@@ -13,6 +13,7 @@
  * %LICENSE%
  */
 
+#include <stdatomic.h>
 #include "client.h"
 #include "phy.h"
 
@@ -682,7 +683,10 @@ void _clbc_OEPINT(void)
 	uint32_t epInt;
 	uint8_t epNum = 0U;
 	stm32n6_endpt_t *ep;
-	uint32_t daintClear = clbc_common.dc->daintClear;
+	uint32_t daintClear = atomic_fetch_and(&clbc_common.dc->daintClear, 0x0000FFFFU);
+
+	daintClear &= 0xFFFF0000U;
+	daintClear >>= 16U;
 
 	while (daintClear != 0U) {
 
@@ -786,7 +790,9 @@ void _clbc_IEPINT(void)
 	uint32_t epMsk, epEmp;
 	uint8_t epNum = 0U;
 	stm32n6_endpt_t *ep;
-	uint32_t daintClear = clbc_common.dc->daintClear;
+	uint32_t daintClear = atomic_fetch_and(&clbc_common.dc->daintClear, 0xFFFF0000U);
+
+	daintClear &= 0x0000FFFFU;
 
 	while (daintClear != 0U) {
 


### PR DESCRIPTION
TASK: PP-403

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This change fixes the handling of the `daintClear` variable ("device all endpoints interrupt").

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
During interrupts, hardware sets the `OTG_DAINT` register to indicate that a "significant event" occurred on one or more of the endpoints (1 bit per IN endpoint and 1 bit per OUT endpoint). This value was copied to a global `daintClear` variable in the interrupt handler so that it could later be used in the userspace thread (to indicate which endpoints have events that should be handled). The problem presented itself when more than one endpoint interrupt occurred between the iterations of the userspace thread. The interrupt handler would completely overwrite `daintClear` which would erase any previous, potentially not yet handled, events. This was causing the driver to miss some of the events, in particular, there was a reoccurring problem with `cdc_send` hanging forever because it missed the `XFRC` event ("transfer complete").

The code was modified so that the interrupt handler only sets the bits in `daintClear` and the userspace thread clears the bits as it's handling the events. This way no bit will be cleared until the event is handled. 

After a suggestion from Gemini, I also used atomic operations in the userspace thread to avoid the one in a million chance of interrupt firing exactly in the middle of a read-modify-write cycle.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m-stm32n6.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
