### PR TITLE
stm32l4-multi/pwm_n6: implement bidirectional DShot communication

### DIFF
--- a/multi/stm32l4-multi/libmulti/include/libmulti/libdma.h
+++ b/multi/stm32l4-multi/libmulti/include/libmulti/libdma.h
@@ -21,11 +21,22 @@
 #define DMA_MAX_LEN ((1u << 16) - 1u)
 
 
-/* clang-format off */
-enum { dma_per2mem = 0, dma_mem2per };
+enum {
+	dma_per2mem = 0,
+	dma_mem2per,
+};
 
 
-enum libdma_peripheral_type { dma_spi = 0, dma_uart, dma_tim_upd, dma_memTransfer };
+enum libdma_peripheral_type {
+	dma_spi = 0,
+	dma_uart,
+	dma_tim_upd,
+	dma_memTransfer,
+	dma_tim_cap1,
+	dma_tim_cap2,
+	dma_tim_cap3,
+	dma_tim_cap4,
+};
 
 
 /* Memory-to-memory transfer is implemented as a fictional "peripheral type" dma_memTransfer.
@@ -37,6 +48,7 @@ enum libdma_memTransfer_num {
 };
 
 
+/* clang-format off */
 enum libdma_interrupt_flags { dma_ht = (1 << 0), dma_tc = (1 << 1) };
 
 

--- a/multi/stm32l4-multi/libmulti/include/libmulti/libdma.h
+++ b/multi/stm32l4-multi/libmulti/include/libmulti/libdma.h
@@ -232,6 +232,6 @@ ssize_t libxpdma_bufferRemaining(const struct libdma_per *per, int dir);
  * For now to we assume DMA buffers will be allocated once at the start of the program as needed
  * and for this reason no corresponding `libdma_free` function exists.
  */
-void *libdma_malloc(size_t size);
+void *libdma_malloc(size_t size, size_t alignment);
 
 #endif

--- a/multi/stm32l4-multi/libmulti/libgpdma.c
+++ b/multi/stm32l4-multi/libmulti/libgpdma.c
@@ -261,9 +261,10 @@ struct libdma_perSetup {
 
 
 struct libdma_per {
-	const struct libdma_perSetup *setup;
-	uint8_t dma;                   /* Controller selected for the given peripheral */
+	uint8_t dma;                   /* Controller selected for the given peripheral. DMA_NUM_CONTROLLERS signifies slot is not in use. */
 	uint8_t chns[dma_mem2per + 1]; /* Channel used for a given direction. Value of DMA_NUM_CHANNELS signifies channel is not in use. */
+	uint8_t reqs[dma_mem2per + 1];
+	uint8_t portPer;
 };
 
 
@@ -273,46 +274,175 @@ struct libdma_per {
  * Only the AXI port of HPDMA can access TCM memories in the CPU.
  */
 
-static const struct libdma_perSetup libdma_persUart[] = {
-	[usart1] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_usart1_rx, dma_req_usart1_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[usart2] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_usart2_rx, dma_req_usart2_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[usart3] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_usart3_rx, dma_req_usart3_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[uart4] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_uart4_rx, dma_req_uart4_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[uart5] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_uart5_rx, dma_req_uart5_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[usart6] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_usart6_rx, dma_req_usart6_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[uart7] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_uart7_rx, dma_req_uart7_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[uart8] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_uart8_rx, dma_req_uart8_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[uart9] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_uart9_rx, dma_req_uart9_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[usart10] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_usart10_rx, dma_req_usart10_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
+static const uint8_t libdma_reqsUartRx[] = {
+	[usart1] = dma_req_usart1_rx,
+	[usart2] = dma_req_usart2_rx,
+	[usart3] = dma_req_usart3_rx,
+	[uart4] = dma_req_uart4_rx,
+	[uart5] = dma_req_uart5_rx,
+	[usart6] = dma_req_usart6_rx,
+	[uart7] = dma_req_uart7_rx,
+	[uart8] = dma_req_uart8_rx,
+	[uart9] = dma_req_uart9_rx,
+	[usart10] = dma_req_usart10_rx,
 };
 
 
-static const struct libdma_perSetup libdma_persSpi[] = {
-	[spi1] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_spi1_rx, dma_req_spi1_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[spi2] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_spi2_rx, dma_req_spi2_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[spi3] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_spi3_rx, dma_req_spi3_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[spi4] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_spi4_rx, dma_req_spi4_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[spi5] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_spi5_rx, dma_req_spi5_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[spi6] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_spi6_rx, dma_req_spi6_tx }, .portPer = 1, .portMem = 0, .valid = 1 },
+static const uint8_t libdma_reqsUartTx[] = {
+	[usart1] = dma_req_usart1_tx,
+	[usart2] = dma_req_usart2_tx,
+	[usart3] = dma_req_usart3_tx,
+	[uart4] = dma_req_uart4_tx,
+	[uart5] = dma_req_uart5_tx,
+	[usart6] = dma_req_usart6_tx,
+	[uart7] = dma_req_uart7_tx,
+	[uart8] = dma_req_uart8_tx,
+	[uart9] = dma_req_uart9_tx,
+	[usart10] = dma_req_usart10_tx,
 };
 
 
-static const struct libdma_perSetup libdma_persTimUpd[] = {
-	[pwm_tim1] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_invalid, dma_req_tim1_upd }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[pwm_tim2] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_invalid, dma_req_tim2_upd }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[pwm_tim3] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_invalid, dma_req_tim3_upd }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[pwm_tim4] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_invalid, dma_req_tim4_upd }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[pwm_tim5] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_invalid, dma_req_tim5_upd }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[pwm_tim8] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_invalid, dma_req_tim8_upd }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[pwm_tim15] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_invalid, dma_req_tim15_upd }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[pwm_tim16] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_invalid, dma_req_tim16_upd }, .portPer = 1, .portMem = 0, .valid = 1 },
-	[pwm_tim17] = { .defDMA = DMA_CTRL_GPDMA1, .requests = { dma_req_invalid, dma_req_tim17_upd }, .portPer = 1, .portMem = 0, .valid = 1 },
+static const uint8_t libdma_reqsSpiRx[] = {
+	[spi1] = dma_req_spi1_rx,
+	[spi2] = dma_req_spi2_rx,
+	[spi3] = dma_req_spi3_rx,
+	[spi4] = dma_req_spi4_rx,
+	[spi5] = dma_req_spi5_rx,
+	[spi6] = dma_req_spi6_rx,
 };
 
 
-static const struct libdma_perSetup libdma_persMemTransfer[] = {
-	[memTransfer_perIsDst] = { .defDMA = DMA_CTRL_HPDMA1, .requests = { dma_req_invalid, dma_req_sw_trig }, .portPer = 0, .portMem = 0, .valid = 1 },
-	[memTransfer_perIsSrc] = { .defDMA = DMA_CTRL_HPDMA1, .requests = { dma_req_sw_trig, dma_req_invalid }, .portPer = 0, .portMem = 0, .valid = 1 },
+static const uint8_t libdma_reqsSpiTx[] = {
+	[spi1] = dma_req_spi1_tx,
+	[spi2] = dma_req_spi2_tx,
+	[spi3] = dma_req_spi3_tx,
+	[spi4] = dma_req_spi4_tx,
+	[spi5] = dma_req_spi5_tx,
+	[spi6] = dma_req_spi6_tx,
+};
+
+
+static const uint8_t libdma_reqsTimUpd[] = {
+	[pwm_tim1] = dma_req_tim1_upd,
+	[pwm_tim2] = dma_req_tim2_upd,
+	[pwm_tim3] = dma_req_tim3_upd,
+	[pwm_tim4] = dma_req_tim4_upd,
+	[pwm_tim5] = dma_req_tim5_upd,
+	[pwm_tim6] = dma_req_tim6_upd,
+	[pwm_tim7] = dma_req_tim7_upd,
+	[pwm_tim8] = dma_req_tim8_upd,
+	[pwm_tim9] = dma_req_invalid,
+	[pwm_tim10] = dma_req_invalid,
+	[pwm_tim11] = dma_req_invalid,
+	[pwm_tim12] = dma_req_invalid,
+	[pwm_tim13] = dma_req_invalid,
+	[pwm_tim14] = dma_req_invalid,
+	[pwm_tim15] = dma_req_tim15_upd,
+	[pwm_tim16] = dma_req_tim16_upd,
+	[pwm_tim17] = dma_req_tim17_upd,
+	[pwm_tim18] = dma_req_tim18_upd,
+};
+
+
+static const uint8_t libdma_reqsTimCC1[] = {
+	[pwm_tim1] = dma_req_tim1_cc1,
+	[pwm_tim2] = dma_req_tim2_cc1,
+	[pwm_tim3] = dma_req_tim3_cc1,
+	[pwm_tim4] = dma_req_tim4_cc1,
+	[pwm_tim5] = dma_req_tim5_cc1,
+	[pwm_tim6] = dma_req_invalid,
+	[pwm_tim7] = dma_req_invalid,
+	[pwm_tim8] = dma_req_tim8_cc1,
+	[pwm_tim9] = dma_req_invalid,
+	[pwm_tim10] = dma_req_invalid,
+	[pwm_tim11] = dma_req_invalid,
+	[pwm_tim12] = dma_req_invalid,
+	[pwm_tim13] = dma_req_invalid,
+	[pwm_tim14] = dma_req_invalid,
+	[pwm_tim15] = dma_req_tim15_cc1,
+	[pwm_tim16] = dma_req_tim16_cc1,
+	[pwm_tim17] = dma_req_tim17_cc1,
+	[pwm_tim18] = dma_req_tim18_cc1,
+};
+
+
+static const uint8_t libdma_reqsTimCC2[] = {
+	[pwm_tim1] = dma_req_tim1_cc2,
+	[pwm_tim2] = dma_req_tim2_cc2,
+	[pwm_tim3] = dma_req_tim3_cc2,
+	[pwm_tim4] = dma_req_tim4_cc2,
+	[pwm_tim5] = dma_req_tim5_cc2,
+	[pwm_tim6] = dma_req_invalid,
+	[pwm_tim7] = dma_req_invalid,
+	[pwm_tim8] = dma_req_tim8_cc2,
+	[pwm_tim9] = dma_req_invalid,
+	[pwm_tim10] = dma_req_invalid,
+	[pwm_tim11] = dma_req_invalid,
+	[pwm_tim12] = dma_req_invalid,
+	[pwm_tim13] = dma_req_invalid,
+	[pwm_tim14] = dma_req_invalid,
+	[pwm_tim15] = dma_req_tim15_cc2,
+};
+
+
+static const uint8_t libdma_reqsTimCC3[] = {
+	[pwm_tim1] = dma_req_tim1_cc3,
+	[pwm_tim2] = dma_req_tim2_cc3,
+	[pwm_tim3] = dma_req_tim3_cc3,
+	[pwm_tim4] = dma_req_tim4_cc3,
+	[pwm_tim5] = dma_req_tim5_cc3,
+	[pwm_tim6] = dma_req_invalid,
+	[pwm_tim7] = dma_req_invalid,
+	[pwm_tim8] = dma_req_tim8_cc3,
+};
+
+
+static const uint8_t libdma_reqsTimCC4[] = {
+	[pwm_tim1] = dma_req_tim1_cc4,
+	[pwm_tim2] = dma_req_tim2_cc4,
+	[pwm_tim3] = dma_req_tim3_cc4,
+	[pwm_tim4] = dma_req_tim4_cc4,
+	[pwm_tim5] = dma_req_tim5_cc4,
+	[pwm_tim6] = dma_req_invalid,
+	[pwm_tim7] = dma_req_invalid,
+	[pwm_tim8] = dma_req_tim8_cc4,
+};
+
+
+static const uint8_t libdma_memTransferP2M[] = {
+	[memTransfer_perIsDst] = dma_req_invalid,
+	[memTransfer_perIsSrc] = dma_req_sw_trig,
+};
+
+
+static const uint8_t libdma_memTransferM2P[] = {
+	[memTransfer_perIsDst] = dma_req_sw_trig,
+	[memTransfer_perIsSrc] = dma_req_invalid,
+};
+
+typedef struct {
+	const uint8_t *reqsPer2Mem;
+	const uint8_t *reqsMem2Per;
+	size_t num;
+	uint8_t defaultDma;
+	uint8_t portPer;
+} libdma_perReqLookup_t;
+
+
+_Static_assert(NELEMS(libdma_reqsSpiRx) == NELEMS(libdma_reqsSpiTx));
+_Static_assert(NELEMS(libdma_reqsUartRx) == NELEMS(libdma_reqsUartTx));
+_Static_assert(NELEMS(libdma_memTransferP2M) == NELEMS(libdma_memTransferM2P));
+
+
+static const libdma_perReqLookup_t libdma_reqsLookup[] = {
+	[dma_spi] = { libdma_reqsSpiRx, libdma_reqsSpiTx, NELEMS(libdma_reqsSpiRx), DMA_CTRL_GPDMA1, 1 },
+	[dma_uart] = { libdma_reqsUartRx, libdma_reqsUartTx, NELEMS(libdma_reqsUartRx), DMA_CTRL_GPDMA1, 1 },
+	[dma_tim_upd] = { NULL, libdma_reqsTimUpd, NELEMS(libdma_reqsTimUpd), DMA_CTRL_GPDMA1, 1 },
+	[dma_memTransfer] = { libdma_memTransferP2M, libdma_memTransferM2P, NELEMS(libdma_memTransferM2P), DMA_CTRL_HPDMA1, 0 },
+	[dma_tim_cap1] = { libdma_reqsTimCC1, NULL, NELEMS(libdma_reqsTimCC1), DMA_CTRL_GPDMA1, 1 },
+	[dma_tim_cap2] = { libdma_reqsTimCC2, NULL, NELEMS(libdma_reqsTimCC2), DMA_CTRL_GPDMA1, 1 },
+	[dma_tim_cap3] = { libdma_reqsTimCC3, NULL, NELEMS(libdma_reqsTimCC3), DMA_CTRL_GPDMA1, 1 },
+	[dma_tim_cap4] = { libdma_reqsTimCC4, NULL, NELEMS(libdma_reqsTimCC4), DMA_CTRL_GPDMA1, 1 },
 };
 
 
@@ -653,36 +783,41 @@ static int libxpdma_findChannel(uint8_t request, int dir, uint32_t *chanFreePtr,
 }
 
 
+static int libxpdma_lookupPeripheral(int per, unsigned int num, uint8_t requests[2], uint8_t *defaultDMA, uint8_t *portPer)
+{
+	if (per >= NELEMS(libdma_reqsLookup)) {
+		return -EINVAL;
+	}
+
+	const libdma_perReqLookup_t *l = &libdma_reqsLookup[per];
+	if (num >= l->num) {
+		return -EINVAL;
+	}
+
+	requests[dma_per2mem] = (l->reqsPer2Mem == NULL) ? dma_req_invalid : l->reqsPer2Mem[num];
+	requests[dma_mem2per] = (l->reqsMem2Per == NULL) ? dma_req_invalid : l->reqsMem2Per[num];
+	if ((requests[dma_per2mem] == dma_req_invalid) && (requests[dma_mem2per] == dma_req_invalid)) {
+		/* If both requests are invalid, this peripheral/number combination is invalid */
+		return -EINVAL;
+	}
+
+	*defaultDMA = l->defaultDma;
+	*portPer = l->portPer;
+	return EOK;
+}
+
+
 int libxpdma_acquirePeripheral(int per, unsigned int num, uint32_t flags, const struct libdma_per **perP)
 {
-	const struct libdma_perSetup *setups;
-	size_t setupsSize;
-	if (per == dma_spi) {
-		setupsSize = NELEMS(libdma_persSpi);
-		setups = libdma_persSpi;
-	}
-	else if (per == dma_uart) {
-		setupsSize = NELEMS(libdma_persUart);
-		setups = libdma_persUart;
-	}
-	else if (per == dma_tim_upd) {
-		setupsSize = NELEMS(libdma_persTimUpd);
-		setups = libdma_persTimUpd;
-	}
-	else if (per == dma_memTransfer) {
-		setupsSize = NELEMS(libdma_persMemTransfer);
-		setups = libdma_persMemTransfer;
-	}
-	else {
-		return -EINVAL;
+	uint8_t requests[2];
+	uint8_t dma;
+	uint8_t portPer;
+
+	int ret = libxpdma_lookupPeripheral(per, num, requests, &dma, &portPer);
+	if (ret < 0) {
+		return ret;
 	}
 
-	if ((num >= setupsSize) || (setups[num].valid == 0)) {
-		return -EINVAL;
-	}
-
-	const struct libdma_perSetup *setup = &setups[num];
-	uint32_t dma = setup->defDMA;
 	if ((flags & (LIBXPDMA_ACQUIRE_FORCE_HPDMA | LIBXPDMA_ACQUIRE_FORCE_GPDMA)) != 0) {
 		bool findHPDMA = (flags & LIBXPDMA_ACQUIRE_FORCE_HPDMA) != 0;
 		for (dma = 0; dma < DMA_NUM_CONTROLLERS; dma++) {
@@ -702,7 +837,7 @@ int libxpdma_acquirePeripheral(int per, unsigned int num, uint32_t flags, const 
 	struct libdma_per *p = NULL;
 	/* Find a free slot for peripheral information */
 	for (int i = 0; i < sizeof(ctrl->pers) / sizeof(ctrl->pers[0]); i++) {
-		if (ctrl->pers[i].setup == NULL) {
+		if (ctrl->pers[i].dma >= DMA_NUM_CONTROLLERS) {
 			p = &ctrl->pers[i];
 			break;
 		}
@@ -716,7 +851,7 @@ int libxpdma_acquirePeripheral(int per, unsigned int num, uint32_t flags, const 
 	/* Find enough unused channels necessary for peripheral */
 	uint32_t chanFree = ctrl->chanFree;
 	for (int dir = dma_per2mem; dir <= dma_mem2per; dir++) {
-		int acqResult = libxpdma_findChannel(setup->requests[dir], dir, &chanFree, flags);
+		int acqResult = libxpdma_findChannel(requests[dir], dir, &chanFree, flags);
 		if (acqResult < 0) {
 			mutexUnlock(ctrl->takenLock);
 			return acqResult;
@@ -726,8 +861,10 @@ int libxpdma_acquirePeripheral(int per, unsigned int num, uint32_t flags, const 
 	}
 
 	ctrl->chanFree = chanFree;
-	p->setup = setup;
 	p->dma = dma;
+	p->reqs[0] = requests[0];
+	p->reqs[1] = requests[1];
+	p->portPer = portPer;
 	mutexUnlock(ctrl->takenLock);
 
 	*perP = p;
@@ -777,7 +914,7 @@ int libxpdma_configurePeripheral(const struct libdma_per *per, int dir, const li
 	sChn->cx.tr1 &= ~(XPDMA_CXTR1_INDIVIDUAL_BITS << shift);
 	uint32_t cxtr1_temp =
 			(1u << 15) | /* secure transfer */
-			((per->setup->portPer & 1) << 14) |
+			((per->portPer & 1) << 14) |
 			(((cfg->burstSize - 1) & 0x3f) << 4) |
 			((cfg->increment != 0) ? (1 << 3) : 0) |
 			((cfg->elSize_log & 0x3) << 0);
@@ -785,7 +922,7 @@ int libxpdma_configurePeripheral(const struct libdma_per *per, int dir, const li
 
 	/* TCEM bits will be configured by libxpdma_configureMemory */
 	sChn->cx.tr2 &= XPDMA_CXTR2_TCEM_MASK;
-	if (per->setup->requests[dir] == dma_req_sw_trig) {
+	if (per->reqs[dir] == dma_req_sw_trig) {
 		sChn->cx.tr2 |= XPDMA_CXTR2_MEM2MEM;
 	}
 	else {
@@ -794,7 +931,7 @@ int libxpdma_configurePeripheral(const struct libdma_per *per, int dir, const li
 				XPDMA_CXTR2_PF_NORMAL |
 				XPDMA_CXTR2_PER_BURST |
 				dir_bit |
-				(per->setup->requests[dir] & 0xff);
+				(per->reqs[dir] & 0xff);
 	}
 
 	if (dir == dma_mem2per) {
@@ -871,7 +1008,7 @@ static ssize_t libxpdma_configureBuffer(
 	tr1_new &= ~(XPDMA_CXTR1_INDIVIDUAL_BITS << shift);
 	uint32_t tr1_bits =
 			(1u << 15) | /* secure transfer */
-			((per->setup->portMem & 1) << 14) |
+			(0 << 14) |  /* Use port 0 for memory (AHB on GPDMA, AXI on HPDMA) */
 			((buf->burstSize - 1) << 4) |
 			((buf->increment != 0) ? (1 << 3) : 0) |
 			(buf->elSize_log & 0x3);
@@ -1573,7 +1710,7 @@ int libdma_init(void)
 		}
 
 		for (size_t per = 0; per < (sizeof(dma_ctrl[dma].pers) / sizeof(dma_ctrl[dma].pers[0])); per++) {
-			dma_ctrl[dma].pers[per].setup = NULL;
+			dma_ctrl[dma].pers[per].dma = DMA_NUM_CONTROLLERS;
 			dma_ctrl[dma].pers[per].chns[0] = DMA_NUM_CHANNELS;
 			dma_ctrl[dma].pers[per].chns[1] = DMA_NUM_CHANNELS;
 		}

--- a/multi/stm32l4-multi/libmulti/libgpdma.c
+++ b/multi/stm32l4-multi/libmulti/libgpdma.c
@@ -1288,14 +1288,24 @@ static int libdma_getDmaMemory(void)
 }
 
 
-void *libdma_malloc(size_t size)
+void *libdma_malloc(size_t size, size_t alignment)
 {
+	/* Alignment must be a power of 2 */
+	if ((alignment & (alignment - 1)) != 0) {
+		return NULL;
+	}
+
 	mutexLock(dma_common.dmaAllocMutex);
-	if (size > dma_common.dmaAllocSz) {
+	size_t misalign = ((uintptr_t)dma_common.dmaAllocPtr & (alignment - 1));
+	misalign = (misalign != 0) ? (alignment - misalign) : 0;
+
+	if ((dma_common.dmaAllocSz < misalign) || (size > (dma_common.dmaAllocSz - misalign))) {
 		mutexUnlock(dma_common.dmaAllocMutex);
 		return NULL;
 	}
 
+	dma_common.dmaAllocSz -= misalign;
+	dma_common.dmaAllocPtr += misalign;
 	void *ret = dma_common.dmaAllocPtr;
 	dma_common.dmaAllocSz -= size;
 	dma_common.dmaAllocPtr += size;

--- a/multi/stm32l4-multi/libmulti/libgpdma.c
+++ b/multi/stm32l4-multi/libmulti/libgpdma.c
@@ -213,6 +213,10 @@ enum xpdma_cx_regs {
  * However, bits 29:26 and 13:10 refer to the transfer as a whole (byte exchange, padding and alignment). */
 #define XPDMA_CXTR1_INDIVIDUAL_BITS 0xc3ffUL
 #define XPDMA_CXTR1_COMMON_BITS     0x3c003c00UL
+#define XPDMA_CXTR1_PAM_MASK        (3 << 11)           /* Mask for padding/alignment mode */
+#define XPDMA_CXTR1_PAM_PACK        (2 << 11)           /* Padding/alignment set to FIFO queued packing */
+#define XPDMA_CXTR1_SRC_EL_SIZE(x)  (((x) >> 0) & 0x3)  /* Log2 of element size for source */
+#define XPDMA_CXTR1_DST_EL_SIZE(x)  (((x) >> 16) & 0x3) /* Log2 of element size for destination */
 
 #define XPDMA_CXTR2_TCEM_BLOCK   (0 << 30) /* Generate TC event on block completion, HT on half block */
 #define XPDMA_CXTR2_TCEM_RBLOCK  (1 << 30) /* Generate TC event on repeated block completion, HT on half repeated block */
@@ -987,12 +991,29 @@ static ssize_t libxpdma_configureBuffer(
 		libdma_chn_setup_t *setup,
 		uint32_t *changeMask_out)
 {
-	if ((buf->bufSize == 0) || (buf->bufSize > DMA_MAX_LEN)) {
+	const uint8_t max_elSize_log = dma_setup[dma].isHPDMA ? 3 : 2;
+	if ((buf->bufSize == 0) || ((buf->bufSize & ((1 << buf->elSize_log) - 1)) != 0)) {
 		return -EINVAL;
 	}
 
-	const uint8_t max_elSize_log = dma_setup[dma].isHPDMA ? 3 : 2;
 	if (buf->elSize_log > max_elSize_log) {
+		return -EINVAL;
+	}
+
+	uint32_t bufSizeAtSource = buf->bufSize;
+	if (dir == dma_per2mem) {
+		/* This is a workaround for an unintuitive behavior of the DMA controller.
+		 * Block size stored in BR1 register is always counted at *source* element size.
+		 * E.g. if you have a 32-bit peripheral and only want low 16 bits stored in the buffer,
+		 * BR1 value will have to be twice the size of destination buffer in bytes. */
+		uint32_t perElSizeLog = XPDMA_CXTR1_SRC_EL_SIZE(setup->tr1);
+		uint8_t pamRequest = buf->transform & 0x6;
+		if ((perElSizeLog != buf->elSize_log) && (pamRequest != LIBXPDMA_TRANSFORM_PACK)) {
+			bufSizeAtSource = (buf->bufSize >> buf->elSize_log) << perElSizeLog;
+		}
+	}
+
+	if (bufSizeAtSource > DMA_MAX_LEN) {
 		return -EINVAL;
 	}
 
@@ -1023,8 +1044,8 @@ static ssize_t libxpdma_configureBuffer(
 		n_changes++;
 	}
 
-	if ((setup->br1 & 0xffff) != buf->bufSize) {
-		setup->br1 = (setup->br1 & 0xffff0000) | (buf->bufSize & 0xffff);
+	if ((setup->br1 & 0xffff) != bufSizeAtSource) {
+		setup->br1 = (setup->br1 & 0xffff0000) | (bufSizeAtSource & 0xffff);
 		changeMask |= XPDMA_CXLLR_UB1;
 		n_changes++;
 	}
@@ -1380,7 +1401,21 @@ ssize_t libxpdma_bufferRemaining(const struct libdma_per *per, int dir)
 
 	volatile uint32_t *chnBase = libdma_channelBase(dma, chn);
 	/* Only bottom 16 bits contain data. */
-	return *(chnBase + xpdma_cxbr1) & 0xffff;
+	uint32_t nBytesSrc = *(chnBase + xpdma_cxbr1) & 0xffff;
+	/* Block size stored in BR1 register is always counted at *source* element size.
+	 * If source is memory, then it's OK already.
+	 * If source is peripheral, it's at different element size and packing is not applied, we need to calculate
+	 * the resulting number of bytes in memory. */
+	if (dir == dma_mem2per) {
+		return (ssize_t)nBytesSrc;
+	}
+
+	uint32_t tr1 = *(chnBase + xpdma_cxtr1);
+	if (XPDMA_CXTR1_SRC_EL_SIZE(tr1) != XPDMA_CXTR1_DST_EL_SIZE(tr1) && ((tr1 & XPDMA_CXTR1_PAM_MASK) != XPDMA_CXTR1_PAM_PACK)) {
+		return (nBytesSrc >> XPDMA_CXTR1_SRC_EL_SIZE(tr1)) << XPDMA_CXTR1_DST_EL_SIZE(tr1);
+	}
+
+	return nBytesSrc;
 }
 
 

--- a/multi/stm32l4-multi/pwm_n6.c
+++ b/multi/stm32l4-multi/pwm_n6.c
@@ -28,8 +28,8 @@
 #include <stdlib.h>
 #include <time.h>
 
-#define USE_DSHOT_DMA 1
-#define MAX_DSHOT_DMA 32
+#define USE_DSHOT_DMA  1
+#define DMA_ALLOC_SIZE (18 * PWM_CHN_NUM * sizeof(uint16_t))
 
 #define TIM_DIER_UIE   (1 << 0)  /* Update IRQ enable */
 #define TIM_DIER_CC1IE (1 << 1)  /* Capture/compare 1 IRQ enable */
@@ -104,11 +104,15 @@ typedef struct {
 	bool initialized;
 #if USE_DSHOT_DMA
 	handle_t dmaMutex;
+	void *dmaMem;
 	const struct libdma_per *dma_per[PWM_CHN_NUM];
 	const struct libdma_per *dma_multiChannel;
 	const struct libdma_per *dma_capture[PWM_CHN_NUM];
 #endif
 } pwm_tim_data_t;
+
+/* Idle value made available as a static const, so that it can be read by DMA */
+static const uint16_t pwm_idleValue = 0;
 
 static const struct {
 	pwm_tim_setup_t timer[pwm_tim_count];
@@ -238,6 +242,12 @@ static struct {
 	pwm_tim_data_t timer[pwm_tim_count];
 	uint32_t baseFreq; /* Timer base frequency, 32-bit range is acceptable on this platform */
 } pwm_common;
+
+/* Get log2(size) for sizes of 4, 2 or 1. */
+static inline uint8_t sizeLog(size_t size)
+{
+	return (size == 4) ? 2 : ((size == 2) ? 1 : 0);
+}
 
 
 static int pwm_validateTimer(pwm_tim_id_t timer, bool checkInitialized, uint8_t checkDMAFlags)
@@ -725,116 +735,6 @@ static int pwm_initDMA(pwm_tim_id_t timer, pwm_ch_id_t chn, enum pwm_dmaAllocTyp
 }
 #endif
 
-static void pwm_fillBitSequence(uint16_t value, uint16_t hcmp, uint16_t lcmp, uint16_t seq[PWM_BITSEQ4_BITS + 2])
-{
-	int bit;
-
-	for (bit = 0; bit < PWM_BITSEQ4_BITS; ++bit) {
-		uint16_t mask = (uint16_t)(1u << (PWM_BITSEQ4_BITS - 1 - bit));
-		seq[bit] = ((value & mask) != 0u) ? hcmp : lcmp;
-	}
-
-	/* Add two "idle" values at the end of the DMA buffer.
-	 * One value is necessary because after DMA writes the last compare value, `libdma_tx` exits and user may
-	 * disable the timer immediately without waiting for the final cycle to finish.
-	 * Another value is added because compare values are "delayed" - a write to the CCR register after an update event
-	 * will not take effect immediately, but during the next cycle.
-	 * Without those two "idle" values, the last value would not be transmitted and second-to-last value
-	 * would not be transmitted completely.
-	 */
-	seq[PWM_BITSEQ4_BITS] = 0;
-	seq[PWM_BITSEQ4_BITS + 1] = 0;
-}
-
-
-static int pwm_callBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn[PWM_CHN_NUM], uint16_t seq[PWM_CHN_NUM][PWM_BITSEQ4_BITS + 2])
-{
-#if USE_DSHOT_DMA
-	volatile uint32_t *base = pwm_setup.timer[timer].base;
-	const struct libdma_per *per[PWM_CHN_NUM];
-	volatile int done[PWM_CHN_NUM] = { 0 };
-	uint8_t started = 0;
-	bool udeMasked = false;
-	int res = 0, i;
-
-	mutexLock(pwm_common.timer[timer].dmaMutex);
-
-	for (i = 0; i < PWM_CHN_NUM; ++i) {
-		libdma_transfer_buffer_t buf = {
-			.buf = seq[i],
-			.bufSize = sizeof(seq[i]),
-			.elSize_log = 1,
-			.burstSize = 1,
-			.increment = 1,
-			.isCached = 1,
-			.transform = LIBXPDMA_TRANSFORM_ALIGNR0,
-		};
-
-		per[i] = pwm_common.timer[timer].dma_per[chn[i]];
-		if (per[i] == NULL) {
-			res = pwm_initDMA(timer, chn[i], pwm_dmaUpd);
-			per[i] = pwm_common.timer[timer].dma_per[chn[i]];
-		}
-
-		if (res < 0) {
-			break;
-		}
-
-		res = libxpdma_configureMemory(per[i], dma_mem2per, 0, &buf, 1);
-		if (res < 0) {
-			break;
-		}
-
-		/* Start/arm the PWM channel in idle state. DMA will update CCR on timer update events. */
-		res = pwm_setInternal(timer, chn[i], 0, 0);
-		if (res < 0) {
-			break;
-		}
-	}
-
-	if (res >= 0) {
-		/* Request is disabled before DMA start and enabled after to prevent a possible race condition
-		 * between DMA start and timer update request. */
-		*(base + tim_dier) &= ~TIM_DIER_UDE;
-		udeMasked = true;
-
-		for (i = 0; i < PWM_CHN_NUM; ++i) {
-			res = libxpdma_startTransferWithFlag(per[i], dma_mem2per, &done[i]);
-			if (res < 0) {
-				break;
-			}
-			started++;
-		}
-	}
-
-	if (udeMasked) {
-		*(base + tim_dier) |= TIM_DIER_UDE;
-		udeMasked = false;
-	}
-
-	if (res >= 0) {
-		/* Wait for all transfers. Preserve the first error, but still drain all transactions. */
-		res = 0;
-		for (i = 0; i < PWM_CHN_NUM; ++i) {
-			int waitRes = libxpdma_waitForTransaction(per[i], &done[i], NULL, 0);
-			if ((res >= 0) && (waitRes < 0)) {
-				res = waitRes;
-			}
-		}
-	}
-	else if (started != 0u) {
-		for (i = 0; i < started; ++i) {
-			(void)libxpdma_waitForTransaction(per[i], &done[i], NULL, 0);
-		}
-	}
-
-	mutexUnlock(pwm_common.timer[timer].dmaMutex);
-	return res;
-#else
-	return -ENOSYS;
-#endif
-}
-
 
 int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t nbits, uint8_t datasize, int flags)
 {
@@ -863,19 +763,14 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 
 #if USE_DSHOT_DMA
 	mutexLock(pwm_common.timer[timer].dmaMutex);
-	const struct libdma_per *per = pwm_common.timer[timer].dma_per[chn];
-	if (per == NULL) {
-		res = (res < 0) ? res : pwm_initDMA(timer, chn, pwm_dmaUpd);
-		per = pwm_common.timer[timer].dma_per[chn];
-	}
+	res = (res < 0) ? res : pwm_initDMA(timer, chn, pwm_dmaUpd);
 
-	static const uint8_t zero_value = 0;
-	const uint8_t datasize_log = (datasize == 1) ? 0 : ((datasize == 2) ? 1 : 2);
+	const struct libdma_per *per = pwm_common.timer[timer].dma_per[chn];
 	libdma_transfer_buffer_t bufs[2] = {
 		{
 			.buf = data,
-			.bufSize = nbits << datasize_log,
-			.elSize_log = datasize_log,
+			.bufSize = nbits * datasize,
+			.elSize_log = sizeLog(datasize),
 			.burstSize = 1,
 			.increment = 1,
 			.isCached = 1,
@@ -892,9 +787,9 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 		 * on how fast `libdma_tx` returns after DMA is finished.
 		 */
 		{
-			.buf = (void *)&zero_value,
-			.bufSize = 2,
-			.elSize_log = 0,
+			.buf = (void *)&pwm_idleValue,
+			.bufSize = 2 * sizeof(pwm_idleValue),
+			.elSize_log = sizeLog(sizeof(pwm_idleValue)),
 			.burstSize = 1,
 			.increment = 0,
 			.isCached = 0,
@@ -903,7 +798,7 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 	};
 	res = (res < 0) ? res : libxpdma_configureMemory(per, dma_mem2per, 0, bufs, 2);
 	/* Start the PWM channel. Set first duty cycle to 0 - idle state. It will be output until DMA takes over. */
-	res = (res < 0) ? res : pwm_setInternal(timer, chn, 0, 0);
+	res = (res < 0) ? res : pwm_setInternal(timer, chn, pwm_idleValue, 0);
 	volatile int done = 0;
 	/* Request is disabled before DMA start and enabled after to prevent a possible race condition
 	 * between DMA start and timer update request. */
@@ -946,12 +841,42 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 }
 
 
+/* Render data given in `val16` into an array of timer compare values.
+ * * `output` - array of timer values.
+ *   Array must have (`n_bits * n_channels`) elements.
+ * * `n_bits` - total number of bits to render (0..16)
+ * * `valIdx` - mapping from physical channel to indices into `val16`.
+ *   Index of < 0 indicates the channel will be inactive.
+ *   Array must have `n_channels` elements.
+ * * `n_channels` - total number of channels to output (0..`PWM_CHN_NUM`)
+ * * `val16` - data for channels.
+ *   Array must have `max(valIdx[...])` elements.
+ * * `hcmp` - timer compare value for 1 bit
+ * * `lcmp` - timer compare value for 0 bit
+ */
+static void pwm_renderBitSequence(volatile uint16_t *output, size_t n_bits, int *valIdx, size_t n_channels, const uint16_t *val16, uint16_t hcmp, uint16_t lcmp)
+{
+	for (size_t bitIdx = 0; bitIdx < n_bits; bitIdx++) {
+		uint16_t mask = (1U << (n_bits - 1 - bitIdx));
+		for (size_t chnIdx = 0; chnIdx < n_channels; chnIdx++) {
+			int idx = valIdx[chnIdx];
+			uint16_t cmp = pwm_idleValue;
+			if (idx >= 0) {
+				cmp = ((val16[idx] & mask) != 0) ? hcmp : lcmp;
+			}
+
+			output[(bitIdx * n_channels) + chnIdx] = cmp;
+		}
+	}
+}
+
+
 int pwm_setBitSequence4(pwm_tim_id_t timer, const uint16_t chnRaw[4], const uint16_t val16[4], uint16_t hcmp, uint16_t lcmp, int flags)
 {
-	pwm_ch_id_t chn[PWM_CHN_NUM];
-	uint16_t seq[PWM_CHN_NUM][PWM_BITSEQ4_BITS + 2];
-	int res, i, j;
-
+#if USE_DSHOT_DMA
+	int res;
+	/* Mapping from physical channels (pwm_ch1 .. pwm_ch4) to indices in val16 array */
+	int valIdx[PWM_CHN_NUM] = { -1, -1, -1, -1 };
 	(void)flags;
 
 	res = pwm_validateTimer(timer, true, DMA_CAP_UPD);
@@ -959,28 +884,102 @@ int pwm_setBitSequence4(pwm_tim_id_t timer, const uint16_t chnRaw[4], const uint
 		return res;
 	}
 
-	for (i = 0; i < PWM_CHN_NUM; ++i) {
-		chn[i] = (pwm_ch_id_t)chnRaw[i];
-
-		res = pwm_validateChannel(timer, chn[i]);
+	pwm_tim_data_t *t = &pwm_common.timer[timer];
+	for (int i = 0; i < 4; i++) {
+		pwm_ch_id_t chn = (pwm_ch_id_t)chnRaw[i];
+		res = pwm_validateChannel(timer, chn);
 		if (res < 0) {
 			return res;
 		}
 
-		for (j = 0; j < i; ++j) {
-			if (chn[i] == chn[j]) {
-				return -EINVAL;
-			}
-
-			if (PWM_CCR_REG(chn[i]) == PWM_CCR_REG(chn[j])) {
-				return -EINVAL;
-			}
+		if (valIdx[chn] != -1) {
+			/* One of the channels was given twice */
+			return -EINVAL;
 		}
 
-		pwm_fillBitSequence(val16[i], hcmp, lcmp, seq[i]);
+		valIdx[chn] = i;
 	}
 
-	return pwm_callBitSequence(timer, chn, seq);
+	mutexLock(t->dmaMutex);
+	res = pwm_initDMA(timer, 0, pwm_dmaUpdMultiChannel);
+	if (res < 0) {
+		mutexUnlock(t->dmaMutex);
+		return res;
+	}
+
+	if (t->dmaMem == NULL) {
+		t->dmaMem = libdma_malloc(DMA_ALLOC_SIZE, sizeof(uint16_t));
+		if (t->dmaMem == NULL) {
+			mutexUnlock(t->dmaMutex);
+			return -ENOMEM;
+		}
+	}
+
+	const struct libdma_per *per = t->dma_multiChannel;
+	static const size_t n_bits = 16;
+	static const size_t n_values = n_bits * PWM_CHN_NUM;
+	_Static_assert(n_values * sizeof(uint16_t) <= DMA_ALLOC_SIZE);
+	volatile uint16_t *rendered = t->dmaMem;
+	pwm_renderBitSequence(rendered, n_bits, valIdx, PWM_CHN_NUM, val16, hcmp, lcmp);
+	libdma_transfer_buffer_t bufs[2] = {
+		{
+			.buf = (void *)rendered,
+			.bufSize = n_values * sizeof(rendered[0]),
+			.elSize_log = sizeLog(sizeof(rendered[0])),
+			.burstSize = PWM_CHN_NUM, /* Use burst transaction when reading to reduce bus contention a bit */
+			.increment = 1,
+			.isCached = 0,
+			.transform = LIBXPDMA_TRANSFORM_ALIGNR0,
+		},
+		/* Insert the two idle values (see above) */
+		{
+			.buf = (void *)&pwm_idleValue,
+			.bufSize = 2 * PWM_CHN_NUM * sizeof(pwm_idleValue),
+			.elSize_log = sizeLog(sizeof(pwm_idleValue)),
+			.burstSize = PWM_CHN_NUM,
+			.increment = 0,
+			.isCached = 0,
+			.transform = LIBXPDMA_TRANSFORM_ALIGNR0,
+		},
+	};
+
+	res = libxpdma_configureMemory(per, dma_mem2per, 0, bufs, 2);
+	if (res < 0) {
+		mutexUnlock(t->dmaMutex);
+		return res;
+	}
+
+	/* Start the PWM channel. Set first duty cycle to 0 - idle state. It will be output until DMA takes over. */
+	for (int i = pwm_ch1; i <= pwm_ch4; i++) {
+		res = pwm_setInternal(timer, i, pwm_idleValue, 0);
+		if (res < 0) {
+			mutexUnlock(t->dmaMutex);
+			return res;
+		}
+	}
+
+	volatile int done = 0;
+	/* Configure DMA distribution system */
+	*(pwm_setup.timer[timer].base + tim_dier) &= ~TIM_DIER_UDE;
+	*(pwm_setup.timer[timer].base + tim_dcr) =
+			(1 << 16) |                /* DMA burst source: update event */
+			((PWM_CHN_NUM - 1) << 8) | /* DMA burst length: all available channels */
+			(tim_ccr1 << 0);           /* DMA burst start at CCR1 register */
+	res = libxpdma_startTransferWithFlag(per, dma_mem2per, &done);
+	if (res < 0) {
+		mutexUnlock(t->dmaMutex);
+		return res;
+	}
+
+	*(pwm_setup.timer[timer].base + tim_dier) |= TIM_DIER_UDE;
+	/* TODO: we can calculate a timeout here */
+	res = libxpdma_waitForTransaction(per, &done, NULL, 0);
+	mutexUnlock(t->dmaMutex);
+	return res;
+#else
+	(void)pwm_renderBitSequence;
+	return -ENOSYS;
+#endif
 }
 
 

--- a/multi/stm32l4-multi/pwm_n6.c
+++ b/multi/stm32l4-multi/pwm_n6.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <stdatomic.h>
 #include <sys/threads.h>
 #include <sys/interrupt.h>
 #include <sys/pwman.h>
@@ -30,7 +31,41 @@
 #define USE_DSHOT_DMA 1
 #define MAX_DSHOT_DMA 32
 
-#define TIM_DIER_UDE (1 << 8) /* Update DMA request enable */
+#define TIM_DIER_UIE   (1 << 0)  /* Update IRQ enable */
+#define TIM_DIER_CC1IE (1 << 1)  /* Capture/compare 1 IRQ enable */
+#define TIM_DIER_CC2IE (1 << 2)  /* Capture/compare 2 IRQ enable */
+#define TIM_DIER_CC3IE (1 << 3)  /* Capture/compare 3 IRQ enable */
+#define TIM_DIER_CC4IE (1 << 4)  /* Capture/compare 4 IRQ enable */
+#define TIM_DIER_UDE   (1 << 8)  /* Update DMA request enable */
+#define TIM_DIER_CC1DE (1 << 9)  /* Capture/compare 1 DMA request enable */
+#define TIM_DIER_CC2DE (1 << 10) /* Capture/compare 2 DMA request enable */
+#define TIM_DIER_CC3DE (1 << 11) /* Capture/compare 3 DMA request enable */
+#define TIM_DIER_CC4DE (1 << 12) /* Capture/compare 4 DMA request enable */
+
+/* Note: status registers are write 0 to clear, write 1 indifferent */
+
+#define TIM_SR_UIF   (1 << 0)  /* Update flag */
+#define TIM_SR_CC1IF (1 << 1)  /* Capture/compare 1 flag */
+#define TIM_SR_CC2IF (1 << 2)  /* Capture/compare 2 flag */
+#define TIM_SR_CC3IF (1 << 3)  /* Capture/compare 3 flag */
+#define TIM_SR_CC4IF (1 << 4)  /* Capture/compare 4 flag */
+#define TIM_SR_TIF   (1 << 6)  /* Trigger event flag */
+#define TIM_SR_CC1OF (1 << 9)  /* Capture/compare 1 overcapture flag */
+#define TIM_SR_CC2OF (1 << 10) /* Capture/compare 2 overcapture flag */
+#define TIM_SR_CC3OF (1 << 11) /* Capture/compare 3 overcapture flag */
+#define TIM_SR_CC4OF (1 << 12) /* Capture/compare 4 overcapture flag */
+
+#define TIM_EGR_UG (1 << 0) /* Generate update event */
+
+/* DMA capability flags - there exists a DMA request of this type for this timer */
+#define DMA_CAP_CC1 (1 << 0)
+#define DMA_CAP_CC2 (1 << 1)
+#define DMA_CAP_CC3 (1 << 2)
+#define DMA_CAP_CC4 (1 << 3)
+#define DMA_CAP_UPD (1 << 4)
+#define DMA_CAP_TRG (1 << 5)
+#define DMA_CAP_COM (1 << 6)
+
 
 /* Data used in IRQ dshot. Limited to one channel per timer. */
 typedef struct {
@@ -59,141 +94,170 @@ typedef struct {
 	const unsigned int uevirq; /* Update Event interrupt request */
 	const uint32_t pctl;
 	const uint8_t channels; /* If channel available (1 << channel_id) set */
+	const uint8_t dmaCaps;  /* DMA capabilities */
 } pwm_tim_setup_t;
 
 typedef struct {
 	pwm_irq_t irq;
 	uint32_t arr;
-	uint8_t channelOn;
-	uint8_t devOn;
+	atomic_uint_least8_t channelOn;
+	bool initialized;
 #if USE_DSHOT_DMA
+	handle_t dmaMutex;
 	const struct libdma_per *dma_per[PWM_CHN_NUM];
+	const struct libdma_per *dma_multiChannel;
+	const struct libdma_per *dma_capture[PWM_CHN_NUM];
 #endif
 } pwm_tim_data_t;
 
-/* clang-format off */
 static const struct {
 	pwm_tim_setup_t timer[pwm_tim_count];
 } pwm_setup = {
 	.timer = {
 		[pwm_tim1] = {
 			.base = TIM1_BASE,
+			.pctl = pctl_tim1,
 			.channels = (1 << pwm_ch1) | (1 << pwm_ch1n) | (1 << pwm_ch2) | (1 << pwm_ch2n) |
-					    (1 << pwm_ch3) | (1 << pwm_ch3n) | (1 << pwm_ch4) | (1 << pwm_ch4n),
+					(1 << pwm_ch3) | (1 << pwm_ch3n) | (1 << pwm_ch4) | (1 << pwm_ch4n),
 			.uevirq = tim1_up_irq,
-			.pctl = pctl_tim1
+			.dmaCaps = DMA_CAP_CC1 | DMA_CAP_CC2 | DMA_CAP_CC3 | DMA_CAP_CC4 | DMA_CAP_UPD | DMA_CAP_TRG | DMA_CAP_COM,
 		},
 		[pwm_tim2] = {
 			.base = TIM2_BASE,
+			.pctl = pctl_tim2,
 			.channels = (1 << pwm_ch1) | (1 << pwm_ch2) | (1 << pwm_ch3) | (1 << pwm_ch4),
 			.uevirq = tim2_irq,
-			 .pctl = pctl_tim2
+			.dmaCaps = DMA_CAP_CC1 | DMA_CAP_CC2 | DMA_CAP_CC3 | DMA_CAP_CC4 | DMA_CAP_UPD | DMA_CAP_TRG,
 		},
 		[pwm_tim3] = {
 			.base = TIM3_BASE,
+			.pctl = pctl_tim3,
 			.channels = (1 << pwm_ch1) | (1 << pwm_ch2) | (1 << pwm_ch3) | (1 << pwm_ch4),
 			.uevirq = tim3_irq,
-			.pctl = pctl_tim3
+			.dmaCaps = DMA_CAP_CC1 | DMA_CAP_CC2 | DMA_CAP_CC3 | DMA_CAP_CC4 | DMA_CAP_UPD | DMA_CAP_TRG,
 		},
 		[pwm_tim4] = {
 			.base = TIM4_BASE,
+			.pctl = pctl_tim4,
 			.channels = (1 << pwm_ch1) | (1 << pwm_ch2) | (1 << pwm_ch3) | (1 << pwm_ch4),
-			.uevirq = tim4_irq, .pctl = pctl_tim4
+			.uevirq = tim4_irq,
+			.dmaCaps = DMA_CAP_CC1 | DMA_CAP_CC2 | DMA_CAP_CC3 | DMA_CAP_CC4 | DMA_CAP_UPD | DMA_CAP_TRG,
 		},
 		[pwm_tim5] = {
 			.base = TIM5_BASE,
+			.pctl = pctl_tim5,
 			.channels = (1 << pwm_ch1) | (1 << pwm_ch2) | (1 << pwm_ch3) | (1 << pwm_ch4),
 			.uevirq = tim5_irq,
-			.pctl = pctl_tim5 },
+			.dmaCaps = DMA_CAP_CC1 | DMA_CAP_CC2 | DMA_CAP_CC3 | DMA_CAP_CC4 | DMA_CAP_UPD | DMA_CAP_TRG,
+		},
 		[pwm_tim6] = {
 			.base = TIM6_BASE,
+			.pctl = pctl_tim6,
+			.uevirq = tim6_irq,
+			.dmaCaps = DMA_CAP_UPD,
 		},
 		[pwm_tim7] = {
 			.base = TIM7_BASE,
+			.pctl = pctl_tim7,
+			.uevirq = tim7_irq,
+			.dmaCaps = DMA_CAP_UPD,
 		},
 		[pwm_tim8] = {
 			.base = TIM8_BASE,
-			.channels = (1 << pwm_ch1) | (1 << pwm_ch1n) | (1 << pwm_ch2) | (1 << pwm_ch2n) |
-			            (1 << pwm_ch3) | (1 << pwm_ch3n) | (1 << pwm_ch4) | (1 << pwm_ch4n),
+			.pctl = pctl_tim8,
+			.channels = (1 << pwm_ch1) | (1 << pwm_ch1n) | (1 << pwm_ch2) | (1 << pwm_ch2n) | (1 << pwm_ch3) | (1 << pwm_ch3n) | (1 << pwm_ch4) | (1 << pwm_ch4n),
 			.uevirq = tim8_up_irq,
-			.pctl = pctl_tim8
+			.dmaCaps = DMA_CAP_CC1 | DMA_CAP_CC2 | DMA_CAP_CC3 | DMA_CAP_CC4 | DMA_CAP_UPD | DMA_CAP_TRG | DMA_CAP_COM,
 		},
 		[pwm_tim9] = {
 			.base = TIM9_BASE,
+			.pctl = pctl_tim9,
 			.channels = (1 << pwm_ch1) | (1 << pwm_ch2),
 			.uevirq = tim9_irq,
-			.pctl = pctl_tim9
 		},
 		[pwm_tim10] = {
 			.base = TIM10_BASE,
+			.pctl = pctl_tim10,
 			.channels = (1 << pwm_ch1),
 			.uevirq = tim10_irq,
-			.pctl = pctl_tim10
 		},
 		[pwm_tim11] = {
 			.base = TIM11_BASE,
+			.pctl = pctl_tim11,
 			.channels = (1 << pwm_ch1),
 			.uevirq = tim11_irq,
-			.pctl = pctl_tim11
 		},
 		[pwm_tim12] = {
 			.base = TIM12_BASE,
+			.pctl = pctl_tim12,
 			.channels = (1 << pwm_ch1) | (1 << pwm_ch2),
 			.uevirq = tim12_irq,
-			.pctl = pctl_tim12
 		},
 		[pwm_tim13] = {
 			.base = TIM13_BASE,
+			.pctl = pctl_tim13,
 			.channels = (1 << pwm_ch1),
 			.uevirq = tim13_irq,
-			.pctl = pctl_tim13
 		},
 		[pwm_tim14] = {
 			.base = TIM14_BASE,
+			.pctl = pctl_tim14,
 			.channels = (1 << pwm_ch1),
 			.uevirq = tim14_irq,
-			.pctl = pctl_tim14
 		},
 		[pwm_tim15] = {
 			.base = TIM15_BASE,
+			.pctl = pctl_tim15,
 			.channels = (1 << pwm_ch1) | (1 << pwm_ch1n) | (1 << pwm_ch2),
 			.uevirq = tim15_irq,
-			.pctl = pctl_tim15
+			.dmaCaps = DMA_CAP_CC1 | DMA_CAP_CC2 | DMA_CAP_UPD | DMA_CAP_TRG | DMA_CAP_COM,
 		},
 		[pwm_tim16] = {
 			.base = TIM16_BASE,
+			.pctl = pctl_tim16,
 			.channels = (1 << pwm_ch1) | (1 << pwm_ch1n),
 			.uevirq = tim16_irq,
-			.pctl = pctl_tim16
+			.dmaCaps = DMA_CAP_CC1 | DMA_CAP_UPD | DMA_CAP_COM,
 		},
 		[pwm_tim17] = {
 			.base = TIM17_BASE,
+			.pctl = pctl_tim17,
 			.channels = (1 << pwm_ch1) | (1 << pwm_ch1n),
 			.uevirq = tim17_irq,
-			.pctl = pctl_tim17
+			.dmaCaps = DMA_CAP_CC1 | DMA_CAP_UPD | DMA_CAP_COM,
 		},
 		[pwm_tim18] = {
 			.base = TIM18_BASE,
+			.pctl = pctl_tim18,
+			.uevirq = tim18_irq,
+			.dmaCaps = DMA_CAP_CC1 | DMA_CAP_UPD | DMA_CAP_COM,
 		} }
 };
-/* clang-format on */
 
 static struct {
 	pwm_tim_data_t timer[pwm_tim_count];
-#if USE_DSHOT_DMA
-	handle_t dmalock;
-#endif
+	uint32_t baseFreq; /* Timer base frequency, 32-bit range is acceptable on this platform */
 } pwm_common;
 
 
-static int pwm_validateTimer(pwm_tim_id_t timer)
+static int pwm_validateTimer(pwm_tim_id_t timer, bool checkInitialized, uint8_t checkDMAFlags)
 {
 	if (timer < 0 || timer >= pwm_tim_count) {
 		return -EINVAL;
 	}
+
 	if (((PWM_TIM_BASIC >> timer) & 1) != 0) {
 		return -EINVAL;
 	}
+
+	if (checkInitialized && !pwm_common.timer[timer].initialized) {
+		return -EINVAL;
+	}
+
+	if ((pwm_setup.timer[timer].dmaCaps & checkDMAFlags) != checkDMAFlags) {
+		return -EINVAL;
+	}
+
 	return EOK;
 }
 
@@ -278,14 +342,14 @@ static int pwm_updateEventIrq(unsigned int n, void *arg)
 
 	/* If irq isn't used to load next DSHOT bit, didsable future UEV interrupts. */
 	if (!irq->flag_dshot_uev) {
-		*(base + tim_dier) &= ~1u;
+		*(base + tim_dier) &= ~TIM_DIER_UIE;
 	}
 	else {
 #if USE_DSHOT_DMA == 0
 		pwm_ch_id_t chn = dshot->chn;
 		/* If the last bit was already emitted, can safely disable further UEV IRQ */
 		if (dshot->bitPos > dshot->bitSize) {
-			*(base + tim_dier) &= ~1u;
+			*(base + tim_dier) &= ~TIM_DIER_UIE;
 			irq->flag_dshot_end = 1;
 		}
 		/* If last bit then preload compare value to 0 to end the sequence */
@@ -301,8 +365,7 @@ static int pwm_updateEventIrq(unsigned int n, void *arg)
 #endif
 	}
 
-	/* Clear UIF in SR */
-	*(base + tim_sr) &= ~1u;
+	*(base + tim_sr) = ~TIM_SR_UIF;
 	irq->flag_uevreceived = 1;
 	return 0;
 }
@@ -310,15 +373,13 @@ static int pwm_updateEventIrq(unsigned int n, void *arg)
 
 int pwm_disableTimer(pwm_tim_id_t timer)
 {
-	int res = pwm_validateTimer(timer);
+	int res = pwm_validateTimer(timer, true, 0);
 	if (res < 0) {
 		return res;
 	}
 	/* Disable all enabled channels */
 	for (pwm_ch_id_t chn = 0; chn < PWM_CHN_NUM; chn++) {
-		if (((pwm_common.timer[timer].channelOn >> chn) & 1) != 0) {
-			pwm_disableChannel(timer, chn);
-		}
+		pwm_disableChannel(timer, chn);
 	}
 
 	/* Clear CEN in CR1 */
@@ -330,7 +391,7 @@ int pwm_disableTimer(pwm_tim_id_t timer)
 
 int pwm_disableChannel(pwm_tim_id_t timer, pwm_ch_id_t chn)
 {
-	int res = pwm_validateTimer(timer);
+	int res = pwm_validateTimer(timer, true, 0);
 	if (res < 0) {
 		return res;
 	}
@@ -339,20 +400,25 @@ int pwm_disableChannel(pwm_tim_id_t timer, pwm_ch_id_t chn)
 		return res;
 	}
 
+	uint8_t prevChannelOn = atomic_fetch_and(&pwm_common.timer[timer].channelOn, ~(1 << chn));
+	if (((prevChannelOn >> chn) & 1) == 0) {
+		/* Already disabled */
+		return 0;
+	}
+
 	/* Disable the channel. Clear CCxE in CCER */
 	*(pwm_setup.timer[timer].base + tim_ccer) &= ~(1 << PWM_CCER_CCE_OFF(chn));
 	if (pwm_channelHasComplement(timer, chn)) {
 		*(pwm_setup.timer[timer].base + tim_ccer) &= ~(1 << PWM_CCER_CCNE_OFF(chn));
 	}
-	/* Remember that channel is closed */
-	pwm_common.timer[timer].channelOn &= ~(1 << chn);
+
 	return EOK;
 }
 
 
 uint64_t pwm_getBaseFrequency(pwm_tim_id_t timer)
 {
-	int res = pwm_validateTimer(timer);
+	int res = pwm_validateTimer(timer, false, 0);
 	if (res < 0) {
 		return 0;
 	}
@@ -361,7 +427,22 @@ uint64_t pwm_getBaseFrequency(pwm_tim_id_t timer)
 	if (res < 0) {
 		return 0;
 	}
+	pwm_common.baseFreq = (uint32_t)baseFreq; /* Update stored base frequency */
 	return baseFreq;
+}
+
+/* Generate update event (UG bit in EGR) to update prescaler, autoreload value and clear counters */
+static void pwm_forceUpdateEvent(pwm_tim_id_t timer)
+{
+	volatile uint32_t *base = pwm_setup.timer[timer].base;
+	*(base + tim_sr) = ~TIM_SR_UIF; /* Clear update event flag */
+	/* Force an update event */
+	*(base + tim_egr) = TIM_EGR_UG;
+	while ((*(base + tim_sr) & TIM_SR_UIF) == 0) {
+		/* Wait for timer to have an update event, it should be very short (~50 ns) */
+	}
+
+	*(base + tim_sr) = ~TIM_SR_UIF; /* Clear update event flag */
 }
 
 
@@ -373,7 +454,7 @@ int pwm_configure(pwm_tim_id_t timer, uint16_t prescaler, uint32_t top)
 	uint16_t t16;
 	volatile uint32_t *base;
 	pwm_irq_t *irq;
-	int res = pwm_validateTimer(timer);
+	int res = pwm_validateTimer(timer, false, 0);
 
 	if (res < 0) {
 		return res;
@@ -383,10 +464,17 @@ int pwm_configure(pwm_tim_id_t timer, uint16_t prescaler, uint32_t top)
 	}
 	base = pwm_setup.timer[timer].base;
 	irq = &pwm_common.timer[timer].irq;
-	if (pwm_common.timer[timer].devOn == 0) {
+	if (!pwm_common.timer[timer].initialized) {
 		devClk(pwm_setup.timer[timer].pctl, 1);
-		pwm_common.timer[timer].devOn = 1;
+		if (pwm_setup.timer[timer].dmaCaps != 0) {
+			if (mutexCreate(&pwm_common.timer[timer].dmaMutex) < 0) {
+				return -ENOMEM;
+			}
+		}
+
+		pwm_common.timer[timer].initialized = true;
 	}
+
 	if (!irq->flag_initialized) {
 		mutexCreate(&irq->uevlock);
 		condCreate(&irq->uevcond);
@@ -395,13 +483,14 @@ int pwm_configure(pwm_tim_id_t timer, uint16_t prescaler, uint32_t top)
 	}
 
 	/* Fail if one of the channels hasn't been disabled */
-	if (pwm_common.timer[timer].channelOn != 0) {
+	if (atomic_load(&pwm_common.timer[timer].channelOn) != 0) {
 		return -EPERM;
 	}
 
+	dataBarier();
+
 	/* In CR1 set prescaler, countermode, autoreload, clockdivision, repetition counter */
 	t16 = *((base + tim_cr1));
-	dataBarier();
 
 	/* Set counter mode UP in CR1 => clear DIR and CMS */
 	if (((PWM_TIM_CNT_MODE_SELECT >> timer) & 1) != 0) {
@@ -413,7 +502,6 @@ int pwm_configure(pwm_tim_id_t timer, uint16_t prescaler, uint32_t top)
 	t16 &= ~1u;
 
 	*(base + tim_cr1) = t16;
-	dataBarier();
 
 	/* In AF1/2 disable break input */
 	if (((PWM_TIM_BREAK1_MODE >> timer) & 1) != 0) {
@@ -425,7 +513,6 @@ int pwm_configure(pwm_tim_id_t timer, uint16_t prescaler, uint32_t top)
 
 	/* Set autoreload in ARR */
 	pwm_common.timer[timer].arr = top;
-
 	*(base + tim_arr) = top;
 
 	/* Set prescaler in PSC */
@@ -436,170 +523,95 @@ int pwm_configure(pwm_tim_id_t timer, uint16_t prescaler, uint32_t top)
 		*(base + tim_rcr) = 0;
 	}
 
-	dataBarier();
-
-	/* Enable update event interrupt */
-	*(base + tim_dier) |= 0x1;
-
-	dataBarier();
-	/* Generate update event (UG bit in EGR) to reload prescaler and repetition counter */
-	*(base + tim_egr) |= 0x1;
-
-	dataBarier();
-
 	/* Enable autoreload buffering in CR1 ARPE */
 	*(base + tim_cr1) |= (1 << 7);
-
-	dataBarier();
-
-	/* Wait for update event to load prescaler and arr */
-	mutexLock(irq->uevlock);
-	while (!irq->flag_uevreceived) {
-		condWait(irq->uevcond, irq->uevlock, 0);
-	}
-	irq->flag_uevreceived = 0;
-	mutexUnlock(irq->uevlock);
-
-	return EOK;
-}
-
-
-int pwm_set(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t compare)
-{
-	volatile uint32_t *reg;
-	uint32_t tmpcr2 = 0, tmpccmr = 0, tmpccer = 0, tmpbdtr = 0;
-	volatile uint32_t *base;
-	pwm_irq_t *irq;
-#if USE_DSHOT_DMA == 0
-	pwm_dshot_ctx_t *dshot;
-#endif
-
-	int res = pwm_validateTimer(timer);
-	if (res < 0) {
-		return res;
-	}
-	res = pwm_validateChannel(timer, chn);
-	if (res < 0) {
-		return res;
-	}
-	if ((((PWM_TIM_32BIT >> timer) & 1) == 0) && ((compare & 0xFFFF0000) != 0)) {
-		return -EINVAL;
-	}
-	if (compare > pwm_common.timer[timer].arr) {
-		return -EINVAL;
-	}
-	base = pwm_setup.timer[timer].base;
-	irq = &pwm_common.timer[timer].irq;
-#if USE_DSHOT_DMA == 0
-	dshot = &irq->dshot;
-#endif
-
-	/* If channel is on, then only reconfigure compare value */
-	if (((pwm_common.timer[timer].channelOn >> chn) & 1) != 0) {
-		*(base + PWM_CCR_REG(chn)) = compare;
-		return EOK;
-	}
-
-	/* Set output channel preloading in CCMRx OCyPE */
-	reg = (base + PWM_CCMR_REG(chn));
-	*reg |= (1 << PWM_CCMR_OCPE_OFF(chn));
-
-	/* TODO: Find out what's the deal with channel 5,6. Why are they not in the pin table, but in the register description? */
-
-	dataBarier();
-
-	/* Disable the channel. Clear CCxE in CCER */
-	*(base + tim_ccer) &= ~(1 << PWM_CCER_CCE_OFF(chn));
-	if (pwm_channelHasComplement(timer, chn)) {
-		*(base + tim_ccer) &= ~(1 << PWM_CCER_CCNE_OFF(chn));
-	}
-
-	dataBarier();
-
-	tmpcr2 = *(base + tim_cr2);
-	tmpccmr = *(base + PWM_CCMR_REG(chn));
-	tmpccer = *(base + tim_ccer);
-
-	/* Set channel as output. Clear CCyS */
-	tmpccmr &= ~(0x3 << PWM_CCMR_CCS_OFF(chn));
-	/* Set output compare mode to PWM 1 mode (0110 bits 16, 6:4)*/
-	tmpccmr &= ~((1 << PWM_CCMR_OCMH_OFF(chn)) | (0x7 << PWM_CCMR_OCML_OFF(chn)));
-	tmpccmr |= (0x6 << PWM_CCMR_OCML_OFF(chn));
-	/* Set output compare polarity to active high (0)*/
-	tmpccer &= ~(1 << PWM_CCER_CCP_OFF(chn));
-
-	// This isn't necessarily a check if complement exists, but if there is break mode
-	if (pwm_channelHasComplement(timer, chn)) {
-		/* Disable the complementary channel */
-		tmpccer &= ~(1 << PWM_CCER_CCNE_OFF(chn));
-		/* Set complementary output polarity (to active high) */
-		tmpccer &= ~(1 << PWM_CCER_CCNP_OFF(chn));
-		/* Set output idle state to low */
-		tmpcr2 &= ~(1 << PWM_CR2_OIS_OFF(chn));
-		/* Set complementary output idle state to low */
-		tmpcr2 &= ~(1 << PWM_CR2_OISN_OFF(chn));
-
-		*(base + tim_cr2) = tmpcr2;
-	}
-
-	/* Write changes */
-	*(base + PWM_CCMR_REG(chn)) = tmpccmr;
-	*(base + tim_ccer) = tmpccer;
-	/* Set compare value in CCRx */
-	*(base + PWM_CCR_REG(chn)) = compare;
-
-	dataBarier();
-
-	/* Disable fast output */
-	*(base + PWM_CCMR_REG(chn)) &= ~(1 << PWM_CCMR_OCFE_OFF(chn));
 
 	pwm_disableMasterSlave(timer);
 
 	/* Initialize BDTR register. Dead time feature is unnecessary. Disable breaks */
 	if ((((PWM_TIM_BREAK1_MODE | PWM_TIM_BREAK2_MODE) >> timer) & 1) != 0) {
-		tmpbdtr = 0;
 		/* Enable main output (MOE) */
-		tmpbdtr |= (1 << 15);
-		*(base + tim_bdtr) = tmpbdtr;
+		*(base + tim_bdtr) = (1 << 15);
+	}
+
+	pwm_forceUpdateEvent(timer);
+
+	dataBarier();
+
+	return EOK;
+}
+
+
+static int pwm_setInternal(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t compare, uint8_t activeLow)
+{
+	volatile uint32_t *base = pwm_setup.timer[timer].base;
+
+	/* If channel is on, then only reconfigure compare value */
+	uint8_t prevChannelOn = atomic_fetch_or(&pwm_common.timer[timer].channelOn, (1 << chn));
+	if (((prevChannelOn >> chn) & 1) != 0) {
+		*(base + PWM_CCR_REG(chn)) = compare;
+		return EOK;
 	}
 
 	dataBarier();
 
-	/* Enable output channel (and it's complement) */
-	*(base + tim_ccer) |= (1 << PWM_CCER_CCE_OFF(chn));
+	/* Disable the channel. Clear CCxE in CCER */
+	uint32_t tmpccer = *(base + tim_ccer);
+	tmpccer &= ~(1 << PWM_CCER_CCE_OFF(chn));
 	if (pwm_channelHasComplement(timer, chn)) {
-		*(base + tim_ccer) |= (1 << PWM_CCER_CCNE_OFF(chn));
+		tmpccer &= ~(1 << PWM_CCER_CCNE_OFF(chn));
 	}
 
-	dataBarier();
-	/* Enable update event interrupt */
-	*(base + tim_dier) |= 0x1;
+	*(base + tim_ccer) = tmpccer;
 
-	/* Temporarily clear the DSHOT_UEV flag to run the regular UEV handler */
-	uint32_t oldflag = irq->flag_dshot_uev;
-	irq->flag_dshot_uev = 0;
-	dataBarier();
+	uint32_t tmpccmr = *(base + PWM_CCMR_REG(chn));
+	/* Set channel as output. Clear CCyS */
+	tmpccmr &= ~(0x3 << PWM_CCMR_CCS_OFF(chn));
+	/* Set output compare mode to PWM 1 mode (0110 bits 16, 6:4)*/
+	tmpccmr &= ~((1 << PWM_CCMR_OCMH_OFF(chn)) | (0x7 << PWM_CCMR_OCML_OFF(chn)));
+	tmpccmr |= (0x6 << PWM_CCMR_OCML_OFF(chn));
+	/* Set output channel preloading in CCMRx OCyPE */
+	tmpccmr |= (1 << PWM_CCMR_OCPE_OFF(chn));
+	/* Disable fast output */
+	tmpccmr &= ~(1 << PWM_CCMR_OCFE_OFF(chn));
+	/* Set output compare polarity */
+	tmpccer &= ~(1 << PWM_CCER_CCP_OFF(chn));
+	tmpccer |= (activeLow != 0) ? (1 << PWM_CCER_CCP_OFF(chn)) : 0;
+	/* Enable output channel */
+	tmpccer |= (1 << PWM_CCER_CCE_OFF(chn));
 
-	/* Force an update event */
-	*(base + tim_egr) |= 0x1;
-
-	/* Wait for the update event */
-	mutexLock(irq->uevlock);
-	while (!irq->flag_uevreceived) {
-		condWait(irq->uevcond, irq->uevlock, 0);
+	// This isn't necessarily a check if complement exists, but if there is break mode
+	if (pwm_channelHasComplement(timer, chn)) {
+		/* Enable the complementary channel */
+		tmpccer |= (1 << PWM_CCER_CCNE_OFF(chn));
+		/* Set complementary output polarity (same as normal channel) */
+		tmpccer &= ~(1 << PWM_CCER_CCNP_OFF(chn));
+		tmpccer |= (activeLow != 0) ? (1 << PWM_CCER_CCNP_OFF(chn)) : 0;
+		/* Set output idle state to low */
+		uint32_t tmpcr2 = *(base + tim_cr2);
+		tmpcr2 &= ~(1 << PWM_CR2_OIS_OFF(chn));
+		/* Set complementary output idle state to low */
+		tmpcr2 &= ~(1 << PWM_CR2_OISN_OFF(chn));
+		*(base + tim_cr2) = tmpcr2;
 	}
-	irq->flag_uevreceived = 0;
-	mutexUnlock(irq->uevlock);
 
-	dataBarier();
-	/* Restore the old flags */
-	irq->flag_dshot_uev = oldflag;
-	dataBarier();
+	/* Write configuration changes */
+	*(base + PWM_CCMR_REG(chn)) = tmpccmr;
+	/* Set compare value in CCRx */
+	*(base + PWM_CCR_REG(chn)) = compare;
+
+	pwm_forceUpdateEvent(timer);
+
+	/* Write changes to CCER (also enables channel) */
+	*(base + tim_ccer) = tmpccer;
 
 #if USE_DSHOT_DMA == 0
+	pwm_irq_t *irq = &pwm_common.timer[timer].irq;
+	pwm_dshot_ctx_t *dshot = &irq->dshot;
+
 	/* Enable subsequent UEV interrupts if in dshot mode */
 	if (irq->flag_dshot_uev) {
-		*(base + tim_dier) |= 0x1;
+		*(base + tim_dier) |= TIM_DIER_UIE;
 	}
 
 	/* Preload the second compare value if in dshot mode */
@@ -614,16 +626,13 @@ int pwm_set(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t compare)
 	*(base + tim_cr1) |= 0x1;
 
 	dataBarier();
-
-	/* Mark that channel is on */
-	pwm_common.timer[timer].channelOn |= (1 << chn);
 	return EOK;
 }
 
 
-int pwm_get(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t *top, uint32_t *compare)
+int pwm_set(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t compare, uint8_t activeLow)
 {
-	int res = pwm_validateTimer(timer);
+	int res = pwm_validateTimer(timer, true, 0);
 	if (res < 0) {
 		return res;
 	}
@@ -631,26 +640,79 @@ int pwm_get(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t *top, uint32_t *compar
 	if (res < 0) {
 		return res;
 	}
-	if (((pwm_common.timer[timer].channelOn >> chn) & 1) == 0) {
+	if ((((PWM_TIM_32BIT >> timer) & 1) == 0) && ((compare & 0xFFFF0000) != 0)) {
+		return -EINVAL;
+	}
+	if (compare > pwm_common.timer[timer].arr) {
+		return -EINVAL;
+	}
+	return pwm_setInternal(timer, chn, compare, activeLow);
+}
+
+
+int pwm_get(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t *top, uint32_t *compare)
+{
+	int res = pwm_validateTimer(timer, true, 0);
+	if (res < 0) {
+		return res;
+	}
+	res = pwm_validateChannel(timer, chn);
+	if (res < 0) {
+		return res;
+	}
+
+	/* If channel is off, we don't allow reading of current timer settings */
+	if (((atomic_load(&pwm_common.timer[timer].channelOn) >> chn) & 1) == 0) {
 		return -EPERM;
 	}
+
 	/* Load top and compare. Return compare/top */
 	*top = *(pwm_setup.timer[timer].base + tim_arr);
 	*compare = *(pwm_setup.timer[timer].base + PWM_CCR_REG(chn));
 	return EOK;
 }
 
-static int pwm_initDMAChannel(pwm_tim_id_t timer, pwm_ch_id_t chn)
+#if USE_DSHOT_DMA
+enum pwm_dmaAllocType {
+	pwm_dmaUpd,
+	pwm_dmaUpdMultiChannel,
+	pwm_dmaCapture,
+};
+
+static int pwm_initDMA(pwm_tim_id_t timer, pwm_ch_id_t chn, enum pwm_dmaAllocType type)
 {
-	int res = libxpdma_acquirePeripheral(dma_tim_upd, timer, 0, &(pwm_common.timer[timer].dma_per[chn]));
-	if ((res < 0) || (pwm_common.timer[timer].dma_per[chn] == NULL)) {
+	const struct libdma_per **target;
+	switch (type) {
+		case pwm_dmaUpd:
+			target = &pwm_common.timer[timer].dma_per[chn];
+			break;
+		case pwm_dmaUpdMultiChannel:
+			target = &pwm_common.timer[timer].dma_multiChannel;
+			break;
+		case pwm_dmaCapture:
+			target = &pwm_common.timer[timer].dma_capture[chn];
+			break;
+		default:
+			/* Should never happen except for programmer error */
+			return -EINVAL;
+	}
+
+	/* Check again, as it may have changed since last check */
+	if (*target != NULL) {
+		return 0;
+	}
+
+	int per = (type == pwm_dmaCapture) ? (dma_tim_cap1 + chn) : dma_tim_upd;
+	int dir = (type == pwm_dmaCapture) ? dma_per2mem : dma_mem2per;
+	int res = libxpdma_acquirePeripheral(per, timer, 0, target);
+	if ((res < 0) || (*target == NULL)) {
 		return res;
 	}
 
-	/* You're supposed to set control DMA-TIM transfers via TIM_DCR and TIM_DMAR registers
-	 * but that failed in testing, so we just give DMA the destination address directly. */
-	volatile uint32_t *destination = pwm_setup.timer[timer].base + PWM_CCR_REG(chn);
-	res = (res < 0) ? res : libxpdma_configureChannel(pwm_common.timer[timer].dma_per[chn], dma_mem2per, dma_priorityVeryHigh, NULL);
+	volatile uint32_t *destination = (type == pwm_dmaUpdMultiChannel) ?
+			(pwm_setup.timer[timer].base + tim_dmar) :
+			(pwm_setup.timer[timer].base + PWM_CCR_REG(chn));
+	res = (res < 0) ? res : libxpdma_configureChannel(*target, dir, dma_priorityVeryHigh, NULL);
 	libdma_peripheral_config_t cfg = {
 		.addr = (void *)destination,
 		.elSize_log = (((PWM_TIM_32BIT >> timer) & 1) != 0) ? 2 : 1,
@@ -658,9 +720,10 @@ static int pwm_initDMAChannel(pwm_tim_id_t timer, pwm_ch_id_t chn)
 		.increment = 0,
 	};
 
-	res = (res < 0) ? res : libxpdma_configurePeripheral(pwm_common.timer[timer].dma_per[chn], dma_mem2per, &cfg);
+	res = (res < 0) ? res : libxpdma_configurePeripheral(*target, dir, &cfg);
 	return res;
 }
+#endif
 
 static void pwm_fillBitSequence(uint16_t value, uint16_t hcmp, uint16_t lcmp, uint16_t seq[PWM_BITSEQ4_BITS + 2])
 {
@@ -694,7 +757,7 @@ static int pwm_callBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn[PWM_CHN_NUM],
 	bool udeMasked = false;
 	int res = 0, i;
 
-	mutexLock(pwm_common.dmalock);
+	mutexLock(pwm_common.timer[timer].dmaMutex);
 
 	for (i = 0; i < PWM_CHN_NUM; ++i) {
 		libdma_transfer_buffer_t buf = {
@@ -709,7 +772,7 @@ static int pwm_callBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn[PWM_CHN_NUM],
 
 		per[i] = pwm_common.timer[timer].dma_per[chn[i]];
 		if (per[i] == NULL) {
-			res = pwm_initDMAChannel(timer, chn[i]);
+			res = pwm_initDMA(timer, chn[i], pwm_dmaUpd);
 			per[i] = pwm_common.timer[timer].dma_per[chn[i]];
 		}
 
@@ -723,7 +786,7 @@ static int pwm_callBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn[PWM_CHN_NUM],
 		}
 
 		/* Start/arm the PWM channel in idle state. DMA will update CCR on timer update events. */
-		res = pwm_set(timer, chn[i], 0);
+		res = pwm_setInternal(timer, chn[i], 0, 0);
 		if (res < 0) {
 			break;
 		}
@@ -765,7 +828,7 @@ static int pwm_callBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn[PWM_CHN_NUM],
 		}
 	}
 
-	mutexUnlock(pwm_common.dmalock);
+	mutexUnlock(pwm_common.timer[timer].dmaMutex);
 	return res;
 #else
 	return -ENOSYS;
@@ -776,7 +839,7 @@ static int pwm_callBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn[PWM_CHN_NUM],
 int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t nbits, uint8_t datasize, int flags)
 {
 	int res;
-	res = pwm_validateTimer(timer);
+	res = pwm_validateTimer(timer, true, DMA_CAP_UPD);
 	if (res < 0) {
 		return res;
 	}
@@ -799,10 +862,10 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 	}
 
 #if USE_DSHOT_DMA
-	mutexLock(pwm_common.dmalock);
+	mutexLock(pwm_common.timer[timer].dmaMutex);
 	const struct libdma_per *per = pwm_common.timer[timer].dma_per[chn];
 	if (per == NULL) {
-		res = (res < 0) ? res : pwm_initDMAChannel(timer, chn);
+		res = (res < 0) ? res : pwm_initDMA(timer, chn, pwm_dmaUpd);
 		per = pwm_common.timer[timer].dma_per[chn];
 	}
 
@@ -840,7 +903,7 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 	};
 	res = (res < 0) ? res : libxpdma_configureMemory(per, dma_mem2per, 0, bufs, 2);
 	/* Start the PWM channel. Set first duty cycle to 0 - idle state. It will be output until DMA takes over. */
-	res = (res < 0) ? res : pwm_set(timer, chn, 0);
+	res = (res < 0) ? res : pwm_setInternal(timer, chn, 0, 0);
 	volatile int done = 0;
 	/* Request is disabled before DMA start and enabled after to prevent a possible race condition
 	 * between DMA start and timer update request. */
@@ -849,7 +912,7 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 	*(pwm_setup.timer[timer].base + tim_dier) |= TIM_DIER_UDE;
 	/* TODO: we can calculate a timeout here */
 	res = (res < 0) ? res : libxpdma_waitForTransaction(per, &done, NULL, 0);
-	mutexUnlock(pwm_common.dmalock);
+	mutexUnlock(pwm_common.timer[timer].dmaMutex);
 #else
 	uint16_t firstCompare;
 	pwm_irq_t *irq = &pwm_common.timer[timer].irq;
@@ -867,7 +930,7 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 	dataBarier();
 
 	firstCompare = pwm_getUserCompareVal(data, 0, datasize);
-	pwm_set(timer, chn, firstCompare);
+	pwm_setInternal(timer, chn, firstCompare, 0);
 
 	/* Wait for the DSHOT sequence to end */
 	mutexLock(irq->uevlock);
@@ -891,7 +954,7 @@ int pwm_setBitSequence4(pwm_tim_id_t timer, const uint16_t chnRaw[4], const uint
 
 	(void)flags;
 
-	res = pwm_validateTimer(timer);
+	res = pwm_validateTimer(timer, true, DMA_CAP_UPD);
 	if (res < 0) {
 		return res;
 	}
@@ -924,8 +987,10 @@ int pwm_setBitSequence4(pwm_tim_id_t timer, const uint16_t chnRaw[4], const uint
 int pwm_init(void)
 {
 #if USE_DSHOT_DMA
-	mutexCreate(&pwm_common.dmalock);
 	libdma_init();
 #endif
+
+	/* All timers have the same base frequency on this platform */
+	pwm_getBaseFrequency(pwm_tim1);
 	return 0;
 }

--- a/multi/stm32l4-multi/pwm_n6.c
+++ b/multi/stm32l4-multi/pwm_n6.c
@@ -121,7 +121,6 @@ typedef struct {
 
 /* Interrupt data for one timer */
 typedef struct {
-	bool flag_initialized;
 	volatile uint32_t flag_uevreceived;
 	volatile uint32_t flag_dshot_uev; /* IRQ used to reconfigure duty cycle */
 	volatile uint32_t flag_dshot_end; /* DSHOT bit sequence complete */
@@ -144,9 +143,9 @@ typedef struct {
 	pwm_irq_t irq;
 	uint32_t arr;
 	atomic_uint_least8_t channelOn;
-	bool initialized;
+	atomic_uint_least8_t initialized;
+	handle_t mutex;
 #if USE_DSHOT_DMA
-	handle_t dmaMutex;
 	void *dshotBuf;  /* Start of buffer allocated for DShot data */
 	void *dshotData; /* Start of DShot data (must be cache line aligned) */
 	const struct libdma_per *dma_per[PWM_CHN_NUM];
@@ -163,6 +162,10 @@ static const uint16_t pwm_idleValue = 0;
 #define SKIPSETUP_DMA_MULTICHN_SHIFT (SKIPSETUP_DMA_PER_SHIFT + NELEMS(((pwm_tim_data_t *)NULL)->dma_per))
 #define SKIPSETUP_DMA_CAPTURE_SHIFT  (SKIPSETUP_DMA_MULTICHN_SHIFT + 1)
 #define SKIPSETUP_END_SHIFT          (SKIPSETUP_DMA_CAPTURE_SHIFT + NELEMS(((pwm_tim_data_t *)NULL)->dma_capture))
+
+#define TIMER_INIT_NONE        0
+#define TIMER_INIT_IN_PROGRESS (1 << 0)
+#define TIMER_INIT_DONE        (1 << 1)
 
 static const struct {
 	pwm_tim_setup_t timer[pwm_tim_count];
@@ -415,7 +418,7 @@ static int pwm_validateTimer(pwm_tim_id_t timer, bool checkInitialized, uint8_t 
 		return -EINVAL;
 	}
 
-	if (checkInitialized && !pwm_common.timer[timer].initialized) {
+	if (checkInitialized && (atomic_load(&pwm_common.timer[timer].initialized) & TIMER_INIT_DONE) == 0) {
 		return -EINVAL;
 	}
 
@@ -540,21 +543,19 @@ static int pwm_updateEventIrq(unsigned int n, void *arg)
 }
 
 
-int pwm_disableTimer(pwm_tim_id_t timer)
+static void pwm_disableChannelInternal(pwm_tim_id_t timer, pwm_ch_id_t chn)
 {
-	int res = pwm_validateTimer(timer, true, 0);
-	if (res < 0) {
-		return res;
-	}
-	/* Disable all enabled channels */
-	for (pwm_ch_id_t chn = 0; chn < PWM_CHN_NUM; chn++) {
-		pwm_disableChannel(timer, chn);
+	uint8_t prevChannelOn = atomic_fetch_and(&pwm_common.timer[timer].channelOn, ~(1 << chn));
+	if (((prevChannelOn >> chn) & 1) == 0) {
+		/* Already disabled */
+		return;
 	}
 
-	/* Clear CEN in CR1 */
-	*(pwm_setup.timer[timer].base + tim_cr1) &= ~1u;
-
-	return EOK;
+	/* Disable the channel. Clear CCxE in CCER */
+	*(pwm_setup.timer[timer].base + tim_ccer) &= ~(1 << PWM_CCER_CCE_OFF(chn));
+	if (pwm_channelHasComplement(timer, chn)) {
+		*(pwm_setup.timer[timer].base + tim_ccer) &= ~(1 << PWM_CCER_CCNE_OFF(chn));
+	}
 }
 
 
@@ -569,18 +570,29 @@ int pwm_disableChannel(pwm_tim_id_t timer, pwm_ch_id_t chn)
 		return res;
 	}
 
-	uint8_t prevChannelOn = atomic_fetch_and(&pwm_common.timer[timer].channelOn, ~(1 << chn));
-	if (((prevChannelOn >> chn) & 1) == 0) {
-		/* Already disabled */
-		return 0;
+	mutexLock(pwm_common.timer[timer].mutex);
+	pwm_disableChannelInternal(timer, chn);
+	mutexUnlock(pwm_common.timer[timer].mutex);
+	return 0;
+}
+
+
+int pwm_disableTimer(pwm_tim_id_t timer)
+{
+	int res = pwm_validateTimer(timer, true, 0);
+	if (res < 0) {
+		return res;
 	}
 
-	/* Disable the channel. Clear CCxE in CCER */
-	*(pwm_setup.timer[timer].base + tim_ccer) &= ~(1 << PWM_CCER_CCE_OFF(chn));
-	if (pwm_channelHasComplement(timer, chn)) {
-		*(pwm_setup.timer[timer].base + tim_ccer) &= ~(1 << PWM_CCER_CCNE_OFF(chn));
+	mutexLock(pwm_common.timer[timer].mutex);
+	/* Disable all enabled channels */
+	for (pwm_ch_id_t chn = 0; chn < PWM_CHN_NUM; chn++) {
+		pwm_disableChannelInternal(timer, chn);
 	}
 
+	/* Clear CEN in CR1 */
+	*(pwm_setup.timer[timer].base + tim_cr1) &= ~1u;
+	mutexUnlock(pwm_common.timer[timer].mutex);
 	return EOK;
 }
 
@@ -633,22 +645,32 @@ int pwm_configure(pwm_tim_id_t timer, uint16_t prescaler, uint32_t top)
 	}
 	base = pwm_setup.timer[timer].base;
 	irq = &pwm_common.timer[timer].irq;
-	if (!pwm_common.timer[timer].initialized) {
+	uint8_t timer_inited = atomic_fetch_or(&pwm_common.timer[timer].initialized, TIMER_INIT_IN_PROGRESS);
+	if (timer_inited == TIMER_INIT_NONE) {
 		devClk(pwm_setup.timer[timer].pctl, 1);
-		if (pwm_setup.timer[timer].dmaCaps != 0) {
-			if (mutexCreate(&pwm_common.timer[timer].dmaMutex) < 0) {
-				return -ENOMEM;
-			}
+		if (mutexCreate(&pwm_common.timer[timer].mutex) < 0) {
+			atomic_store(&pwm_common.timer[timer].initialized, TIMER_INIT_NONE);
+			return -ENOMEM;
 		}
 
-		pwm_common.timer[timer].initialized = true;
-	}
+		if (mutexCreate(&irq->uevlock) < 0) {
+			resourceDestroy(pwm_common.timer[timer].mutex);
+			atomic_store(&pwm_common.timer[timer].initialized, TIMER_INIT_NONE);
+			return -ENOMEM;
+		}
 
-	if (!irq->flag_initialized) {
-		mutexCreate(&irq->uevlock);
-		condCreate(&irq->uevcond);
-		irq->flag_initialized = true;
+		if (condCreate(&irq->uevcond) < 0) {
+			resourceDestroy(pwm_common.timer[timer].mutex);
+			resourceDestroy(irq->uevlock);
+			atomic_store(&pwm_common.timer[timer].initialized, TIMER_INIT_NONE);
+			return -ENOMEM;
+		}
+
 		interrupt(pwm_setup.timer[timer].uevirq, pwm_updateEventIrq, (void *)timer, irq->uevcond, NULL);
+		atomic_fetch_or(&pwm_common.timer[timer].initialized, TIMER_INIT_DONE);
+	}
+	else if ((timer_inited & TIMER_INIT_DONE) == 0) {
+		return -EBUSY;
 	}
 
 	/* Fail if one of the channels hasn't been disabled */
@@ -656,7 +678,7 @@ int pwm_configure(pwm_tim_id_t timer, uint16_t prescaler, uint32_t top)
 		return -EPERM;
 	}
 
-	dataBarier();
+	mutexLock(pwm_common.timer[timer].mutex);
 
 	/* In CR1 set prescaler, countermode, autoreload, clockdivision, repetition counter */
 	t16 = *((base + tim_cr1));
@@ -705,13 +727,12 @@ int pwm_configure(pwm_tim_id_t timer, uint16_t prescaler, uint32_t top)
 
 	pwm_forceUpdateEvent(timer);
 
-	dataBarier();
-
+	mutexUnlock(pwm_common.timer[timer].mutex);
 	return EOK;
 }
 
 
-static int pwm_setInternal(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t compare, uint8_t activeLow)
+static int pwm_setInternal(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t compare, uint8_t activeLow, bool doMutex)
 {
 	volatile uint32_t *base = pwm_setup.timer[timer].base;
 
@@ -722,8 +743,11 @@ static int pwm_setInternal(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t compare
 		return EOK;
 	}
 
-	dataBarier();
+	if (doMutex) {
+		mutexLock(pwm_common.timer[timer].mutex);
+	}
 
+	dataBarier();
 	/* Disable the channel. Clear CCxE in CCER */
 	uint32_t tmpccer = *(base + tim_ccer);
 	tmpccer &= ~(1 << PWM_CCER_CCE_OFF(chn));
@@ -792,6 +816,10 @@ static int pwm_setInternal(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t compare
 	*(base + tim_cr1) |= 0x1;
 
 	dataBarier();
+	if (doMutex) {
+		mutexUnlock(pwm_common.timer[timer].mutex);
+	}
+
 	return EOK;
 }
 
@@ -812,7 +840,7 @@ int pwm_set(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t compare, uint8_t activ
 	if (compare > pwm_common.timer[timer].arr) {
 		return -EINVAL;
 	}
-	return pwm_setInternal(timer, chn, compare, activeLow);
+	return pwm_setInternal(timer, chn, compare, activeLow, true);
 }
 
 
@@ -844,6 +872,7 @@ enum pwm_dmaAllocType {
 	pwm_dmaUpdMultiChannel,
 	pwm_dmaCapture,
 };
+
 
 static int pwm_initDMA(pwm_tim_id_t timer, pwm_ch_id_t chn, enum pwm_dmaAllocType type)
 {
@@ -917,8 +946,8 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 		return 0;
 	}
 
+	mutexLock(pwm_common.timer[timer].mutex);
 #if USE_DSHOT_DMA
-	mutexLock(pwm_common.timer[timer].dmaMutex);
 	res = (res < 0) ? res : pwm_initDMA(timer, chn, pwm_dmaUpd);
 
 	const struct libdma_per *per = pwm_common.timer[timer].dma_per[chn];
@@ -954,7 +983,7 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 	};
 	res = (res < 0) ? res : libxpdma_configureMemory(per, dma_mem2per, 0, bufs, 2);
 	/* Start the PWM channel. Set first duty cycle to 0 - idle state. It will be output until DMA takes over. */
-	res = (res < 0) ? res : pwm_setInternal(timer, chn, pwm_idleValue, 0);
+	res = (res < 0) ? res : pwm_setInternal(timer, chn, pwm_idleValue, 0, false);
 	volatile int done = 0;
 	/* Request is disabled before DMA start and enabled after to prevent a possible race condition
 	 * between DMA start and timer update request. */
@@ -963,7 +992,6 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 	*(pwm_setup.timer[timer].base + tim_dier) |= TIM_DIER_UDE;
 	/* TODO: we can calculate a timeout here */
 	res = (res < 0) ? res : libxpdma_waitForTransaction(per, &done, NULL, 0);
-	mutexUnlock(pwm_common.timer[timer].dmaMutex);
 #else
 	(void)pwm_idleValue;
 	uint16_t firstCompare;
@@ -982,7 +1010,7 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 	dataBarier();
 
 	firstCompare = pwm_getUserCompareVal(data, 0, datasize);
-	pwm_setInternal(timer, chn, firstCompare, 0);
+	pwm_setInternal(timer, chn, firstCompare, 0, false);
 
 	/* Wait for the DSHOT sequence to end */
 	mutexLock(irq->uevlock);
@@ -993,6 +1021,7 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 	irq->flag_dshot_end = 0;
 	mutexUnlock(irq->uevlock);
 #endif
+	mutexUnlock(pwm_common.timer[timer].mutex);
 
 	return res;
 }
@@ -1201,7 +1230,7 @@ static void pwm_bitSequenceCleanup(pwm_tim_id_t timer, uint32_t doRx)
 	/* If any channels were receiving, flag that they need to be re-configured by the next pwm_setInternal call */
 	atomic_fetch_and(&t->channelOn, ~doRx);
 	*(base + tim_dier) &= ~(TIM_DIER_UDE | TIM_DIER_CC1DE | TIM_DIER_CC2DE | TIM_DIER_CC3DE | TIM_DIER_CC4DE);
-	mutexUnlock(t->dmaMutex);
+	mutexUnlock(t->mutex);
 }
 
 
@@ -1400,20 +1429,23 @@ int pwm_setBitSequence4(pwm_tim_id_t timer, const uint16_t chnRaw[4], const uint
 		return -EIO;
 	}
 
+	mutexLock(t->mutex);
 	const uint32_t gcrBitTime = DSHOT_GCR_RATIO(t->arr);
 	if (gcrBitTime == 0) {
+		mutexUnlock(t->mutex);
 		return -EINVAL;
 	}
 
 	if (doRx != 0) {
-		t->irq.flag_dshot_uev = DSHOT_UEV_DMA_RX_END;
 		res = pwm_bitSequenceTimerReconfig(timer, doRx, gcrBitTime, &arg);
 		if (res < 0) {
+			mutexUnlock(t->mutex);
 			return res;
 		}
+
+		t->irq.flag_dshot_uev = DSHOT_UEV_DMA_RX_END;
 	}
 
-	mutexLock(t->dmaMutex);
 	res = pwm_bitSequenceInitDMA(timer, doRx);
 	if (res < 0) {
 		pwm_bitSequenceCleanup(timer, doRx);
@@ -1445,7 +1477,7 @@ int pwm_setBitSequence4(pwm_tim_id_t timer, const uint16_t chnRaw[4], const uint
 			continue;
 		}
 
-		res = pwm_setInternal(timer, i, pwm_idleValue, actLow[i]);
+		res = pwm_setInternal(timer, i, pwm_idleValue, actLow[i], false);
 		if (res < 0) {
 			pwm_bitSequenceCleanup(timer, doRx);
 			return res;

--- a/multi/stm32l4-multi/pwm_n6.c
+++ b/multi/stm32l4-multi/pwm_n6.c
@@ -23,13 +23,52 @@
 #include "libmulti/libdma.h"
 
 #include "common.h"
+#include <board_config.h>
 
 #include <unistd.h>
 #include <stdlib.h>
 #include <time.h>
 
-#define USE_DSHOT_DMA  1
-#define DMA_ALLOC_SIZE (18 * PWM_CHN_NUM * sizeof(uint16_t))
+#define CACHE_LINE_ALIGN(sz) (((sz) + CACHE_LINE_SIZE - 1) & ~(CACHE_LINE_SIZE - 1))
+
+/* Values below are meant to be compile-time configurable */
+
+#ifndef DSHOT_RX_MARGIN_US
+/* Additional time to wait for end of reception in microseconds.
+ * Note that returning to userspace after condWait() will take another few microseconds,
+ * so in practice this margin becomes larger than the value here. */
+#define DSHOT_RX_MARGIN_US 5
+#endif
+
+#ifndef CACHE_LINE_SIZE
+/* WHAT IF YOU
+ * wanted to check cache line size from userspace
+ * BUT ARM SAID
+ * "Privileged access permitted only. Unprivileged accesses generate a fault." */
+#define CACHE_LINE_SIZE 32
+#endif
+
+#ifndef DSHOT_GCR_RATIO
+/* Officially, GCR bit length is 4/5 of the DShot PWM length.
+ * However, on some ESC it seems to be closer to 3/4, so I wanted to make it more configurable. */
+#define DSHOT_GCR_RATIO(x) (((x) * 4) / 5)
+#endif
+
+/* Values below are part of DShot protocol and are not expected to change */
+
+#define DSHOT_TX_N_BITS     16 /* Number of bits for transmission */
+#define DSHOT_SWITCHOVER_US 30 /* Maximum time to switch from transmission to reception in microseconds */
+#define DSHOT_GCR_N_BITS    21 /* Total of 21 bits may be received (including leading 0) */
+/* When using modified GCR encoding on 16-bit numbers, we may get up to 18 signal transitions.
+ * However, when only counting eRPM responses with valid checksums, up to 16 transitions will happen. */
+#define DSHOT_GCR_N_TRANSITIONS 16
+
+#define DSHOT_RX_BUF_SIZE (DSHOT_GCR_N_TRANSITIONS * PWM_CHN_NUM * sizeof(uint16_t))
+#define DSHOT_TX_BUF_SIZE (DSHOT_TX_N_BITS * PWM_CHN_NUM * sizeof(uint16_t))
+/* DShot DMA buffer must be large enough to contain transmission or reception data (whichever is larger) */
+#define DSHOT_BUF_SIZE CACHE_LINE_ALIGN(((DSHOT_RX_BUF_SIZE > DSHOT_TX_BUF_SIZE) ? (DSHOT_RX_BUF_SIZE) : (DSHOT_TX_BUF_SIZE)))
+
+#define USE_DSHOT_DMA 1
 
 #define TIM_DIER_UIE   (1 << 0)  /* Update IRQ enable */
 #define TIM_DIER_CC1IE (1 << 1)  /* Capture/compare 1 IRQ enable */
@@ -65,6 +104,10 @@
 #define DMA_CAP_UPD (1 << 4)
 #define DMA_CAP_TRG (1 << 5)
 #define DMA_CAP_COM (1 << 6)
+
+#define DSHOT_UEV_NONE       0
+#define DSHOT_UEV_IRQ_DRIVEN 1
+#define DSHOT_UEV_DMA_RX_END 2
 
 
 /* Data used in IRQ dshot. Limited to one channel per timer. */
@@ -104,15 +147,22 @@ typedef struct {
 	bool initialized;
 #if USE_DSHOT_DMA
 	handle_t dmaMutex;
-	void *dmaMem;
+	void *dshotBuf;  /* Start of buffer allocated for DShot data */
+	void *dshotData; /* Start of DShot data (must be cache line aligned) */
 	const struct libdma_per *dma_per[PWM_CHN_NUM];
 	const struct libdma_per *dma_multiChannel;
 	const struct libdma_per *dma_capture[PWM_CHN_NUM];
+	uint32_t dma_skipSetup;
 #endif
 } pwm_tim_data_t;
 
 /* Idle value made available as a static const, so that it can be read by DMA */
 static const uint16_t pwm_idleValue = 0;
+
+#define SKIPSETUP_DMA_PER_SHIFT      0
+#define SKIPSETUP_DMA_MULTICHN_SHIFT (SKIPSETUP_DMA_PER_SHIFT + NELEMS(((pwm_tim_data_t *)NULL)->dma_per))
+#define SKIPSETUP_DMA_CAPTURE_SHIFT  (SKIPSETUP_DMA_MULTICHN_SHIFT + 1)
+#define SKIPSETUP_END_SHIFT          (SKIPSETUP_DMA_CAPTURE_SHIFT + NELEMS(((pwm_tim_data_t *)NULL)->dma_capture))
 
 static const struct {
 	pwm_tim_setup_t timer[pwm_tim_count];
@@ -250,6 +300,111 @@ static inline uint8_t sizeLog(size_t size)
 }
 
 
+/* Decode timer counts into eRPM value.
+ * First it turns timer counts into a stream of bits, then it undoes the modified GCR encoding to get the raw value.
+ * * bitlen - expected time per bit (unit: timer tick)
+ * * counts - array of timer counts taken at edges of signal
+ * * n_counts - number of timer counts that were captured
+ * * val_out - output of decoded binary value
+ * returns:
+ * * 0 on success
+ * * -EILSEQ on unsuccessful decode
+ * NOTE: we assume the timer won't overflow - it shouldn't happen because DMA requests are turned off upon RX timeout.
+ */
+static int dshot_decodeRxData(uint16_t bitlen, const uint16_t *counts, size_t nCounts, uint16_t *val_out)
+{
+	static const size_t MAX_BITS = DSHOT_GCR_N_BITS;
+	if (nCounts < 2) {
+		/* Nothing was captured */
+		return -ENODATA;
+	}
+
+	if (((nCounts % 2) != 0) || (nCounts < 10)) {
+		/* The last rising edge of the signal was not captured or
+		 * less than minimum number of transitions was captured */
+		return -EILSEQ;
+	}
+
+	uint32_t val = 1; /* Signal always starts in high state, so starting value is 1 */
+	size_t totalBits = 0;
+	for (size_t i = 1; i <= nCounts; i++) {
+		uint32_t nBits;
+		if (totalBits > MAX_BITS) {
+			/* We decoded too many bits - signal glitch or clock drifted too far */
+			return -EILSEQ;
+		}
+		else if (totalBits == MAX_BITS) {
+			break;
+		}
+		else if (i == nCounts) {
+			nBits = MAX_BITS - totalBits;
+		}
+		else {
+			uint16_t diff = counts[i] - counts[i - 1];
+			nBits = (diff + (bitlen / 2)) / bitlen; /* Divide with rounding to get the expected length */
+		}
+
+		totalBits += nBits;
+		uint32_t new_bits = (~val & 1) << nBits;
+		val <<= nBits;
+		val |= (new_bits != 0) ? (new_bits - 1) : 0;
+	}
+
+	/* Decode modified GCR into regular GCR. Note that because bit 21 is set, bit 20 will also be set,
+	 * but it's okay because we only care about bits 0..19. */
+	uint32_t gcr = val ^ (val >> 1);
+
+	static const int8_t gcrDecodeLookup[32] = {
+		[0x00] = -EILSEQ,
+		[0x01] = -EILSEQ,
+		[0x02] = -EILSEQ,
+		[0x03] = -EILSEQ,
+		[0x04] = -EILSEQ,
+		[0x05] = -EILSEQ,
+		[0x06] = -EILSEQ,
+		[0x07] = -EILSEQ,
+		[0x08] = -EILSEQ,
+		[0x09] = 9,
+		[0x0a] = 10,
+		[0x0b] = 11,
+		[0x0c] = -EILSEQ,
+		[0x0d] = 13,
+		[0x0e] = 14,
+		[0x0f] = 15,
+		[0x10] = -EILSEQ,
+		[0x11] = -EILSEQ,
+		[0x12] = 2,
+		[0x13] = 3,
+		[0x14] = -EILSEQ,
+		[0x15] = 5,
+		[0x16] = 6,
+		[0x17] = 7,
+		[0x18] = -EILSEQ,
+		[0x19] = 0,
+		[0x1a] = 8,
+		[0x1b] = 1,
+		[0x1c] = -EILSEQ,
+		[0x1d] = 4,
+		[0x1e] = 12,
+		[0x1f] = -EILSEQ,
+	};
+
+	uint16_t res = 0;
+	for (int i = 3; i >= 0; i--) {
+		int8_t lu = gcrDecodeLookup[(gcr >> (i * 5)) & 0x1f];
+		if (lu < 0) {
+			return (int)lu;
+		}
+
+		res <<= 4;
+		res |= (uint8_t)lu;
+	}
+
+	*val_out = res;
+	return 0;
+}
+
+
 static int pwm_validateTimer(pwm_tim_id_t timer, bool checkInitialized, uint8_t checkDMAFlags)
 {
 	if (timer < 0 || timer >= pwm_tim_count) {
@@ -351,7 +506,8 @@ static int pwm_updateEventIrq(unsigned int n, void *arg)
 #endif
 
 	/* If irq isn't used to load next DSHOT bit, didsable future UEV interrupts. */
-	if (!irq->flag_dshot_uev) {
+	uint32_t flag_dshot_uev = irq->flag_dshot_uev;
+	if (flag_dshot_uev == DSHOT_UEV_NONE) {
 		*(base + tim_dier) &= ~TIM_DIER_UIE;
 	}
 	else {
@@ -372,6 +528,9 @@ static int pwm_updateEventIrq(unsigned int n, void *arg)
 			*(base + PWM_CCR_REG(chn)) = pwm_getUserCompareVal(dshot->data, dshot->bitPos, dshot->dataSize);
 			dshot->bitPos++;
 		}
+#else
+		*(base + tim_dier) &= ~(TIM_DIER_CC1DE | TIM_DIER_CC2DE | TIM_DIER_CC3DE | TIM_DIER_CC4DE | TIM_DIER_UIE);
+		irq->flag_dshot_uev = DSHOT_UEV_NONE;
 #endif
 	}
 
@@ -620,12 +779,9 @@ static int pwm_setInternal(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t compare
 	pwm_dshot_ctx_t *dshot = &irq->dshot;
 
 	/* Enable subsequent UEV interrupts if in dshot mode */
-	if (irq->flag_dshot_uev) {
+	if (irq->flag_dshot_uev == DSHOT_UEV_IRQ_DRIVEN) {
 		*(base + tim_dier) |= TIM_DIER_UIE;
-	}
-
-	/* Preload the second compare value if in dshot mode */
-	if (irq->flag_dshot_uev) {
+		/* Preload the second compare value if in dshot mode */
 		*(base + PWM_CCR_REG(chn)) = pwm_getUserCompareVal(dshot->data, dshot->bitPos, dshot->dataSize);
 		dshot->bitPos++;
 	}
@@ -809,6 +965,7 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 	res = (res < 0) ? res : libxpdma_waitForTransaction(per, &done, NULL, 0);
 	mutexUnlock(pwm_common.timer[timer].dmaMutex);
 #else
+	(void)pwm_idleValue;
 	uint16_t firstCompare;
 	pwm_irq_t *irq = &pwm_common.timer[timer].irq;
 	pwm_dshot_ctx_t *dshot = &irq->dshot;
@@ -819,7 +976,7 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 		.data = data,
 		.dataSize = datasize
 	};
-	irq->flag_dshot_uev = 1;
+	irq->flag_dshot_uev = DSHOT_UEV_IRQ_DRIVEN;
 	irq->flag_dshot_end = 0;
 
 	dataBarier();
@@ -832,7 +989,7 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 	while (!irq->flag_dshot_end) {
 		condWait(irq->uevcond, irq->uevlock, 0);
 	}
-	irq->flag_dshot_uev = 0;
+	irq->flag_dshot_uev = DSHOT_UEV_NONE;
 	irq->flag_dshot_end = 0;
 	mutexUnlock(irq->uevlock);
 #endif
@@ -841,6 +998,7 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
 }
 
 
+#if USE_DSHOT_DMA
 /* Render data given in `val16` into an array of timer compare values.
  * * `output` - array of timer values.
  *   Array must have (`n_bits * n_channels`) elements.
@@ -854,39 +1012,371 @@ int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t
  * * `hcmp` - timer compare value for 1 bit
  * * `lcmp` - timer compare value for 0 bit
  */
-static void pwm_renderBitSequence(volatile uint16_t *output, size_t n_bits, int *valIdx, size_t n_channels, const uint16_t *val16, uint16_t hcmp, uint16_t lcmp)
+static void pwm_renderBitSequence(void *output, size_t n_bits, int *valIdx, size_t n_channels, const uint16_t *val16, uint16_t hcmp, uint16_t lcmp)
 {
-	for (size_t bitIdx = 0; bitIdx < n_bits; bitIdx++) {
-		uint16_t mask = (1U << (n_bits - 1 - bitIdx));
-		for (size_t chnIdx = 0; chnIdx < n_channels; chnIdx++) {
-			int idx = valIdx[chnIdx];
-			uint16_t cmp = pwm_idleValue;
-			if (idx >= 0) {
-				cmp = ((val16[idx] & mask) != 0) ? hcmp : lcmp;
+	if ((n_bits <= 16) && (n_channels == 4)) {
+		/* If using 16 bits and 4 channels we can render data using this pseudo-vectorized code.
+		 * It doesn't use MVE, but is still 3x as performant as naive code. */
+		uint64_t *out64 = output;
+		uint64_t dataVec = 0, lowVec = 0;
+		for (int i = 0; i < 4; i++) {
+			if (valIdx[i] >= 0) {
+				uint64_t val = val16[valIdx[i]] ^ ((hcmp >= lcmp) ? 0 : 0xffff);
+				dataVec |= val << (i * 16);
+				lowVec |= (uint64_t)min(hcmp, lcmp) << (i * 16);
 			}
+			else {
+				lowVec |= (uint64_t)(pwm_idleValue & 0xffff) << (i * 16);
+			}
+		}
 
-			output[(bitIdx * n_channels) + chnIdx] = cmp;
+		const uint32_t diff = (hcmp >= lcmp) ? (hcmp - lcmp) : (lcmp - hcmp);
+		const uint32_t oneVec = 0x00010001UL;
+		for (int i = (int)n_bits - 1; i >= 0; i--) {
+			/* Split into top and bottom 32 bits - we're working on a 32-bit CPU, so 64-bit values are actually stored
+			 * as pairs of registers.  We know no carry can happen when multiplying or adding and we don't care about
+			 * carrying when shifting - the casts to uint32_t are there to convince the compiler of that.
+			 * Eventually, this should compile into two sequences of `lsr`, `and`, `mla`, `str`. */
+			uint32_t tmp_h = ((uint32_t)(dataVec >> 32) >> i) & oneVec;
+			uint32_t tmp_l = ((uint32_t)(dataVec & 0xffffffffUL) >> i) & oneVec;
+			tmp_h *= diff;
+			tmp_l *= diff;
+			tmp_h += lowVec >> 32;
+			tmp_l += lowVec & 0xffffffffUL;
+			out64[n_bits - 1 - i] = ((uint64_t)tmp_h << 32) | tmp_l;
+		}
+	}
+	else {
+		uint16_t *out16 = output;
+		for (size_t bitIdx = 0; bitIdx < n_bits; bitIdx++) {
+			uint16_t mask = (1U << (n_bits - 1 - bitIdx));
+			for (size_t chnIdx = 0; chnIdx < n_channels; chnIdx++) {
+				int idx = valIdx[chnIdx];
+				uint16_t cmp = pwm_idleValue;
+				if (idx >= 0) {
+					cmp = ((val16[idx] & mask) != 0) ? hcmp : lcmp;
+				}
+
+				out16[(bitIdx * n_channels) + chnIdx] = cmp;
+			}
 		}
 	}
 }
 
 
-int pwm_setBitSequence4(pwm_tim_id_t timer, const uint16_t chnRaw[4], const uint16_t val16[4], uint16_t hcmp, uint16_t lcmp, int flags)
+/* Initialize DMA */
+static int pwm_bitSequenceInitDMA(pwm_tim_id_t timer, uint32_t doRx)
 {
-#if USE_DSHOT_DMA
-	int res;
-	/* Mapping from physical channels (pwm_ch1 .. pwm_ch4) to indices in val16 array */
-	int valIdx[PWM_CHN_NUM] = { -1, -1, -1, -1 };
-	(void)flags;
-
-	res = pwm_validateTimer(timer, true, DMA_CAP_UPD);
+	pwm_tim_data_t *t = &pwm_common.timer[timer];
+	int res = pwm_initDMA(timer, 0, pwm_dmaUpdMultiChannel);
 	if (res < 0) {
 		return res;
 	}
 
+	if (t->dshotData == NULL) {
+		/* malloc() always (or almost always) returns non-cache-line-aligned pointer here
+		 * so we preemptively allocate more than necessary */
+		void *mem = malloc(DSHOT_BUF_SIZE + CACHE_LINE_SIZE);
+		if (mem == NULL) {
+			return -ENOMEM;
+		}
+
+		t->dshotBuf = mem;
+		if (((uintptr_t)mem % CACHE_LINE_SIZE) != 0) {
+			mem -= ((uintptr_t)mem % CACHE_LINE_SIZE);
+			mem += CACHE_LINE_SIZE;
+		}
+
+		t->dshotData = mem;
+	}
+
+	for (int chn = pwm_ch1; chn <= pwm_ch4; chn++) {
+		if (((doRx >> chn) & 1) == 0) {
+			continue;
+		}
+
+		res = pwm_initDMA(timer, chn, pwm_dmaCapture);
+		if (res < 0) {
+			return res;
+		}
+	}
+
+	return 0;
+}
+
+/* Set up the memory side of the transfer and start RX transfers.
+ * Because our DMA API stores the setup parameters internally and the buffers are the same every time,
+ * there is no need to call libxpdma_configureMemory again unless there's been a change of parameters in the meantime.
+ * Skipping this setup step saves us 2 microseconds. */
+static int pwm_bitSequenceSetupDMA(pwm_tim_id_t timer, uint32_t doRx)
+{
+	pwm_tim_data_t *t = &pwm_common.timer[timer];
+	*(pwm_setup.timer[timer].base + tim_dier) &= ~(TIM_DIER_UDE | TIM_DIER_CC1DE | TIM_DIER_CC2DE | TIM_DIER_CC3DE | TIM_DIER_CC4DE);
+	int res;
+	if ((t->dma_skipSetup & (1 << SKIPSETUP_DMA_MULTICHN_SHIFT)) == 0) {
+		/* Note: the buffers are actually in cached memory, but we don't want the DMA driver to perform cache operations,
+		 * so we set buffer descriptors to "not cached". Otherwise, the DMA driver would perform cache ops 5 times,
+		 * when in reality we just need 1. */
+		libdma_transfer_buffer_t txBufs[2] = {
+			{
+				.buf = t->dshotData,
+				.bufSize = DSHOT_TX_N_BITS * PWM_CHN_NUM * sizeof(uint16_t),
+				.elSize_log = sizeLog(sizeof(uint16_t)),
+				.burstSize = PWM_CHN_NUM, /* Use burst transaction when reading to reduce bus contention a bit */
+				.increment = 1,
+				.isCached = 0,
+				.transform = LIBXPDMA_TRANSFORM_ALIGNR0,
+			},
+			/* Insert the two idle values (see above) */
+			{
+				.buf = (void *)&pwm_idleValue,
+				.bufSize = 2 * PWM_CHN_NUM * sizeof(pwm_idleValue),
+				.elSize_log = sizeLog(sizeof(pwm_idleValue)),
+				.burstSize = PWM_CHN_NUM,
+				.increment = 0,
+				.isCached = 0,
+				.transform = LIBXPDMA_TRANSFORM_ALIGNR0,
+			},
+		};
+
+		res = libxpdma_configureMemory(t->dma_multiChannel, dma_mem2per, 0, txBufs, 2);
+		if (res < 0) {
+			return res;
+		}
+
+		t->dma_skipSetup |= (1 << SKIPSETUP_DMA_MULTICHN_SHIFT);
+	}
+
+	/* Configure DMA burst mechanism */
+	*(pwm_setup.timer[timer].base + tim_dcr) =
+			(1 << 16) |                /* DMA burst source: update event */
+			((PWM_CHN_NUM - 1) << 8) | /* DMA burst length: all available channels */
+			(tim_ccr1 << 0);           /* DMA burst start at CCR1 register */
+
+	libdma_transfer_buffer_t rxBuf = {
+		.bufSize = DSHOT_GCR_N_TRANSITIONS * sizeof(uint16_t),
+		.elSize_log = sizeLog(sizeof(uint16_t)),
+		.burstSize = 1,
+		.increment = 1,
+		.isCached = 0,
+		.transform = LIBXPDMA_TRANSFORM_ALIGNR0,
+	};
+
+	for (int chn = pwm_ch1; chn <= pwm_ch4; chn++) {
+		if (((doRx >> chn) & 1) == 0) {
+			continue;
+		}
+
+		if ((t->dma_skipSetup & (1 << (SKIPSETUP_DMA_CAPTURE_SHIFT + chn))) == 0) {
+			rxBuf.buf = t->dshotData + (DSHOT_GCR_N_TRANSITIONS * sizeof(uint16_t) * chn);
+			res = libxpdma_configureMemory(t->dma_capture[chn], dma_per2mem, 0, &rxBuf, 1);
+			if (res < 0) {
+				return res;
+			}
+
+			t->dma_skipSetup |= (1 << (SKIPSETUP_DMA_CAPTURE_SHIFT + chn));
+		}
+
+		res = libxpdma_startTransferPollingOnly(t->dma_capture[chn], dma_per2mem);
+		if (res < 0) {
+			return res;
+		}
+	}
+
+	return 0;
+}
+
+
+static void pwm_bitSequenceCleanup(pwm_tim_id_t timer, uint32_t doRx)
+{
+	volatile uint32_t *base = pwm_setup.timer[timer].base;
+	pwm_tim_data_t *t = &pwm_common.timer[timer];
+	for (int chn = pwm_ch1; chn <= pwm_ch4; chn++) {
+		if (((doRx >> chn) & 1) != 0) {
+			/* Channels may have been cancelled before, but there's no harm doing it again */
+			libxpdma_cancelTransfer(t->dma_capture[chn], dma_per2mem);
+		}
+	}
+
+	/* If any channels were receiving, flag that they need to be re-configured by the next pwm_setInternal call */
+	atomic_fetch_and(&t->channelOn, ~doRx);
+	*(base + tim_dier) &= ~(TIM_DIER_UDE | TIM_DIER_CC1DE | TIM_DIER_CC2DE | TIM_DIER_CC3DE | TIM_DIER_CC4DE);
+	mutexUnlock(t->dmaMutex);
+}
+
+
+typedef struct
+{
+	pwm_tim_id_t timer;
+	volatile int done; /* TX complete flag */
+	uint32_t dier;     /* Bits to set in DIER register to enable reception. If == 0, reception disabled. */
+	struct {
+		uint32_t ccerOff; /* CCER value which switches selected channels off */
+		uint32_t ccmr[2]; /* CCMRx values for receiving */
+		uint32_t ccer;    /* CCER value which enables receiving on selected channels */
+		uint32_t srClear; /* Bits to clear in SR register before reception can start */
+		uint32_t arrRx;   /* ARR value for RX timeout */
+		uint32_t arrPrev; /* ARR value to restore after RX timeout */
+	} regs;               /* Pre-rendered register values. May be uninitialized when TX only. */
+} pwm_bitSequenceSwitchArg_t;
+
+
+/* Render timer configuration data that will be written to registers during ISR */
+static int pwm_bitSequenceTimerReconfig(pwm_tim_id_t timer, uint32_t doRx, uint32_t gcrBitTime, pwm_bitSequenceSwitchArg_t *arg)
+{
+	volatile uint32_t *base = pwm_setup.timer[timer].base;
+	const uint32_t timerMax = (((PWM_TIM_32BIT >> timer) & 1) != 0) ? 0xFFFFFFFF : 0xFFFF;
+	/* Calculate RX timeout. We will always wait at least this time, so it should be more or less optimal. */
+	uint32_t timerFreq = pwm_common.baseFreq / (*(base + tim_psc) + 1);
+	arg->regs.arrRx = (((DSHOT_SWITCHOVER_US + DSHOT_RX_MARGIN_US) * (timerFreq / 1000000)) + (DSHOT_GCR_N_BITS * gcrBitTime)) - 1;
+	if (arg->regs.arrRx > timerMax) {
+		return -EINVAL;
+	}
+
+	arg->regs.arrPrev = pwm_common.timer[timer].arr;
+	arg->regs.srClear = 0;
+	arg->regs.ccerOff = *(base + tim_ccer);
+	arg->regs.ccer = arg->regs.ccerOff;
+	arg->regs.ccmr[0] = *(base + tim_ccmr1);
+	arg->regs.ccmr[1] = *(base + tim_ccmr2);
+	for (int chn = pwm_ch1; chn <= pwm_ch4; chn++) {
+		if (((doRx >> chn) & 1) == 0) {
+			continue;
+		}
+
+		arg->dier |= TIM_DIER_CC1DE << chn;
+		arg->regs.srClear |= TIM_SR_CC1IF << chn;
+		/* Disable output, set input sensitivity to both edges */
+		arg->regs.ccerOff &= ~((1 << PWM_CCER_CCE_OFF(chn)) | (1 << PWM_CCER_CCNE_OFF(chn)));
+		arg->regs.ccerOff |= (1 << PWM_CCER_CCP_OFF(chn)) | (1 << PWM_CCER_CCNP_OFF(chn));
+
+		uint32_t v = arg->regs.ccmr[PWM_CCMR_REG(chn) - tim_ccmr1];
+		/* Switch mode to input from tim_tiX where X == channel number */
+		v &= ~(0x3 << PWM_CCMR_CCS_OFF(chn));
+		v |= (0x1 << PWM_CCMR_CCS_OFF(chn));
+		/* Capture every event */
+		v &= ~(0x3 << PWM_CCMR_ICPSC_OFF(chn));
+		/* Set digital filter to 5 samples @ f(DTS)/32 frequency -> reject events shorter than 0.4 us */
+		v &= ~(0xf << PWM_CCMR_ICF_OFF(chn));
+		v |= (13 << PWM_CCMR_ICF_OFF(chn));
+		arg->regs.ccmr[PWM_CCMR_REG(chn) - tim_ccmr1] = v;
+
+		/* Enable input */
+		arg->regs.ccer &= ~(1 << PWM_CCER_CCNE_OFF(chn));
+		arg->regs.ccer |= (1 << PWM_CCER_CCP_OFF(chn)) | (1 << PWM_CCER_CCNP_OFF(chn)) | (1 << PWM_CCER_CCE_OFF(chn));
+	}
+
+	return 0;
+}
+
+
+/* Signal end of TX DMA and reconfigure timer for receiving if RX was requested */
+static void pwm_bitSequenceSwitchISR(void *cbArg, int type)
+{
+	(void)type;
+	pwm_bitSequenceSwitchArg_t *arg = cbArg;
+	volatile uint32_t *base = pwm_setup.timer[arg->timer].base;
+
+	if (arg->dier != 0) {
+		/* Switch timer parameters */
+		*(base + tim_ccer) = arg->regs.ccerOff;
+		*(base + tim_ccmr1) = arg->regs.ccmr[0];
+		*(base + tim_ccmr2) = arg->regs.ccmr[1];
+		*(base + tim_ccer) = arg->regs.ccer;
+		*(base + tim_arr) = arg->regs.arrRx;
+		/* Clear update event flags */
+		*(base + tim_sr) = ~TIM_SR_UIF;
+		*(base + tim_egr) = TIM_EGR_UG; /* Force an update event */
+		while ((*(base + tim_sr) & TIM_SR_UIF) == 0) {
+			/* Wait for timer to have an update event, it's very short (~50 ns) */
+		}
+
+		*(base + tim_sr) = ~(arg->regs.srClear | TIM_SR_UIF); /* Clear update event flag */
+		*(base + tim_dier) |= TIM_DIER_UIE | arg->dier;
+		/* Preload the previously set autoreload value, i.e. cleanup */
+		*(base + tim_arr) = arg->regs.arrPrev;
+	}
+
+	arg->done = 1;
+}
+
+
+static void pwm_bitSequenceFinalizeRx(pwm_tim_id_t timer, uint32_t gcrBitTime, uint32_t doRx, int valIdx[PWM_CHN_NUM], int rxOutput[4])
+{
+	pwm_tim_data_t *t = &pwm_common.timer[timer];
+	int res;
+
+	int rxLen[PWM_CHN_NUM];
+	for (int chn = pwm_ch1; chn <= pwm_ch4; chn++) {
+		if (((doRx >> chn) & 1) == 0) {
+			rxLen[chn] = -ENODATA;
+			continue;
+		}
+
+		res = libxpdma_bufferRemaining(t->dma_capture[chn], dma_per2mem);
+		if (res < 0) {
+			rxLen[chn] = res;
+		}
+		else if (res > (DSHOT_GCR_N_TRANSITIONS * sizeof(uint16_t))) {
+			rxLen[chn] = -EIO;
+		}
+		else {
+			rxLen[chn] = DSHOT_GCR_N_TRANSITIONS - (res / sizeof(uint16_t));
+		}
+
+		libxpdma_cancelTransfer(t->dma_capture[chn], dma_per2mem);
+	}
+
+	for (int chn = pwm_ch1; chn <= pwm_ch4; chn++) {
+		int outIdx = valIdx[chn];
+		if (outIdx < 0) {
+			continue;
+		}
+
+		if (rxLen[chn] < 0) {
+			rxOutput[outIdx] = rxLen[chn];
+			continue;
+		}
+
+		uint16_t *counts = t->dshotData + (DSHOT_GCR_N_TRANSITIONS * sizeof(uint16_t) * chn);
+		uint16_t val;
+		res = dshot_decodeRxData(gcrBitTime, counts, rxLen[chn], &val);
+		rxOutput[outIdx] = (res < 0) ? res : (int)val;
+	}
+}
+
+
+int pwm_setBitSequence4(pwm_tim_id_t timer, const uint16_t chnRaw[4], const uint16_t val16[4], uint16_t hcmp, uint16_t lcmp, int flags, int rxOutput[4])
+{
+	(void)flags;
+	int res;
+	/* Mapping from physical channels (pwm_ch1 .. pwm_ch4) to indices in val16 array */
+	int valIdx[PWM_CHN_NUM] = { -1, -1, -1, -1 };
+	bool actLow[PWM_CHN_NUM] = { false, false, false, false };
+	uint32_t doRx = 0;
+	uint8_t reqDmaCaps = DMA_CAP_UPD;
+	/* TODO: it would be nice to support timers with < 4 channels */
+	reqDmaCaps |= DMA_CAP_CC1 | DMA_CAP_CC2 | DMA_CAP_CC3 | DMA_CAP_CC4;
+
+	res = pwm_validateTimer(timer, true, reqDmaCaps);
+	if (res < 0) {
+		return res;
+	}
+
+	volatile uint32_t *base = pwm_setup.timer[timer].base;
+	pwm_bitSequenceSwitchArg_t arg = {
+		.timer = timer,
+		.done = 0,
+		.dier = 0,
+	};
+
 	pwm_tim_data_t *t = &pwm_common.timer[timer];
 	for (int i = 0; i < 4; i++) {
-		pwm_ch_id_t chn = (pwm_ch_id_t)chnRaw[i];
+		if ((chnRaw[i] & PWM_BITSEQ4_CHN_INVALID) != 0) {
+			continue;
+		}
+
+		pwm_ch_id_t chn = (pwm_ch_id_t)(chnRaw[i] & PWM_BITSEQ4_CHN_MASK);
 		res = pwm_validateChannel(timer, chn);
 		if (res < 0) {
 			return res;
@@ -898,89 +1388,117 @@ int pwm_setBitSequence4(pwm_tim_id_t timer, const uint16_t chnRaw[4], const uint
 		}
 
 		valIdx[chn] = i;
+		actLow[chn] = (chnRaw[i] & PWM_BITSEQ4_CHN_IDLE_HIGH) != 0;
+		doRx |= ((chnRaw[i] & PWM_BITSEQ4_CHN_DO_RX) != 0) ? (1 << chn) : 0;
 	}
 
-	mutexLock(t->dmaMutex);
-	res = pwm_initDMA(timer, 0, pwm_dmaUpdMultiChannel);
-	if (res < 0) {
-		mutexUnlock(t->dmaMutex);
-		return res;
+	if ((doRx != 0) && (rxOutput == NULL)) {
+		return -EINVAL;
 	}
 
-	if (t->dmaMem == NULL) {
-		t->dmaMem = libdma_malloc(DMA_ALLOC_SIZE, sizeof(uint16_t));
-		if (t->dmaMem == NULL) {
-			mutexUnlock(t->dmaMutex);
-			return -ENOMEM;
-		}
+	if (pwm_common.baseFreq == 0) {
+		return -EIO;
 	}
 
-	const struct libdma_per *per = t->dma_multiChannel;
-	static const size_t n_bits = 16;
-	static const size_t n_values = n_bits * PWM_CHN_NUM;
-	_Static_assert(n_values * sizeof(uint16_t) <= DMA_ALLOC_SIZE);
-	volatile uint16_t *rendered = t->dmaMem;
-	pwm_renderBitSequence(rendered, n_bits, valIdx, PWM_CHN_NUM, val16, hcmp, lcmp);
-	libdma_transfer_buffer_t bufs[2] = {
-		{
-			.buf = (void *)rendered,
-			.bufSize = n_values * sizeof(rendered[0]),
-			.elSize_log = sizeLog(sizeof(rendered[0])),
-			.burstSize = PWM_CHN_NUM, /* Use burst transaction when reading to reduce bus contention a bit */
-			.increment = 1,
-			.isCached = 0,
-			.transform = LIBXPDMA_TRANSFORM_ALIGNR0,
-		},
-		/* Insert the two idle values (see above) */
-		{
-			.buf = (void *)&pwm_idleValue,
-			.bufSize = 2 * PWM_CHN_NUM * sizeof(pwm_idleValue),
-			.elSize_log = sizeLog(sizeof(pwm_idleValue)),
-			.burstSize = PWM_CHN_NUM,
-			.increment = 0,
-			.isCached = 0,
-			.transform = LIBXPDMA_TRANSFORM_ALIGNR0,
-		},
-	};
-
-	res = libxpdma_configureMemory(per, dma_mem2per, 0, bufs, 2);
-	if (res < 0) {
-		mutexUnlock(t->dmaMutex);
-		return res;
+	const uint32_t gcrBitTime = DSHOT_GCR_RATIO(t->arr);
+	if (gcrBitTime == 0) {
+		return -EINVAL;
 	}
 
-	/* Start the PWM channel. Set first duty cycle to 0 - idle state. It will be output until DMA takes over. */
-	for (int i = pwm_ch1; i <= pwm_ch4; i++) {
-		res = pwm_setInternal(timer, i, pwm_idleValue, 0);
+	if (doRx != 0) {
+		t->irq.flag_dshot_uev = DSHOT_UEV_DMA_RX_END;
+		res = pwm_bitSequenceTimerReconfig(timer, doRx, gcrBitTime, &arg);
 		if (res < 0) {
-			mutexUnlock(t->dmaMutex);
 			return res;
 		}
 	}
 
-	volatile int done = 0;
-	/* Configure DMA distribution system */
-	*(pwm_setup.timer[timer].base + tim_dier) &= ~TIM_DIER_UDE;
-	*(pwm_setup.timer[timer].base + tim_dcr) =
-			(1 << 16) |                /* DMA burst source: update event */
-			((PWM_CHN_NUM - 1) << 8) | /* DMA burst length: all available channels */
-			(tim_ccr1 << 0);           /* DMA burst start at CCR1 register */
-	res = libxpdma_startTransferWithFlag(per, dma_mem2per, &done);
+	mutexLock(t->dmaMutex);
+	res = pwm_bitSequenceInitDMA(timer, doRx);
 	if (res < 0) {
-		mutexUnlock(t->dmaMutex);
+		pwm_bitSequenceCleanup(timer, doRx);
 		return res;
 	}
 
-	*(pwm_setup.timer[timer].base + tim_dier) |= TIM_DIER_UDE;
-	/* TODO: we can calculate a timeout here */
-	res = libxpdma_waitForTransaction(per, &done, NULL, 0);
-	mutexUnlock(t->dmaMutex);
-	return res;
-#else
-	(void)pwm_renderBitSequence;
-	return -ENOSYS;
-#endif
+	pwm_renderBitSequence(t->dshotData, DSHOT_TX_N_BITS, valIdx, PWM_CHN_NUM, val16, hcmp, lcmp);
+
+	platformctl_t pctl;
+	pctl.action = pctl_set;
+	pctl.type = pctl_cleanInvalDCache;
+	pctl.opDCache.addr = t->dshotData;
+	pctl.opDCache.sz = DSHOT_BUF_SIZE;
+	res = platformctl(&pctl);
+	if (res < 0) {
+		pwm_bitSequenceCleanup(timer, doRx);
+		return res;
+	}
+
+	res = pwm_bitSequenceSetupDMA(timer, doRx);
+	if (res < 0) {
+		pwm_bitSequenceCleanup(timer, doRx);
+		return res;
+	}
+
+	/* Start PWM channels. Set first duty cycle to 0 - idle state. It will be output until DMA takes over. */
+	for (int i = pwm_ch1; i <= pwm_ch4; i++) {
+		if (valIdx[i] < 0) {
+			continue;
+		}
+
+		res = pwm_setInternal(timer, i, pwm_idleValue, actLow[i]);
+		if (res < 0) {
+			pwm_bitSequenceCleanup(timer, doRx);
+			return res;
+		}
+	}
+
+	res = libxpdma_startTransferWithCallback(t->dma_multiChannel, dma_mem2per, dma_tc, pwm_bitSequenceSwitchISR, &arg);
+	if (res < 0) {
+		pwm_bitSequenceCleanup(timer, doRx);
+		return res;
+	}
+
+	/* Start TX DMA */
+	*(base + tim_dier) |= TIM_DIER_UDE;
+	/* If only transmitting, wait for DMA to end and exit.
+	 * Otherwise, don't wait for DMA, only for RX finished - this way we can yield the CPU for longer. */
+	if (doRx == 0) {
+		/* Calculate TX timeout as 2x max transmission time (timeout should never be hit) */
+		const time_t timeoutTx = (2 * DSHOT_TX_N_BITS * t->arr) / pwm_common.baseFreq;
+		res = libxpdma_waitForTransaction(t->dma_multiChannel, &arg.done, NULL, timeoutTx);
+		pwm_bitSequenceCleanup(timer, doRx);
+		return res;
+	}
+	else {
+		pwm_irq_t *irq = &pwm_common.timer[timer].irq;
+		/* Wait for update event that signals end of RX */
+		mutexLock(irq->uevlock);
+		while (!irq->flag_uevreceived) {
+			condWait(irq->uevcond, irq->uevlock, 0);
+		}
+
+		irq->flag_uevreceived = 0;
+		mutexUnlock(irq->uevlock);
+
+		/* If TX DMA hasn't finished yet, it's way past timeout - cleanup and bail out */
+		if (arg.done == 0) {
+			libxpdma_cancelTransfer(t->dma_multiChannel, dma_mem2per);
+			pwm_bitSequenceCleanup(timer, doRx);
+			return -ETIME;
+		}
+	}
+
+	pwm_bitSequenceFinalizeRx(timer, gcrBitTime, doRx, valIdx, rxOutput);
+	pwm_bitSequenceCleanup(timer, doRx);
+	return 0;
 }
+#else
+int pwm_setBitSequence4(pwm_tim_id_t timer, const uint16_t chn[PWM_CHN_NUM], const uint16_t val16[PWM_CHN_NUM], uint16_t hcmp, uint16_t lcmp, int flags, int rxOutput[PWM_CHN_NUM])
+{
+	(void)dshot_decodeRxData;
+	return -ENOSYS;
+}
+#endif
 
 
 int pwm_init(void)

--- a/multi/stm32l4-multi/pwm_n6.h
+++ b/multi/stm32l4-multi/pwm_n6.h
@@ -27,12 +27,14 @@
 #define PWM_CHN_NUM      4
 #define PWM_BITSEQ4_BITS 16
 
-#define PWM_CCMR_REG(chn_id)      (((chn_id) <= 1) ? (tim_ccmr1) : (tim_ccmr2))
-#define PWM_CCMR_OCPE_OFF(chn_id) (3 + 8 * ((chn_id) & 1))
-#define PWM_CCMR_CCS_OFF(chn_id)  (8 * ((chn_id) & 1))
-#define PWM_CCMR_OCMH_OFF(chn_id) (16 + 8 * ((chn_id) & 1))
-#define PWM_CCMR_OCML_OFF(chn_id) (4 + 8 * ((chn_id) & 1))
-#define PWM_CCMR_OCFE_OFF(chn_id) (2 + 8 * ((chn_id) & 1))
+#define PWM_CCMR_REG(chn_id)       (((chn_id) <= 1) ? (tim_ccmr1) : (tim_ccmr2))
+#define PWM_CCMR_CCS_OFF(chn_id)   (8 * ((chn_id) & 1))
+#define PWM_CCMR_ICPSC_OFF(chn_id) (2 + 8 * ((chn_id) & 1))
+#define PWM_CCMR_ICF_OFF(chn_id)   (4 + 8 * ((chn_id) & 1))
+#define PWM_CCMR_OCFE_OFF(chn_id)  (2 + 8 * ((chn_id) & 1))
+#define PWM_CCMR_OCPE_OFF(chn_id)  (3 + 8 * ((chn_id) & 1))
+#define PWM_CCMR_OCML_OFF(chn_id)  (4 + 8 * ((chn_id) & 1))
+#define PWM_CCMR_OCMH_OFF(chn_id)  (16 + 8 * ((chn_id) & 1))
 
 #define PWM_CCER_CCE_OFF(chn_id)  (4 * (chn_id))
 #define PWM_CCER_CCNE_OFF(chn_id) (2 + 4 * (chn_id))
@@ -69,7 +71,7 @@ int pwm_configure(pwm_tim_id_t timer, uint16_t prescaler, uint32_t top);
 
 
 /* Set compare value for a specific channel on configured timer. Returns errors */
-int pwm_set(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t compare);
+int pwm_set(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t compare, uint8_t activeLow);
 
 
 /* Returns current duty cycle percentage. Or errors */

--- a/multi/stm32l4-multi/pwm_n6.h
+++ b/multi/stm32l4-multi/pwm_n6.h
@@ -87,7 +87,7 @@ int pwm_get(pwm_tim_id_t timer, pwm_ch_id_t chn, uint32_t *top, uint32_t *compar
 int pwm_setBitSequence(pwm_tim_id_t timer, pwm_ch_id_t chn, void *data, uint32_t nbits, uint8_t datasize, int flags);
 
 
-int pwm_setBitSequence4(pwm_tim_id_t timer, const uint16_t chn[PWM_CHN_NUM], const uint16_t val16[PWM_CHN_NUM], uint16_t hcmp, uint16_t lcmp, int flags);
+int pwm_setBitSequence4(pwm_tim_id_t timer, const uint16_t chn[PWM_CHN_NUM], const uint16_t val16[PWM_CHN_NUM], uint16_t hcmp, uint16_t lcmp, int flags, int rxOutput[PWM_CHN_NUM]);
 
 
 int pwm_init(void);

--- a/multi/stm32l4-multi/stm32l4-multi.c
+++ b/multi/stm32l4-multi/stm32l4-multi.c
@@ -275,7 +275,7 @@ static void handleMsgMulti(msg_t *msg)
 			err = pwm_configure(imsg->pwm_def.timer, imsg->pwm_def.prescaler, imsg->pwm_def.top);
 			break;
 		case pwm_setm:
-			err = pwm_set(imsg->pwm_set.timer, imsg->pwm_set.chn, imsg->pwm_set.compare);
+			err = pwm_set(imsg->pwm_set.timer, imsg->pwm_set.chn, imsg->pwm_set.compare, 0);
 			break;
 		case pwm_getm:
 			uint32_t compare = 0, top = 0;

--- a/multi/stm32l4-multi/stm32l4-multi.c
+++ b/multi/stm32l4-multi/stm32l4-multi.c
@@ -299,7 +299,8 @@ static void handleMsgMulti(msg_t *msg)
 		case pwm_bitseq4:
 			const uint16_t chn[] = { imsg->pwm_bitseq4.chn[0], imsg->pwm_bitseq4.chn[1], imsg->pwm_bitseq4.chn[2], imsg->pwm_bitseq4.chn[3] };
 			const uint16_t val16[] = { imsg->pwm_bitseq4.val16[0], imsg->pwm_bitseq4.val16[1], imsg->pwm_bitseq4.val16[2], imsg->pwm_bitseq4.val16[3] };
-			err = pwm_setBitSequence4(imsg->pwm_bitseq4.timer, chn, val16, imsg->pwm_bitseq4.hcmp, imsg->pwm_bitseq4.lcmp, imsg->pwm_bitseq4.flags);
+			int *rxOutput = ((msg->o.data != NULL) && (msg->o.size == (4 * sizeof(int)))) ? msg->o.data : NULL;
+			err = pwm_setBitSequence4(imsg->pwm_bitseq4.timer, chn, val16, imsg->pwm_bitseq4.hcmp, imsg->pwm_bitseq4.lcmp, imsg->pwm_bitseq4.flags, rxOutput);
 			break;
 #endif
 		default:

--- a/multi/stm32l4-multi/stm32l4-multi.h
+++ b/multi/stm32l4-multi/stm32l4-multi.h
@@ -223,6 +223,13 @@ typedef struct {
 } __attribute__((packed)) pwmdischn_t;
 
 
+#define PWM_BITSEQ4_CHN_INVALID   (1UL << 15) /* This channel in the array will be set to idle state */
+#define PWM_BITSEQ4_CHN_IDLE_HIGH (1UL << 14) /* This channel in the array will be in high state when idle */
+#define PWM_BITSEQ4_CHN_IDLE_LOW  (0UL << 14) /* This channel in the array will be in low state when idle */
+#define PWM_BITSEQ4_CHN_DO_RX     (1UL << 13) /* This channel in the array will try to receive response */
+#define PWM_BITSEQ4_CHN_MASK      0xFFUL      /* Mask for channel number */
+
+
 typedef struct {
 	pwm_tim_id_t timer;
 	pwm_ch_id_t chn;


### PR DESCRIPTION
Implement bidirectional DShot communication and optimize the sending and receiving of DShot values.

## Description

In order to implement bidirectional DShot it was necessary to add new peripheral types (timer capture) to the DMA API. To do it efficiently, lookup tables with peripheral setups were reorganized to reduce redundancies. Also, a bug in the DMA driver was fixed that would cause memory buffer length to be incorrectly calculated in certain usage scenarios. Said bug could, at worst, lead to buffer over-runs when writing.

Many optimizations and improvements were made to and around the `pwm_set` function:

1. The number of HW register accesses was reduced - accessing them is very slow, so unnecessary or redundant operations were removed, consolidated or moved to `pwm_configure`.
1. After forcing timer update, waiting was changed from IRQ-driven to polling - the wait is extremely short (~50 ns) so the previous method had massive overhead of > 8 μs.
1. Argument verification can now be skipped using `pwm_setInternal` function.
1. Option to change PWM signal polarity (active-low vs active-high) was added.

Some other improvements were made to the timers, such as changing DMA mutex-ing to be per-timer, replacing some hard-coded values with macros for better readability and caching timer base frequency to speed up timeout calculations.

The procedure for sending DShot was optimized by using the `DMAR` register to "distribute" timer values across `CCRx` registers instead of using multiple DMA channels to perform the transaction. This reduces the required number of DMA channels from 4 to 1, freeing them for other uses. It does reduce flexibility somewhat (e.g. it's not possible to leave a channel at previous value, only set it to idle value), but for our use case this is acceptable.

In the final version the send/receive buffer is stored in cached memory. In testing it turned out that while rendering TX timer counts to uncached memory was marginally faster (about 1-2 μs faster), processing RX timer counts was significantly slower (about 6 μs) - so I made the decision to return to using cached memory.

To switch the timer from send to receive mode, a callback is attached to the DMA transaction. The callback runs in ISR context as soon as the timer starts outputting idle values. In this callback, the timer is reconfigured to start receiving. The reconfiguration takes about 1.6 μs - well within the protocol's time limit of 30 μs. The timer's channels are reconfigured for capturing input signal transition timestamps and the timer itself to wait until data reception should end. The timer's update ISR disables data capture and signals userspace thread to wake up and process the captured data.

Captured data is processed with a simple algorithm - the time difference between two captures is divided by expected bit length to get the number of bits that should be shifted in. Perhaps by examining all lengths bit length could be recovered more precisely - this would be useful if clock drift turns out to be a major issue, but so far no such problems were found. 

The driver outputs received data into an array of `int`s given by the `data` pointer in the message. Values >= 0 indicate successful reception (lower 16 bits contain the data), `-ENODATA` that no decodable data was received and `-EILSEQ` that the received data could not be decoded.

Ultimately, the time for preparing the timer for sending (rendering values, clearing cache, DMA setup) is 16 μs and for receiving (stopping DMA, decoding values from 4 channels, cleanup) is 11 μs. CPU usage by multidriver when transacting 1000x a second is 5.2% (incl. OS message processing overhead).

Suggestions are welcome for improvements to the API.

## Motivation and Context
JIRA: RTOS-1291

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
