### PR TITLE
storage/grlib-nandfctrl2: set timeout in NAND initialization

### DIFF
--- a/storage/grlib-nandfctrl2/flashdrv.c
+++ b/storage/grlib-nandfctrl2/flashdrv.c
@@ -709,7 +709,7 @@ static void resetNandfctrl2(void)
 	/* Timing mode 0 until ONFI page is read */
 	setOnfiTimingMode(0U, NULL, SYSCLK_FREQ, 0);
 
-	common.regs->tout0 = 0U; /* Disable timeout */
+	common.regs->tout0 = 0xffffffffU; /* Max timeout */
 }
 
 
@@ -792,14 +792,25 @@ static int setupFlash(flashdrv_info_t *info, flashdrv_dma_t *dma, unsigned int t
 		return err;
 	}
 
+	uint32_t timeout;
 	flash_id_t *flashId = (flash_id_t *)dmaScratch(dma);
 
 	if ((flashId->manufacturerId == 0x2cU) && (flashId->deviceId == 0xacU)) {
 		info->name = "Micron MT29F4G08ABBFA";
+		/* 10 ms */
+		timeout = ns2cycles(10 * 1000 * 1000U, SYSCLK_FREQ);
+	}
+	else if ((flashId->manufacturerId == 0x2cU) && (flashId->deviceId == 0x68U)) {
+		info->name = "Micron MT29F32G08ABAAA";
+		/* 7 ms */
+		timeout = ns2cycles(7 * 1000 * 1000U, SYSCLK_FREQ);
 	}
 	else {
 		info->name = "Unknown NAND flash";
+		timeout = 0xffffffffU;
 	}
+
+	common.regs->tout0 = timeout;
 
 	/* Read ONFI parameter page */
 	dmaChainReset(dma);


### PR DESCRIPTION
YT: CSAT-158

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
