### PR TITLE
tty/uart16550: fixes and performance improvements

### DIFF
--- a/tty/uart16550/uart16550.c
+++ b/tty/uart16550/uart16550.c
@@ -20,6 +20,9 @@
 #include <unistd.h>
 #include <paths.h>
 #include <string.h>
+#include <stdatomic.h>
+#include <stddef.h>
+#include <lf-fifo.h>
 
 #include <sys/file.h>
 #include <sys/interrupt.h>
@@ -39,13 +42,50 @@
 
 #define SW_BUF_SIZE 64
 
+#define N_UARTS 4
+
+#define THREAD_STACK_SIZE 2048
+
+/*
+ * Note: different 16550 implementations have different meanings for FIFO threshold settings.
+ * Typically 0x2 is 8 characters threshold in a FIFO of 16 characters.
+ */
+#define UART16550_FIFO_DEFAULT 0x2
+
+#ifndef UART16550_FIFO0
+#define UART16550_FIFO0 UART16550_FIFO_DEFAULT
+#endif
+
+#ifndef UART16550_FIFO1
+#define UART16550_FIFO1 UART16550_FIFO_DEFAULT
+#endif
+
+#ifndef UART16550_FIFO2
+#define UART16550_FIFO2 UART16550_FIFO_DEFAULT
+#endif
+
+#ifndef UART16550_FIFO3
+#define UART16550_FIFO3 UART16550_FIFO_DEFAULT
+#endif
+
+
+static const int8_t uart_defaultFifo[N_UARTS] = {
+	UART16550_FIFO0,
+	UART16550_FIFO1,
+	UART16550_FIFO2,
+	UART16550_FIFO3,
+};
+
+
 typedef struct {
 	uint8_t hwctx[64];
-	uint8_t buf[SW_BUF_SIZE];
-	volatile unsigned int buf_i;
+	lf_fifo_t rxSwFifo;
+	uint8_t rxSwFifoData[SW_BUF_SIZE];
+	atomic_uint_fast8_t lineStatus;
 
 	unsigned int init;
 	unsigned int clk;
+	volatile unsigned int hwOverruns; /* Intended to be read by debugger */
 
 	handle_t mutex;
 	handle_t intcond;
@@ -54,13 +94,13 @@ typedef struct {
 	oid_t oid;
 	libtty_common_t tty;
 
-	char stack[1024] __attribute__((aligned(8)));
+	char stack[THREAD_STACK_SIZE] __attribute__((aligned(8)));
 } uart_t;
 
 
 static struct {
-	uart_t uarts[4];
-	char stack[1024] __attribute__((aligned(8)));
+	uart_t uarts[N_UARTS];
+	char stack[THREAD_STACK_SIZE] __attribute__((aligned(8)));
 } uart_common;
 
 
@@ -68,7 +108,7 @@ static uart_t *uart_get(oid_t *oid)
 {
 	unsigned int i;
 
-	for (i = 0; i < sizeof(uart_common.uarts) / sizeof(uart_common.uarts[0]); i++) {
+	for (i = 0; i < N_UARTS; i++) {
 		if ((uart_common.uarts[i].oid.port == oid->port) && (uart_common.uarts[i].oid.id == oid->id)) {
 			return uart_common.uarts + i;
 		}
@@ -136,6 +176,20 @@ static void signal_txready(void *arg)
 	condSignal(uart->intcond);
 }
 
+
+/*
+ * This function is necessary because Line Status Register contains error bits that are clear-on-read
+ * (like overrun bit), but also hardware-cleared bits like data ready bit.
+ * We need to store and accumulate error bits until we are ready to handle them.
+ */
+static uint8_t uart_readUpdateLineStatus(uart_t *uart)
+{
+	uint8_t lineStatus = uarthw_read(uart->hwctx, REG_LSR);
+	atomic_fetch_or(&uart->lineStatus, lineStatus);
+	return lineStatus;
+}
+
+
 #ifdef __TARGET_RISCV64
 __attribute__((section(".interrupt"))) static int uart_interrupt(unsigned int n, void *arg)
 {
@@ -144,8 +198,7 @@ __attribute__((section(".interrupt"))) static int uart_interrupt(unsigned int n,
 	 * Fortunately the UART IRQ on this platform is edge-triggered so we can just
 	 * exit interrupt, signal uart->intcond and main thread will handle the rest.
 	 */
-	uart_t *uart = (uart_t *)arg;
-	return uart->intcond;
+	return 1;
 }
 #else
 static int uart_interrupt(unsigned int n, void *arg)
@@ -162,18 +215,17 @@ static int uart_interrupt(unsigned int n, void *arg)
 	 */
 	uint8_t iir = uarthw_read(uart->hwctx, REG_IIR);
 	uarthw_write(uart->hwctx, REG_IMR, 0);
-	unsigned int i = uart->buf_i;
 	do {
 		uint8_t intr_type = (iir >> 1) & 0x7;
 		if ((intr_type == IIR_CODE_DR) || (intr_type == IIR_CODE_RTO)) {
-			uint8_t c = uarthw_read(uart->hwctx, REG_RBR);
-			if (i < SW_BUF_SIZE) {
-				uart->buf[i] = c;
-				i++;
+			uint8_t status = uart_readUpdateLineStatus(uart);
+			while ((status & LSR_DR) != 0) {
+				lf_fifo_ow_push(&uart->rxSwFifo, uarthw_read(uart->hwctx, REG_RBR));
+				status = uart_readUpdateLineStatus(uart);
 			}
 		}
 		else if (intr_type == IIR_CODE_LS) {
-			uarthw_read(uart->hwctx, REG_LSR);
+			uart_readUpdateLineStatus(uart);
 		}
 		else if (intr_type == IIR_CODE_MS) {
 			uarthw_read(uart->hwctx, REG_MSR);
@@ -182,40 +234,61 @@ static int uart_interrupt(unsigned int n, void *arg)
 		iir = uarthw_read(uart->hwctx, REG_IIR);
 	} while ((iir & IIR_IRQPEND) == 0);
 
-	uart->buf_i = i;
-	return uart->intcond;
+	return 1;
 }
 #endif
+
+
+static void uart_handleErrors(uart_t *uart)
+{
+	(void)uart_readUpdateLineStatus(uart);
+	uint8_t lineStatus = atomic_exchange(&uart->lineStatus, 0);
+	if (lineStatus & LSR_OE) {
+		uart->hwOverruns++;
+	}
+}
 
 
 static void uart_intthr(void *arg)
 {
 	uart_t *uart = (uart_t *)arg;
-	uint8_t target_imr = IMR_DR;
+	uint8_t target_imr = IMR_DR | IMR_LS;
 
 	mutexLock(uart->mutex);
 	for (;;) {
 		uarthw_write(uart->hwctx, REG_IMR, target_imr);
+		uart_handleErrors(uart);
 		condWait(uart->intcond, uart->mutex, 0);
 		/* For the following part the interrupt needs to be masked */
 		uarthw_write(uart->hwctx, REG_IMR, 0);
 
-		/* Empty received buffer */
-		unsigned int buf_i = uart->buf_i;
-		for (unsigned int i = 0; i < buf_i; i++) {
-			libtty_putchar(&uart->tty, uart->buf[i], NULL);
-		}
+		if (!lf_fifo_empty(&uart->rxSwFifo) || (uart_readUpdateLineStatus(uart) & LSR_DR) != 0) {
+			int wake = 0, wakeHelper = 0;
+			libtty_putchar_lock(&uart->tty);
+			/* Empty received buffer */
+			uint8_t c;
+			while (lf_fifo_ow_pop(&uart->rxSwFifo, &c) != 0) {
+				libtty_putchar_unlocked(&uart->tty, c, &wakeHelper);
+				wake |= wakeHelper;
+			}
 
-		uart->buf_i = 0;
-		/* Depending on implementation we may have more characters in hardware FIFO */
-		while ((uarthw_read(uart->hwctx, REG_LSR) & LSR_DR) != 0) {
-			libtty_putchar(&uart->tty, uarthw_read(uart->hwctx, REG_RBR), NULL);
+			/* Depending on implementation we may have more characters in hardware FIFO */
+			while ((uart_readUpdateLineStatus(uart) & LSR_DR) != 0) {
+				c = uarthw_read(uart->hwctx, REG_RBR);
+				libtty_putchar_unlocked(&uart->tty, c, &wakeHelper);
+				wake |= wakeHelper;
+			}
+
+			libtty_putchar_unlock(&uart->tty);
+			if (wake != 0) {
+				libtty_wake_reader(&uart->tty);
+			}
 		}
 
 		/* Check for transmit */
 		while (1) {
 			if (libtty_txready(&uart->tty) != 0) {
-				if ((uarthw_read(uart->hwctx, REG_LSR) & LSR_THRE) != 0) {
+				if ((uart_readUpdateLineStatus(uart) & LSR_THRE) != 0) {
 					uarthw_write(uart->hwctx, REG_THR, libtty_getchar(&uart->tty, NULL));
 				}
 				else {
@@ -346,7 +419,7 @@ static void _uart_mkDev(uint32_t port, int isconsole)
 	char path[12];
 	unsigned int i;
 
-	for (i = 0; i < sizeof(uart_common.uarts) / sizeof(uart_common.uarts[0]); i++) {
+	for (i = 0; i < N_UARTS; i++) {
 		if (uart_common.uarts[i].init == 1) {
 			uart_common.uarts[i].oid.port = port;
 			uart_common.uarts[i].oid.id = (i == UART16550_CONSOLE_USER) ? 0 : i + 1;
@@ -377,7 +450,7 @@ static void _uart_mkDev(uint32_t port, int isconsole)
 }
 
 
-static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed)
+static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed, int8_t fifo)
 {
 	unsigned int divisor;
 	libtty_callbacks_t callbacks = {
@@ -399,23 +472,43 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed)
 		return err;
 	}
 
-	uart->buf_i = 0;
-	condCreate(&uart->intcond);
-	mutexCreate(&uart->mutex);
+	uart->hwOverruns = 0;
+	atomic_store(&uart->lineStatus, 0);
+	lf_fifo_init(&uart->rxSwFifo, uart->rxSwFifoData, sizeof(uart->rxSwFifoData));
+	err = condCreate(&uart->intcond);
+	if (err < 0) {
+		libtty_destroy(&uart->tty);
+		return err;
+	}
 
-	beginthread(uart_intthr, 1, uart->stack, sizeof(uart->stack), uart);
-	interrupt(uarthw_irq(uart->hwctx), uart_interrupt, uart, uart->intcond, &uart->inth);
+	err = mutexCreate(&uart->mutex);
+	if (err < 0) {
+		resourceDestroy(uart->intcond);
+		libtty_destroy(&uart->tty);
+		return err;
+	}
 
 	/* Set speed (MOD) */
 	uarthw_write(uart->hwctx, REG_LCR, LCR_DLAB);
 	uarthw_write(uart->hwctx, REG_LSB, divisor);
 	uarthw_write(uart->hwctx, REG_MSB, divisor >> 8);
 
-	/* Set data format (MOD) */
-	uarthw_write(uart->hwctx, REG_LCR, LCR_D8N1);
+	/* Set data format, leave DLAB on because some 16750 implementations require it to enable extended FIFO settings */
+	uarthw_write(uart->hwctx, REG_LCR, LCR_DLAB | LCR_D8N1);
 
 	/* Enable and configure FIFOs */
-	uarthw_write(uart->hwctx, REG_FCR, 0xa7);
+	if (fifo < 0) {
+		uarthw_write(uart->hwctx, REG_FCR, 0);
+	}
+	else {
+		/* On some implementations we need to set FIFOEN separately before any other write can take effect */
+		uarthw_write(uart->hwctx, REG_FCR, FCR_FIFOEN);
+		uint8_t fifoSetting = (((uint8_t)fifo & 0x3) << 6);
+		uarthw_write(uart->hwctx, REG_FCR, fifoSetting | FCR_EXTFIFO | FCR_RESETTX | FCR_RESETRX | FCR_FIFOEN);
+	}
+
+	/* Set LCR to its final value */
+	uarthw_write(uart->hwctx, REG_LCR, LCR_D8N1);
 
 	/* Enable hardware interrupts */
 	uarthw_write(uart->hwctx, REG_MCR, MCR_OUT2);
@@ -423,7 +516,26 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed)
 	/* Set interrupt mask */
 	uarthw_write(uart->hwctx, REG_IMR, 0);
 
-	return EOK;
+	err = interrupt(uarthw_irq(uart->hwctx), uart_interrupt, uart, uart->intcond, &uart->inth);
+	if (err < 0) {
+		uarthw_write(uart->hwctx, REG_MCR, 0);
+		resourceDestroy(uart->mutex);
+		resourceDestroy(uart->intcond);
+		libtty_destroy(&uart->tty);
+		return err;
+	}
+
+	err = beginthread(uart_intthr, 1, uart->stack, sizeof(uart->stack), uart);
+	if (err < 0) {
+		resourceDestroy(uart->inth);
+		uarthw_write(uart->hwctx, REG_MCR, 0);
+		resourceDestroy(uart->mutex);
+		resourceDestroy(uart->intcond);
+		libtty_destroy(&uart->tty);
+		return err;
+	}
+
+	return 0;
 }
 
 
@@ -438,13 +550,17 @@ int main(int argc, char **argv)
 		isconsole = 0;
 	}
 	else if (argc != 1) {
-		return -1;
+		return EXIT_FAILURE;
 	}
 
-	portCreate(&port);
+	err = portCreate(&port);
+	if (err < 0) {
+		fprintf(stderr, "uart16550: failed to create port\n");
+		return EXIT_FAILURE;
+	}
 
-	for (i = 0; i < sizeof(uart_common.uarts) / sizeof(uart_common.uarts[0]); i++) {
-		err = _uart_init(&uart_common.uarts[i], i, UART16550_BAUDRATE);
+	for (i = 0; i < N_UARTS; i++) {
+		err = _uart_init(&uart_common.uarts[i], i, UART16550_BAUDRATE, uart_defaultFifo[i]);
 		if (err < 0) {
 			if (err != -ENODEV) {
 				fprintf(stderr, "uart16550: failed to init ttyS%u, err: %d\n", i, err);
@@ -455,7 +571,12 @@ int main(int argc, char **argv)
 		}
 	}
 
-	beginthread(poolthr, 4, uart_common.stack, sizeof(uart_common.stack), (void *)(uintptr_t)port);
+	err = beginthread(poolthr, 4, uart_common.stack, sizeof(uart_common.stack), (void *)(uintptr_t)port);
+	if (err < 0) {
+		fprintf(stderr, "uart16550: failed to start thread\n");
+		return EXIT_FAILURE;
+	}
+
 	_uart_mkDev(port, isconsole);
 	poolthr((void *)(uintptr_t)port);
 

--- a/tty/uart16550/uart16550.c
+++ b/tty/uart16550/uart16550.c
@@ -84,7 +84,7 @@ typedef struct {
 	atomic_uint_fast8_t lineStatus;
 
 	unsigned int init;
-	unsigned int clk;
+	uarthw_info_t hwInfo;
 	volatile unsigned int hwOverruns; /* Intended to be read by debugger */
 
 	handle_t mutex;
@@ -128,7 +128,7 @@ static void set_baudrate(void *_uart, int baud_rate)
 	}
 
 	/* Baud divisor */
-	baud_rate = uart->clk / (16 * baud_rate);
+	baud_rate = uart->hwInfo.fclk / (16 * baud_rate);
 
 	if (baud_rate > UINT16_MAX) {
 		return;
@@ -460,12 +460,12 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed, int8
 		.signal_txready = signal_txready,
 	};
 
-	int err = uarthw_init(uartn, uart->hwctx, sizeof(uart->hwctx), &uart->clk);
+	int err = uarthw_init(uartn, uart->hwctx, sizeof(uart->hwctx), &uart->hwInfo);
 	if (err < 0) {
 		return err;
 	}
 
-	divisor = uart->clk / (16 * speed);
+	divisor = uart->hwInfo.fclk / (16 * speed);
 
 	err = libtty_init(&uart->tty, &callbacks, _PAGE_SIZE, speed);
 	if (err < 0) {
@@ -503,8 +503,8 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed, int8
 	else {
 		/* On some implementations we need to set FIFOEN separately before any other write can take effect */
 		uarthw_write(uart->hwctx, REG_FCR, FCR_FIFOEN);
-		uint8_t fifoSetting = (((uint8_t)fifo & 0x3) << 6);
-		uarthw_write(uart->hwctx, REG_FCR, fifoSetting | FCR_EXTFIFO | FCR_RESETTX | FCR_RESETRX | FCR_FIFOEN);
+		uint8_t fifoSetting = (((uint8_t)fifo & 0x3) << 6) | uart->hwInfo.fcr;
+		uarthw_write(uart->hwctx, REG_FCR, fifoSetting | FCR_RESETTX | FCR_RESETRX | FCR_FIFOEN);
 	}
 
 	/* Set LCR to its final value */

--- a/tty/uart16550/uart16550.c
+++ b/tty/uart16550/uart16550.c
@@ -249,6 +249,30 @@ static void uart_handleErrors(uart_t *uart)
 }
 
 
+static bool uart_handleTx(uart_t *uart)
+{
+	bool waitForTx = false;
+	int wake = 0;
+	while (libtty_txready(&uart->tty) != 0) {
+		if ((uart_readUpdateLineStatus(uart) & LSR_THRE) != 0) {
+			int wakeHelper;
+			uarthw_write(uart->hwctx, REG_THR, libtty_getchar(&uart->tty, &wakeHelper));
+			wake |= wakeHelper;
+		}
+		else {
+			waitForTx = true;
+			break;
+		}
+	}
+
+	if (wake != 0) {
+		libtty_wake_writer(&uart->tty);
+	}
+
+	return waitForTx;
+}
+
+
 static void uart_intthr(void *arg)
 {
 	uart_t *uart = (uart_t *)arg;
@@ -286,20 +310,11 @@ static void uart_intthr(void *arg)
 		}
 
 		/* Check for transmit */
-		while (1) {
-			if (libtty_txready(&uart->tty) != 0) {
-				if ((uart_readUpdateLineStatus(uart) & LSR_THRE) != 0) {
-					uarthw_write(uart->hwctx, REG_THR, libtty_getchar(&uart->tty, NULL));
-				}
-				else {
-					target_imr |= IMR_THRE;
-					break;
-				}
-			}
-			else {
-				target_imr &= ~IMR_THRE;
-				break;
-			}
+		if (uart_handleTx(uart)) {
+			target_imr |= IMR_THRE;
+		}
+		else {
+			target_imr &= ~IMR_THRE;
 		}
 	}
 }

--- a/tty/uart16550/uart16550.c
+++ b/tty/uart16550/uart16550.c
@@ -34,6 +34,7 @@
 #include <libklog.h>
 #include <board_config.h>
 #include <posix/utils.h>
+#include <syslog.h>
 
 #include "uarthw.h"
 #include "uart16550.h"
@@ -85,7 +86,7 @@ typedef struct {
 
 	unsigned int init;
 	uarthw_info_t hwInfo;
-	volatile unsigned int hwOverruns; /* Intended to be read by debugger */
+	atomic_uint_fast32_t hwOverruns;
 
 	handle_t mutex;
 	handle_t intcond;
@@ -96,6 +97,12 @@ typedef struct {
 
 	char stack[THREAD_STACK_SIZE] __attribute__((aligned(8)));
 } uart_t;
+
+
+typedef struct {
+	bool isConsole;
+	bool reportErrors;
+} uart_args_t;
 
 
 static struct {
@@ -244,7 +251,7 @@ static void uart_handleErrors(uart_t *uart)
 	(void)uart_readUpdateLineStatus(uart);
 	uint8_t lineStatus = atomic_exchange(&uart->lineStatus, 0);
 	if (lineStatus & LSR_OE) {
-		uart->hwOverruns++;
+		atomic_fetch_add(&uart->hwOverruns, 1);
 	}
 }
 
@@ -351,6 +358,31 @@ static void uart_ioctl(unsigned int port, msg_t *msg)
 }
 
 
+static void uart_errorThread(void *arg)
+{
+	(void)arg;
+	uint32_t overrunsLast[N_UARTS];
+	memset(&overrunsLast, 0, sizeof(overrunsLast));
+
+	for (;;) {
+		for (unsigned int i = 0; i < N_UARTS; i++) {
+			uart_t *uart = &uart_common.uarts[i];
+			if (uart->init == 0) {
+				continue;
+			}
+
+			uint32_t overrunsNow = atomic_load(&uart->hwOverruns);
+			if (overrunsNow != overrunsLast[i]) {
+				syslog(LOG_WARNING, "UART16550 %u: %u overrun(s) detected", i, overrunsNow - overrunsLast[i]);
+				overrunsLast[i] = overrunsNow;
+			}
+		}
+
+		sleep(1);
+	}
+}
+
+
 static void poolthr(void *arg)
 {
 	unsigned int port = (uintptr_t)arg;
@@ -429,7 +461,7 @@ static void uart_klogClbk(const char *data, size_t size)
 }
 
 
-static void _uart_mkDev(uint32_t port, int isconsole)
+static void _uart_mkDev(uint32_t port, bool isconsole)
 {
 	char path[12];
 	unsigned int i;
@@ -446,7 +478,7 @@ static void _uart_mkDev(uint32_t port, int isconsole)
 			}
 
 			if (i == UART16550_CONSOLE_USER) {
-				if (isconsole != 0) {
+				if (isconsole) {
 					libklog_init(uart_klogClbk);
 					if (create_dev(&uart_common.uarts[i].oid, _PATH_CONSOLE) < 0) {
 						fprintf(stderr, "uart16550: failed to register %s\n", _PATH_CONSOLE);
@@ -487,7 +519,7 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed, int8
 		return err;
 	}
 
-	uart->hwOverruns = 0;
+	atomic_store(&uart->hwOverruns, 0);
 	atomic_store(&uart->lineStatus, 0);
 	lf_fifo_init(&uart->rxSwFifo, uart->rxSwFifoData, sizeof(uart->rxSwFifoData));
 	err = condCreate(&uart->intcond);
@@ -554,17 +586,56 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed, int8
 }
 
 
-int main(int argc, char **argv)
+static void print_usage(const char *name)
+{
+	printf("UART16550 driver. Usage:\n");
+	printf("%s [-n] [-e]\n", name);
+	printf("\t-n - Skip creating %s device (default: no)\n", _PATH_CONSOLE);
+	printf("\t-e - Report data errors to syslog (default: no)\n");
+}
+
+
+static int parse_args(int argc, char *argv[], uart_args_t *args)
+{
+	int opt;
+	args->isConsole = true;
+	args->reportErrors = false;
+
+	while ((opt = getopt(argc, argv, "hne")) != -1) {
+		switch (opt) {
+			case 'n':
+				args->isConsole = false;
+				break;
+
+			case 'e':
+				args->reportErrors = true;
+				break;
+
+			case 'h': /* Fall-through */
+			default:
+				print_usage(argv[0]);
+				return -1;
+		}
+	}
+
+	if (optind < argc) {
+		fprintf(stderr, "%s: unrecognized argument: %s\n", argv[0], argv[optind]);
+		print_usage(argv[0]);
+		return -1;
+	}
+
+	return 0;
+}
+
+
+int main(int argc, char *argv[])
 {
 	unsigned int i;
 	uint32_t port;
 	int err;
+	uart_args_t args;
 
-	int isconsole = 1;
-	if ((argc == 2) && (strcmp(argv[1], "-n") == 0)) {
-		isconsole = 0;
-	}
-	else if (argc != 1) {
+	if (parse_args(argc, argv, &args) < 0) {
 		return EXIT_FAILURE;
 	}
 
@@ -586,13 +657,27 @@ int main(int argc, char **argv)
 		}
 	}
 
+	if (args.reportErrors) {
+		char *stack = malloc(THREAD_STACK_SIZE);
+		if (stack == NULL) {
+			fprintf(stderr, "uart16550: failed to allocate memory for error thread. Errors will not be reported.\n");
+		}
+		else {
+			err = beginthread(uart_errorThread, 5, stack, THREAD_STACK_SIZE, NULL);
+			if (err < 0) {
+				fprintf(stderr, "uart16550: failed to start error thread. Errors will not be reported.\n");
+				free(stack);
+			}
+		}
+	}
+
 	err = beginthread(poolthr, 4, uart_common.stack, sizeof(uart_common.stack), (void *)(uintptr_t)port);
 	if (err < 0) {
 		fprintf(stderr, "uart16550: failed to start thread\n");
 		return EXIT_FAILURE;
 	}
 
-	_uart_mkDev(port, isconsole);
+	_uart_mkDev(port, args.isConsole);
 	poolthr((void *)(uintptr_t)port);
 
 	return EXIT_SUCCESS;

--- a/tty/uart16550/uart16550.h
+++ b/tty/uart16550/uart16550.h
@@ -32,6 +32,7 @@
 
 
 /* Register bits */
+#define IMR_LS   0x04
 #define IMR_THRE 0x02
 #define IMR_DR   0x01
 
@@ -51,8 +52,17 @@
 #define MCR_RTS  0x02
 #define MCR_DTR  0x01
 
-#define LSR_DR   0x01
-#define LSR_THRE 0x20
+#define LSR_DR   0x01 /* Data ready */
+#define LSR_OE   0x02 /* Overrun error */
+#define LSR_PE   0x04 /* Parity error */
+#define LSR_FE   0x08 /* Framing error */
+#define LSR_BI   0x10 /* Break interrupt */
+#define LSR_THRE 0x20 /* Transmitter hold register empty */
+
+#define FCR_FIFOEN  0x1  /* Enable FIFO */
+#define FCR_RESETRX 0x2  /* Reset RX FIFO */
+#define FCR_RESETTX 0x4  /* Reset TX FIFO */
+#define FCR_EXTFIFO 0x20 /* Enable extended FIFO size (16750 / implementation dependent) */
 
 
 #endif

--- a/tty/uart16550/uarthw-pc.c
+++ b/tty/uart16550/uarthw-pc.c
@@ -18,6 +18,7 @@
 #include <errno.h>
 
 #include "uart16550.h"
+#include "uarthw.h"
 
 
 typedef struct {
@@ -51,7 +52,7 @@ unsigned int uarthw_irq(void *hwctx)
 }
 
 
-int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, unsigned int *fclk)
+int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, uarthw_info_t *infoOut)
 {
 	static struct {
 		void *base;
@@ -74,7 +75,9 @@ int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, unsigned int *f
 		return -ENODEV;
 	}
 
-	*fclk = 115200 * 16;
+	infoOut->fclk = 115200 * 16;
+	/* Set extended FIFO capacity (if available) */
+	infoOut->fcr = FCR_EXTFIFO;
 
 	return EOK;
 }

--- a/tty/uart16550/uarthw-riscv.c
+++ b/tty/uart16550/uarthw-riscv.c
@@ -20,6 +20,7 @@
 #include <board_config.h>
 
 #include "uart16550.h"
+#include "uarthw.h"
 
 
 typedef struct {
@@ -53,7 +54,7 @@ unsigned int uarthw_irq(void *hwctx)
 }
 
 
-int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, unsigned int *fclk)
+int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, uarthw_info_t *infoOut)
 {
 	void *base;
 
@@ -79,7 +80,9 @@ int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, unsigned int *f
 		return -ENODEV;
 	}
 
-	*fclk = 115200 * 16;
+	infoOut->fclk = 115200 * 16;
+	/* Set extended FIFO capacity (if available) */
+	infoOut->fcr = FCR_EXTFIFO;
 
 	return EOK;
 }

--- a/tty/uart16550/uarthw-tda4vm.c
+++ b/tty/uart16550/uarthw-tda4vm.c
@@ -22,6 +22,7 @@
 #include <phoenix/arch/armv7r/tda4vm/tda4vm_pins.h>
 
 #include "uart16550.h"
+#include "uarthw.h"
 
 /* UART extension registers */
 #define REG_EFR  2 /* Enhanced feature register */
@@ -199,7 +200,7 @@ static int uarthw_setPin(const tda4vm_uart_info_t *info, uint32_t pin)
 }
 
 
-int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, unsigned int *fclk)
+int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, uarthw_info_t *infoOut)
 {
 	void *base;
 	platformctl_t pctl;
@@ -250,7 +251,10 @@ int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, unsigned int *f
 		return -EIO;
 	}
 
-	*fclk = (unsigned int)pctl.frequency.val / info->divisor;
+	infoOut->fclk = (unsigned int)pctl.frequency.val / info->divisor;
+	/* On TDA4VM the reserved bits in FCR set TX FIFO threshold - set it to 0 (8 spaces) */
+	infoOut->fcr = 0;
+
 	ret = uarthw_setPin(info, info->pins_selected.tx);
 	if (ret < 0) {
 		return ret;

--- a/tty/uart16550/uarthw-zynq.c
+++ b/tty/uart16550/uarthw-zynq.c
@@ -19,6 +19,7 @@
 #include <board_config.h>
 
 #include "uart16550.h"
+#include "uarthw.h"
 
 #ifndef UART16550_BASE0
 #define UART16550_BASE0 0
@@ -88,7 +89,7 @@ unsigned int uarthw_irq(void *hwctx)
 }
 
 
-int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, unsigned int *fclk)
+int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, uarthw_info_t *infoOut)
 {
 	void *base;
 	static const struct {
@@ -123,7 +124,9 @@ int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, unsigned int *f
 		return -ENODEV;
 	}
 
-	*fclk = 100 * 1000 * 1000;
+	infoOut->fclk = 100 * 1000 * 1000;
+	/* On AXI UART 16550 reserved bits in FCR have no function */
+	infoOut->fcr = 0;
 
 	return EOK;
 }

--- a/tty/uart16550/uarthw-zynq.c
+++ b/tty/uart16550/uarthw-zynq.c
@@ -92,7 +92,7 @@ int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, unsigned int *f
 {
 	void *base;
 	static const struct {
-		uint32_t base;
+		uintptr_t base;
 		unsigned int irqno;
 	} uarthw_info[] = {
 		{ .base = UART16550_BASE0, .irqno = UART16550_IRQ0 },

--- a/tty/uart16550/uarthw.h
+++ b/tty/uart16550/uarthw.h
@@ -16,7 +16,14 @@
 #ifndef _DEV_UART16550_UARTHW_H_
 #define _DEV_UART16550_UARTHW_H_
 
-#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+
+
+typedef struct {
+	unsigned int fclk; /* UART baud rate generator base clock */
+	uint8_t fcr;       /* HW-dependent bits in FCR register */
+} uarthw_info_t;
 
 
 extern uint8_t uarthw_read(void *hwctx, unsigned int reg);
@@ -31,7 +38,7 @@ extern char *uarthw_dump(void *hwctx, char *s, size_t sz);
 extern unsigned int uarthw_irq(void *hwctx);
 
 
-extern int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, unsigned int *fclk);
+extern int uarthw_init(unsigned int uartn, void *hwctx, size_t hwctxsz, uarthw_info_t *infoOut);
 
 
 #endif


### PR DESCRIPTION
Multiple fixes to the 16550 driver to improve performance and compatibility with different platforms.

## Description
The 16550 UART driver had multiple problems that were addressed:
1. The AXI UART 16550 v2.0 implementation that was used on Zynq platforms requires that `FCR.FIFOEN` bit be set to 1 first, in a separate write, before FIFO parameters in the same register can be configured. This is not explicitly mentioned in the documentation, only that `FIFOEN` bit must be 1. Now FIFO threshold is set correctly.
2. Compile-time FIFO options were added to allow FIFO threshold to be set per-device (incl. option to turn off FIFO completely). This allows user to configure the UART for a particular use case.
3. Hardware FIFO overrun conditions are now read and accumulated in software and (in debug configuration) signalled through syslog.
4. Previously data within ISR was read into a bespoke buffer implementation. This was replaced with a FIFO implementation from `lf-fifo.h` library. This is in line with other UART drivers and is more reliable - the library was designed to be lock-free using atomic operations.
5. Pushing characters into `libtty` FIFO was reworked so that as many characters as possible are pushed within one lock/unlock pair. This avoids acquiring and releasing the lock for each character separately, which would be bad for performance.
6. Reading data within ISR was extended to read as many characters as are available. This improves performance and helps avoid overruns.
7. Stack size was increased, as the previous stack size was too small for reliable operation on AArch64 platforms.
8. Starting of interrupt handler thread (`uart_intthr`) and registering of interrupt was moved until after hardware initialization is finished. This fixes a race condition that could lead to interrupt mask not being set properly.

In testing on `aarch64-zynqmp-zcu104` these changes eliminate problems with overruns and reduce CPU usage to 37% when UART is used to its maximum configuration (baud rate 460800, receiving characters continuously, 14-character FIFO threshold).

## Motivation and Context
YT: RTOS-1394

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: aarch64-zynqmp-som

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
