### PR TITLE
!sensors: change barometer units to centipascals

### DIFF
--- a/sensors/baro/lps22xx.c
+++ b/sensors/baro/lps22xx.c
@@ -54,9 +54,9 @@
 #define SENSOR_OUTPUT_SIZE 5
 
 /* conversions */
-#define SENSOR_CONV_PASCALS 0.024414062F /* conversion from sensor value to pascals; = (100 * 1/4096) */
-#define SENSOR_CONV_KELV    0.01F        /* conversion from sensor value to kelvin */
-#define SENSOR_KELV_OFFS    273.15F      /* temperature measurement offset + kelvin to celsius offset */
+#define SENSOR_CONV_CENTIPASCALS (1e4F / 4096.0F) /* conversion from sensor value to centipascals */
+#define SENSOR_CONV_KELV         0.01F            /* conversion from sensor value to kelvin */
+#define SENSOR_KELV_OFFS         273.15F          /* temperature measurement offset + kelvin to celsius offset */
 
 #define LPS22XX_BOOT_DELAY_US   (10 * 1000)
 #define LPS22XX_CONFIG_DELAY_US (100 * 1000)
@@ -82,7 +82,7 @@ static uint32_t translatePress(uint8_t lbyte, uint8_t mbyte, uint8_t hbyte)
 
 	val = lbyte | (mbyte << 8) | (hbyte << 16);
 
-	return (uint32_t)((float)val * SENSOR_CONV_PASCALS);
+	return (uint32_t)((float)val * SENSOR_CONV_CENTIPASCALS);
 }
 
 

--- a/sensors/baro/lps25xx.c
+++ b/sensors/baro/lps25xx.c
@@ -59,9 +59,9 @@
 #define SENSOR_OUTPUT_SIZE 5
 
 /* conversions */
-#define SENSOR_CONV_PASCALS 0.024414062F /* conversion from sensor value to pascals; = (100 * 1/4096) */
-#define SENSOR_CONV_KELV    0.002083333F /*conversion from sensor value to kelvin */
-#define SENSOR_KELV_OFFS    315.65F      /* temperature measurement offset + kelvin to celsius offset */
+#define SENSOR_CONV_CENTIPASCALS (1e4F / 4096.0F) /* conversion from sensor value to centipascals */
+#define SENSOR_CONV_KELV         0.002083333F     /*conversion from sensor value to kelvin */
+#define SENSOR_KELV_OFFS         315.65F          /* temperature measurement offset + kelvin to celsius offset */
 
 
 typedef struct {
@@ -78,7 +78,7 @@ static uint32_t translatePress(uint8_t lbyte, uint8_t mbyte, uint8_t hbyte)
 	/* dismiss highest bit as it is unusable */
 	val &= 0x7FFFFF;
 
-	return val * SENSOR_CONV_PASCALS;
+	return val * SENSOR_CONV_CENTIPASCALS;
 }
 
 

--- a/sensors/baro/ms5611.c
+++ b/sensors/baro/ms5611.c
@@ -183,7 +183,7 @@ static void ms5611_publishthr(void *data)
 		/* MS5611 operating ranges: temperature from -40C to +80C, and pressure: 45000Pa, 110000 Pa */
 		if (press > 45000 && press < 120000 && temp > -4000 && temp < 8500) {
 			ctx->evtBaro.timestamp = now;
-			ctx->evtBaro.baro.pressure = press;
+			ctx->evtBaro.baro.pressure = press * 100;
 			ctx->evtBaro.baro.temp = (temp + 27315 + 50) / 100;
 
 			sensors_publish(info->id, &ctx->evtBaro);

--- a/sensors/client-include/libsensors/client.h
+++ b/sensors/client-include/libsensors/client.h
@@ -51,7 +51,7 @@ typedef struct {
 
 typedef struct {
 	uint32_t devId;
-	uint32_t pressure; /* pressure in [Pa] */
+	uint32_t pressure; /* pressure in [cPa] */
 	uint32_t temp;     /* temperature value in Kelvin [K] */
 } baro_data_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR changes units of barometric pressure in libsensors API from pascals to centipascals for finer granularity of readings.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
