### PR TITLE
tty/usbacm: fix deafult thread priority

### DIFF
--- a/tty/usbacm/srv.c
+++ b/tty/usbacm/srv.c
@@ -18,7 +18,7 @@
 
 
 #ifndef USBACM_UMSG_PRIO
-#define USBACM_UMSG_PRIO 4
+#define USBACM_UMSG_PRIO 3
 #endif
 
 #ifndef USBACM_N_UMSG_THREADS


### PR DESCRIPTION
## Description

The UMSG thread handles also the completion callbacks, so its responsiveness is crucial. The previous priority was 3, which was lost during rewrite.

## Motivation and Context

TASK: RTOS-1214

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `MSH`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
