### PR TITLE
libusbclient/stm32n6: stall on requests for unknown string descriptors

### DIFF
--- a/usb/libusbclient/stm32n6-usbc/desc_manager.c
+++ b/usb/libusbclient/stm32n6-usbc/desc_manager.c
@@ -299,7 +299,8 @@ static void desc_ReqGetDescriptor(const usb_setup_packet_t *setup)
 			clbc_epTransmit(0, (uint8_t *)desc_common.strProd.vmStruct, MIN(desc_common.strProd.vmStruct->bLength, setup->wLength));
 		}
 		else {
-			clbc_epTransmit(0, NULL, 0);
+			clbc_epStall(&desc_common.data->endpts[0]);
+			desc_common.dc->ep0State = USBD_EP0_STALL;
 		}
 	}
 	else if ((setup->wValue >> 8) == USB_DESC_TYPE_HID_REPORT) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
This change changes the behavior of the driver when presented with requests for unknown string descriptor indices. Instead of responding with `ZLP` (Zero Length Packet), the device now responds with a `STALL`.

<!--- Describe your changes shortly -->

## Motivation and Context
From USB 2.0 Specification section 9.4.3
> If a device does not support a requested descriptor, it responds with a Request Error

From USB 2.0 Specification section 9.2.7
> The device deals with the Request Error by returning a STALL PID in response to the next Data stage transaction or in the Status stage of the message.

From [Windows OS Descriptors documentation](https://learn.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors#why-does-windows-issue-a-string-descriptor-request-to-index-0xee):
> If a device doesn't contain a valid string descriptor at index 0xEE, it must respond with a stall packet (in other words, a packet that contains a packet identifier of type STALL), which is described in the "Request Errors" section of the Universal Serial Bus Specification.

Before this change, the driver was not conforming to the specification and returning a `ZLP` instead of `STALL`ing.
This issue was the most problematic when connecting to a Microsoft Windows host, because one of the first things Windows asks for is the `0xEE` string descriptor index, which is a special, non-standardized USB string descriptor index used exclusively by Microsoft Windows to detect if a USB device supports Microsoft OS Descriptors (MSOS Descriptors). Returning a `ZLP` essentially meant "yes I have this special Windows descriptor but it's length is 0", which then probably made Windows ask for more Windows specific descriptors and causing issues. It's hard to say what exactly the Windows driver was doing with the zero-length `0xEE` descriptor but empirically, correcting this behavior made the driver more reliable when connecting to Windows hosts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
