### PR TITLE
sensors: switch to finer gyro and magnetometer units

### DIFF
--- a/sensors/client-include/libsensors/client.h
+++ b/sensors/client-include/libsensors/client.h
@@ -92,9 +92,9 @@ typedef struct {
  */
 typedef struct {
 	uint32_t devId;
-	int32_t gyroX;    /* latest angular velocity value in [mrad/s] */
-	int32_t gyroY;    /* latest angular velocity value in [mrad/s] */
-	int32_t gyroZ;    /* latest angular velocity value in [mrad/s] */
+	int32_t gyroX;    /* latest angular velocity value in [urad/s] */
+	int32_t gyroY;    /* latest angular velocity value in [urad/s] */
+	int32_t gyroZ;    /* latest angular velocity value in [urad/s] */
 	uint32_t dAngleX; /* delta angle in [urad] since driver start */
 	uint32_t dAngleY; /* delta angle in [urad] since driver start */
 	uint32_t dAngleZ; /* delta angle in [urad] since driver start */

--- a/sensors/client-include/libsensors/client.h
+++ b/sensors/client-include/libsensors/client.h
@@ -105,10 +105,9 @@ typedef struct {
 /* Magnetometer data */
 typedef struct {
 	uint32_t devId;
-	int16_t magX; /* value in 1E-7 [T] */
-	int16_t magY; /* value in 1E-7 [T] */
-	int16_t magZ; /* value in 1E-7 [T] */
-	uint8_t reserved[2];
+	int32_t magX; /* value in 0.1 [nT] */
+	int32_t magY; /* value in 0.1 [nT] */
+	int32_t magZ; /* value in 0.1 [nT] */
 } mag_data_t;
 
 

--- a/sensors/imu/lsm9dsxx.c
+++ b/sensors/imu/lsm9dsxx.c
@@ -94,7 +94,7 @@
 #define GYR_OVERFLOW       26820 /* if gyro returns more than this, the sensorhub result will overflow */
 
 /* conversions */
-#define GYR2000DPS_CONV_MRAD 1.221730475f /* convert gyroscope value (at scale 2000DPS) to mrad/s */
+#define GYR2000DPS_CONV_URAD 1221.730475f /* convert gyroscope value (at scale 2000DPS) to urad/s */
 #define ACC8G_CONV_MG        0.244F       /* convert accelerations (at 8G scale) [m/s^2] */
 #define MG_CONV_MMS2         9.80665f     /* convert milli G to [mm/s^2] */
 
@@ -112,7 +112,7 @@ static int32_t translateGyr(uint8_t hbyte, uint8_t lbyte)
 	/* MISRA incompliant - casting u16 to s16 with no regard to sign */
 	int16_t val = ((uint16_t)hbyte << 8) | (uint16_t)lbyte;
 
-	return GYR2000DPS_CONV_MRAD * val; /* sensor value to [mrad/s] */
+	return GYR2000DPS_CONV_URAD * val; /* sensor value to [urad/s] */
 }
 
 

--- a/sensors/imu/mpu6000.c
+++ b/sensors/imu/mpu6000.c
@@ -70,7 +70,7 @@
 #define SENSOR_OUTPUT_SIZE 14
 
 /* conversions */
-#define GYR2000DPS_CONV_MRAD 1.064225152f     /* convert gyroscope value (at scale 2000DPS) to mrad/s */
+#define GYR2000DPS_CONV_URAD 1064.225152f     /* convert gyroscope value (at scale 2000DPS) to urad/s */
 #define ACC8G_CONV_MG        0.24414f         /* convert accelerations (at 8G scale) [m/s^2] */
 #define MG_CONV_MMS2         9.80665f         /* convert milli G to [mm/s^2] */
 #define TEMP_SCALER          340              /* temperature register scaler */
@@ -92,7 +92,7 @@ static int32_t translateGyr(uint8_t hbyte, uint8_t lbyte)
 	/* MISRA incompliant - casting u16 to s16 with no regard to sign */
 	val = ((uint16_t)hbyte << 8) | (uint16_t)lbyte;
 
-	return GYR2000DPS_CONV_MRAD * val; /* sensor value to [mrad/s] */
+	return GYR2000DPS_CONV_URAD * val; /* sensor value to [urad/s] */
 }
 
 

--- a/sensors/mag/lis2mdl.c
+++ b/sensors/mag/lis2mdl.c
@@ -49,8 +49,7 @@
 #define REG_DATA_OUT       0x68
 #define SENSOR_OUTPUT_SIZE 6
 
-#define MAG_CONV_MGAUSS 1.5F  /* conversion from sensor value to milligauss (equal to 10^-7 T) */
-#define MAG_OVERFLOW    21843 /* sensorhub will overflow if lis2mdl returns abs(raw) > MAG_OVERFLOW */
+#define MAG_CONV_UGAUSS 1500.0F /* magnetometer unit conversion factor, converts raw register value to 0.1 nT (micro Gauss) */
 
 
 typedef struct {
@@ -59,23 +58,15 @@ typedef struct {
 } lis2mdl_ctx_t;
 
 
-static int16_t translateMag(uint8_t hbyte, uint8_t lbyte)
+static int32_t translateMag(uint8_t hbyte, uint8_t lbyte)
 {
-	int16_t val;
+	int32_t val;
 
-	/* MISRA incompliant - casting u16 to s16 with no regard to sign */
-	val = ((uint16_t)hbyte << 8) | (uint16_t)lbyte;
+	/* MISRA incompliant - casting u32 to s32 with no regard to sign */
+	val = ((uint32_t)hbyte << 8) | (uint32_t)lbyte;
 
-	if (val > MAG_OVERFLOW) {
-		return MAG_OVERFLOW * MAG_CONV_MGAUSS;
-	}
-	else if (val < -MAG_OVERFLOW) {
-		return -MAG_OVERFLOW * MAG_CONV_MGAUSS;
-	}
-	else {
-		/* conversion to milligaus (10^-7 T), as it is already sensor manager storage scale */
-		return val * MAG_CONV_MGAUSS;
-	}
+	/* conversion to microgauss (1e-10 T), as it is already sensor manager storage scale */
+	return val * MAG_CONV_UGAUSS;
 }
 
 

--- a/sensors/mag/lsm9dsxx.c
+++ b/sensors/mag/lsm9dsxx.c
@@ -72,7 +72,7 @@
 #define SENSOR_OUTPUT_SIZE 6
 
 /* conversions */
-#define MAG4G_CONV_MGAUSS 0.14F /* conversion from sensor (at +-4 gauss scale) value to milligauss (equal to 10^-7 T) */
+#define MAG4G_CONV_UGAUSS 140.0F /* conversion from sensor (at +-4 gauss scale) value to microgauss (equal to 0.1 nT) */
 
 
 typedef struct {
@@ -81,14 +81,14 @@ typedef struct {
 } lsm9dsxx_ctx_t;
 
 
-static int16_t translateMag(uint8_t hbyte, uint8_t lbyte)
+static int32_t translateMag(uint8_t hbyte, uint8_t lbyte)
 {
 	int16_t val;
 
 	val = (hbyte << 8) | lbyte;
 
-	/* conversion to milligaus (10^-7 T), as it is already sensor manager storage scale */
-	return val * MAG4G_CONV_MGAUSS;
+	/* conversion to microgauss (10^-10 T), as it is already sensor manager storage scale */
+	return val * MAG4G_CONV_UGAUSS;
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR changes units for magnetometer and gyroscope in libsensors API.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR allows to use full resolution of most available MEMS gyroscopes and magnetometers as it changes to finer units. Previously coarser units were used so that some precision was lost during unit conversion.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
All projects using libsensors should account for three changes:
-> angular rate unit changed from mrad/s to urad/s,
-> magnetometer unit changes from 1e-7 T to 1e-9 nT,
-> magnetic field variable type changed from int16_t to int32_t.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
