### PR TITLE
adc: add explicit cast when printing _PAGE_SIZE

### DIFF
--- a/adc/ad7779/imx6ull/dma.c
+++ b/adc/ad7779/imx6ull/dma.c
@@ -80,7 +80,7 @@ static int sdma_init(size_t size, size_t count, addr_t *phys_addr)
 	addr_t bd_phys_addr;
 
 	if ((size % _PAGE_SIZE) != 0) {
-		log_error("buffer size is not aligned to %lu", _PAGE_SIZE);
+		log_error("buffer size is not aligned to %zu", (size_t)_PAGE_SIZE);
 		return -1;
 	}
 

--- a/adc/ade9113/dma.c
+++ b/adc/ade9113/dma.c
@@ -263,7 +263,7 @@ static void sdmaConfigure(struct sdmaCtx *ctx)
 static int sdmaInit(struct sdmaCtx *const ctx, size_t size, size_t count, const char *rxChannel, const char *txChannel)
 {
 	if ((size % _PAGE_SIZE) != 0) {
-		log_error("buffer size is not aligned to %d", _PAGE_SIZE);
+		log_error("buffer size is not aligned to %zu", (size_t)_PAGE_SIZE);
 		return -1;
 	}
 


### PR DESCRIPTION
Without this ADE9113 fails to compile due to changes in kernel headers https://github.com/phoenix-rtos/phoenix-rtos-kernel/commit/11a35ff39c1723c399de70037cd06f40d46f251c. AD7779 was fixed to work with current kernel - this slightly improves previous fix.

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
