### PR TITLE
libusbclient/stm32n6: stall on unhandled setup requests

### DIFF
--- a/usb/libusbclient/stm32n6-usbc/controller_callbacks.c
+++ b/usb/libusbclient/stm32n6-usbc/controller_callbacks.c
@@ -742,7 +742,10 @@ void _clbc_OEPINT(void)
 
 				clbc_common.dc->ep0State = USBD_EP0_SETUP;
 
-				desc_setup(&clbc_common.dc->setupPacket);
+				if (desc_setup(&clbc_common.dc->setupPacket) < 0) {
+					clbc_epStall(&clbc_common.data->endpts[0]);
+					clbc_common.dc->ep0State = USBD_EP0_STALL;
+				}
 			}
 
 			/* OTEPDIS */

--- a/usb/libusbclient/stm32n6-usbc/desc_manager.c
+++ b/usb/libusbclient/stm32n6-usbc/desc_manager.c
@@ -329,6 +329,11 @@ int desc_setup(const usb_setup_packet_t *setup)
 				desc_ReqGetDescriptor(setup);
 				break;
 
+			case REQ_GET_CONFIGURATION:
+				desc_common.dc->ep0State = USBD_EP0_DATA_IN;
+				desc_ReqGetConfig(setup);
+				break;
+
 			case REQ_CLEAR_FEATURE:
 			case REQ_GET_STATUS:
 			case REQ_GET_INTERFACE:
@@ -336,13 +341,8 @@ int desc_setup(const usb_setup_packet_t *setup)
 			case REQ_SET_FEATURE:
 			case REQ_SET_DESCRIPTOR:
 			case REQ_SYNCH_FRAME:
-				break;
-
-			case REQ_GET_CONFIGURATION:
-				desc_common.dc->ep0State = USBD_EP0_DATA_IN;
-				desc_ReqGetConfig(setup);
-				break;
 			default:
+				res = -1;
 				break;
 		}
 	}
@@ -351,9 +351,10 @@ int desc_setup(const usb_setup_packet_t *setup)
 			case CLASS_REQ_SET_LINE_CODING:
 			case CLASS_REQ_GET_LINE_CODING:
 			case CLASS_REQ_SET_CONTROL_LINE_STATE:
-				(void)desc_classSetup(setup);
+				res = desc_classSetup(setup);
 				break;
 			default:
+				res = -1;
 				break;
 		}
 	}


### PR DESCRIPTION
TASK: PP-403

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
When failing to handle a setup packet, the device will now `STALL` instead of ignoring the packet.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Host operating systems might probe the device for different functionality (Microsoft OS Descriptors, Device Qualifier Descriptors, Binary Object Store, different class-specific CDC functionality etc.), the proper way to tell the host "we do not support this functionality" is to stall the endpoint:

From the USB 2.0 specification section 9.2.7:
> When a request is received by a device that is not defined for the device, is inappropriate for the current setting of the device, or has values that are not compatible with the request, then a Request Error exists. The device deals with the Request Error by returning a STALL PID in response to the next Data stage transaction or in the Status stage of the message.

Before this change, such requests were completely ignored, causing the host to either:
- Keep waiting for a response until a timeout occurred
- Falsely believe that the device supports a capability which it doesn't

This change makes the driver more compatible with the specification and should improve overall reliability and stability of the driver.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m-stm32n6.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
