### PR TITLE
stm32l4-multi/tty: allow use of DMA on STM32N6

### DIFF
--- a/multi/stm32l4-multi/libmulti/include/libmulti/libdma.h
+++ b/multi/stm32l4-multi/libmulti/include/libmulti/libdma.h
@@ -241,7 +241,7 @@ ssize_t libxpdma_bufferRemaining(const struct libdma_per *per, int dir);
 
 
 /* Allocate DMA-capable (uncached) memory.
- * For now to we assume DMA buffers will be allocated once at the start of the program as needed
+ * For now we assume DMA buffers will be allocated once at the start of the program as needed
  * and for this reason no corresponding `libdma_free` function exists.
  */
 void *libdma_malloc(size_t size, size_t alignment);

--- a/multi/stm32l4-multi/libmulti/libdma.c
+++ b/multi/stm32l4-multi/libmulti/libdma.c
@@ -15,6 +15,7 @@
 #include <sys/time.h>
 #include <sys/pwman.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
 #include "../common.h"
 #include "libmulti/libdma.h"
@@ -502,6 +503,41 @@ int libdma_acquirePeripheral(int per, unsigned int num, const struct libdma_per 
 	mutexUnlock(dma_common[(int)p->dma].takenLock);
 
 	return err;
+}
+
+
+void *libdma_malloc(size_t size, size_t alignment)
+{
+	/* Alignment must be a power of 2 */
+	if ((alignment & (alignment - 1)) != 0) {
+		return NULL;
+	}
+
+	/* On STM32L4 memory is not cached, so we can use regular memory for DMA */
+	void *ptr = malloc(size);
+	if (ptr == NULL) {
+		return NULL;
+	}
+
+	if ((alignment != 0) && (((uintptr_t)ptr & (alignment - 1)) != 0)) {
+		void *newPtr = realloc(ptr, size + alignment);
+		if (newPtr == NULL) {
+			free(ptr);
+			return NULL;
+		}
+
+		ptr = newPtr;
+		uintptr_t diff = alignment - ((uintptr_t)ptr & (alignment - 1));
+		if (diff != alignment) {
+			ptr = (char *)ptr + diff;
+		}
+	}
+
+	/*
+	 * Note: because `ptr` could be offset from the malloc'ed chunk of memory, it can't be passed directly to free().
+	 * Remember this for the future when implementing libdma_free().
+	 */
+	return ptr;
 }
 
 

--- a/multi/stm32l4-multi/libmulti/libgpdma.c
+++ b/multi/stm32l4-multi/libmulti/libgpdma.c
@@ -1468,7 +1468,7 @@ void *libdma_malloc(size_t size, size_t alignment)
 	}
 
 	mutexLock(dma_common.dmaAllocMutex);
-	size_t misalign = ((uintptr_t)dma_common.dmaAllocPtr & (alignment - 1));
+	size_t misalign = (alignment == 0) ? 0 : ((uintptr_t)dma_common.dmaAllocPtr & (alignment - 1));
 	misalign = (misalign != 0) ? (alignment - misalign) : 0;
 
 	if ((dma_common.dmaAllocSz < misalign) || (size > (dma_common.dmaAllocSz - misalign))) {

--- a/multi/stm32l4-multi/tty.c
+++ b/multi/stm32l4-multi/tty.c
@@ -899,24 +899,24 @@ int tty_init(void)
 
 			ctx->data.dma.debug.droppedBytes = 0;
 
-			ctx->data.dma.rxbufsz = ttySetup[tty].dmaBufSizeRx;
-			ctx->data.dma.rxbufszMask = ctx->data.dma.rxbufsz - 1;
-			ctx->data.dma.rxbuf = malloc(ctx->data.dma.rxbufsz);
-			if (ctx->data.dma.rxbuf == NULL) {
-				return -ENOMEM;
-			}
-			ctx->data.dma.txbufsz = ttySetup[tty].dmaBufSizeTx;
-			ctx->data.dma.txbuf = malloc(ctx->data.dma.txbufsz);
-			if (ctx->data.dma.txbuf == NULL) {
-				free(ctx->data.dma.rxbuf);
-				return -ENOMEM;
-			}
 			rxFifoBuf = malloc(ttySetup[tty].dmaRxFifoSize);
 			if (rxFifoBuf == NULL) {
-				free(ctx->data.dma.rxbuf);
-				free(ctx->data.dma.txbuf);
 				return -ENOMEM;
 			}
+
+			ctx->data.dma.rxbufsz = ttySetup[tty].dmaBufSizeRx;
+			ctx->data.dma.rxbufszMask = ctx->data.dma.rxbufsz - 1;
+			ctx->data.dma.txbufsz = ttySetup[tty].dmaBufSizeTx;
+
+			void *dmaMemory = libdma_malloc(ctx->data.dma.rxbufsz + ctx->data.dma.txbufsz, 1);
+			if (dmaMemory == NULL) {
+				free(rxFifoBuf);
+				return -ENOMEM;
+			}
+
+			ctx->data.dma.rxbuf = (unsigned char *)dmaMemory;
+			ctx->data.dma.txbuf = (unsigned char *)dmaMemory + ctx->data.dma.rxbufsz;
+
 			lf_fifo_init(&ctx->data.dma.rxFifo, rxFifoBuf, ttySetup[tty].dmaRxFifoSize);
 
 			ctx->type = tty_dma;


### PR DESCRIPTION
## Description
In TTY driver changed memory allocation function from `malloc` to `libdma_malloc` to allow allocation of DMA-capable memory. On STM32L4 there is no memory cache, so the function can take memory allocated from regular malloc - as it was done before. On STM32N6 allocation of uncached memory is required.

## Motivation and Context
Use of DMA significantly reduces CPU load when receiving large amounts of data over UART.

YT: RTOS-1332

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6-nucleo

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
