### PR TITLE
libusbclient/stm32n6: fix interrupt handler races

### DIFF
--- a/usb/libusbclient/stm32n6-usbc/client.c
+++ b/usb/libusbclient/stm32n6-usbc/client.c
@@ -13,6 +13,7 @@
  * %LICENSE%
  */
 
+#include <stdatomic.h>
 #include "phy.h"
 #include "client.h"
 
@@ -65,8 +66,10 @@ static void usbclient_irqThread(void *arg)
 	while (stm_common.dc.runIrqThread == 1U) {
 		condWait(stm_common.dc.irqCond, stm_common.dc.irqLock, 0);
 
+		uint32_t pending = atomic_exchange(&stm_common.dc.pending_event, 0U);
+
 		/* low-speed IRQ handling */
-		ctrl_lifiq_handler(&stm_common.dc.pending_event);
+		ctrl_lifiq_handler(pending);
 
 		if ((stm_common.dc.currEvent != stm_common.dc.prevEvent) && (stm_common.dc.cbEvent != NULL)) {
 			stm_common.dc.cbEvent(stm_common.dc.currEvent, stm_common.dc.ctxUser);

--- a/usb/libusbclient/stm32n6-usbc/client.h
+++ b/usb/libusbclient/stm32n6-usbc/client.h
@@ -129,10 +129,10 @@ typedef struct _usb_dc_t {
 	uint8_t deviceState;
 	uint8_t ep0State;
 
-	uint32_t pending_event;
+	_Atomic uint32_t pending_event;
 	_Atomic uint32_t daintClear;
-	uint32_t irqPendingDIEPINT[ENDPOINTS_NUMBER];
-	uint32_t irqPendingDOEPINT[ENDPOINTS_NUMBER];
+	_Atomic uint32_t irqPendingDIEPINT[ENDPOINTS_NUMBER];
+	_Atomic uint32_t irqPendingDOEPINT[ENDPOINTS_NUMBER];
 	uint32_t diepmsk;
 } usb_dc_t;
 
@@ -228,7 +228,7 @@ void *usbclient_allocBuff(uint32_t size);
 
 extern void ctrl_init(usb_common_data_t *usb_data_in, usb_dc_t *dc_in);
 extern void ctrl_hifiq_handler(uint32_t *irqStatus);
-extern void ctrl_lifiq_handler(uint32_t *irqStatus);
+extern void ctrl_lifiq_handler(uint32_t irqStatus);
 extern void ctrl_setAddress(uint32_t addr);
 
 extern void clbc_init(usb_common_data_t *usb_data_in, usb_dc_t *dc_in);

--- a/usb/libusbclient/stm32n6-usbc/controller.c
+++ b/usb/libusbclient/stm32n6-usbc/controller.c
@@ -181,32 +181,27 @@ void ctrl_hifiq_handler(uint32_t *irqStatus)
 }
 
 
-void ctrl_lifiq_handler(uint32_t *irqStatus)
+void ctrl_lifiq_handler(uint32_t irqStatus)
 {
 	uint8_t epNum;
 
 	/* USBRST */
-	if (IS_IRQ(*irqStatus, GINTSTS_USBRST)) {
-
-		*irqStatus &= ~(1UL << GINTSTS_USBRST);
+	if (IS_IRQ(irqStatus, GINTSTS_USBRST)) {
 		ctrl_common.dc->currEvent = USBCLIENT_EV_RESET;
 
 		_clbc_USBRST();
 	}
 
 	/* ENUMDNE */
-	if (IS_IRQ(*irqStatus, GINTSTS_ENUMDNE)) {
-
+	if (IS_IRQ(irqStatus, GINTSTS_ENUMDNE)) {
 		ctrl_common.dc->deviceState = USBD_STATE_DEFAULT;
-		*irqStatus &= ~(1UL << GINTSTS_ENUMDNE);
 		ctrl_common.dc->currEvent = USBCLIENT_EV_CONNECT;
 
 		_clbc_ENUMDNE();
 	}
 
 	/* USBSUSP */
-	if (IS_IRQ(*irqStatus, GINTSTS_USBSUSP)) {
-
+	if (IS_IRQ(irqStatus, GINTSTS_USBSUSP)) {
 		ctrl_common.dc->deviceState = USBD_STATE_DEFAULT;
 		ctrl_common.dc->ep0State = USBD_EP0_IDLE;
 		ctrl_common.dc->currEvent = USBCLIENT_EV_DISCONNECT;
@@ -223,23 +218,15 @@ void ctrl_lifiq_handler(uint32_t *irqStatus)
 		if (ctrl_common.dc->semBulkTx.v == 0U) {
 			semaphoreUp(&ctrl_common.dc->semBulkTx);
 		}
-
-		*irqStatus &= ~(1UL << GINTSTS_USBSUSP);
 	}
 
 	/* OEPINT */
-	if (IS_IRQ(*irqStatus, GINTSTS_OEPINT)) {
-
-		*irqStatus &= ~(1UL << GINTSTS_OEPINT);
-
+	if (IS_IRQ(irqStatus, GINTSTS_OEPINT)) {
 		_clbc_OEPINT();
 	}
 
 	/* IEPINT */
-	if (IS_IRQ(*irqStatus, GINTSTS_IEPINT)) {
-
-		*irqStatus &= ~(1UL << GINTSTS_IEPINT);
-
+	if (IS_IRQ(irqStatus, GINTSTS_IEPINT)) {
 		_clbc_IEPINT();
 	}
 }

--- a/usb/libusbclient/stm32n6-usbc/controller_callbacks.c
+++ b/usb/libusbclient/stm32n6-usbc/controller_callbacks.c
@@ -693,13 +693,11 @@ void _clbc_OEPINT(void)
 		ep = &clbc_common.data->endpts[epNum];
 
 		if ((daintClear & 0x1U) != 0U) {
-			epInt = clbc_common.dc->irqPendingDOEPINT[epNum];
+			epInt = atomic_exchange(&clbc_common.dc->irqPendingDOEPINT[epNum], 0U);
 			epInt &= USB_REG(DOEPMSK);
 
 			/* XFRC */
 			if (IS_IRQ(epInt, DOEPINT_XFRC)) {
-				clbc_common.dc->irqPendingDOEPINT[epNum] &= ~(1UL << DOEPINT_XFRC);
-
 				/* Control transfer */
 				if (epNum == 0U) {
 					/* if STATUS OUT received */
@@ -734,42 +732,20 @@ void _clbc_OEPINT(void)
 
 			/* STUP */
 			if (IS_IRQ(epInt, DOEPINT_STUP)) {
-				clbc_common.dc->irqPendingDOEPINT[epNum] &= ~(1UL << DOEPINT_STUP);
-
-				if (((epInt >> DOEPINT_STSPHSRX) & 0x1U) == 0x1U) {
-					clbc_common.dc->irqPendingDOEPINT[epNum] &= ~(1UL << DOEPINT_STSPHSRX);
-				}
-
 				clbc_common.dc->ep0State = USBD_EP0_SETUP;
 
 				desc_setup(&clbc_common.dc->setupPacket);
 			}
 
-			/* OTEPDIS */
-			if (IS_IRQ(epInt, DOEPINT_OTEPDIS)) {
-				clbc_common.dc->irqPendingDOEPINT[epNum] &= ~(1UL << DOEPINT_OTEPDIS);
-			}
-
 			/* EPDISD */
 			if (IS_IRQ(epInt, DOEPINT_EPDISD)) {
-				clbc_common.dc->irqPendingDOEPINT[epNum] &= ~(1UL << DOEPINT_EPDISD);
-
 				if ((USB_REG(GINTSTS) >> 7) & 1) {
 					USB_REG(DCTL) |= (1 << 10);
 				}
 			}
 
-			/* STSPHSRX / OTEPSPR */
-			if (IS_IRQ(epInt, DOEPINT_STSPHSRX)) {
-
-				clbc_common.dc->irqPendingDOEPINT[epNum] &= ~(1UL << DOEPINT_STSPHSRX);
-			}
-
 			/* NAK */
 			if (IS_IRQ(epInt, DOEPINT_NAK)) {
-
-				clbc_common.dc->irqPendingDOEPINT[epNum] &= ~(1UL << DOEPINT_NAK);
-
 				/* check if more data are to be received */
 				if (epNum == 0U) {
 					if ((USB_REG(DOEPTSIZ0 + epNum * EP_STRIDE) & (0x3FFUL << DOEPTSIZ_PKTCNT)) != 0UL) {
@@ -810,13 +786,11 @@ void _clbc_IEPINT(void)
 
 			epMsk |= ((epEmp >> (epNum & 0xFU)) & 0x1U) << 7;
 
-			epInt = clbc_common.dc->irqPendingDIEPINT[epNum];
+			epInt = atomic_exchange(&clbc_common.dc->irqPendingDIEPINT[epNum], 0U);
 			epInt &= epMsk;
 
 			/* XFRC */
 			if (IS_IRQ(epInt, DIEPINT_XFRC)) {
-				clbc_common.dc->irqPendingDIEPINT[epNum] &= ~(1UL << DIEPINT_XFRC);
-
 				/* mask TX FIFO empty interrupt */
 				USB_REG(DIEPEMPMSK) &= ~(1UL << epNum);
 
@@ -852,25 +826,8 @@ void _clbc_IEPINT(void)
 				}
 			}
 
-			/* TOC */
-			if (IS_IRQ(epInt, DIEPINT_TOC)) {
-				clbc_common.dc->irqPendingDIEPINT[epNum] &= ~(1UL << DIEPINT_TOC);
-			}
-
-			/* ITTXFE */
-			if (IS_IRQ(epInt, DIEPINT_ITTXFE)) {
-				clbc_common.dc->irqPendingDIEPINT[epNum] &= ~(1UL << DIEPINT_ITTXFE);
-			}
-
-			/* INEPNE */
-			if (IS_IRQ(epInt, DIEPINT_INEPNE)) {
-				clbc_common.dc->irqPendingDIEPINT[epNum] &= ~(1UL << DIEPINT_INEPNE);
-			}
-
 			/* EPDISD */
 			if (IS_IRQ(epInt, DIEPINT_EPDISD)) {
-				clbc_common.dc->irqPendingDIEPINT[epNum] &= ~(1UL << DIEPINT_EPDISD);
-
 				clbc_flushTxFifo(epNum);
 			}
 		}


### PR DESCRIPTION
TASK: PP-403

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change fixes potential read-modify-write races inside the low frequency interrupt handler
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m-stm32n6.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
