### PR TITLE
tty/uart16550: fix race condition when setting baud rate

### DIFF
--- a/tty/uart16550/uart16550.c
+++ b/tty/uart16550/uart16550.c
@@ -92,6 +92,11 @@ typedef struct {
 	handle_t intcond;
 	handle_t inth;
 
+	handle_t lcrCond;
+	handle_t lcrMutex;
+	atomic_uint_fast8_t lastestLcr;
+	atomic_uint_fast16_t baudChange; /* This also needs to be changed under lcrMutex */
+
 	oid_t oid;
 	libtty_common_t tty;
 
@@ -127,7 +132,6 @@ static uart_t *uart_get(oid_t *oid)
 
 static void set_baudrate(void *_uart, int baud_rate)
 {
-	uint8_t reg;
 	uart_t *uart = (uart_t *)_uart;
 
 	if (baud_rate <= 0) {
@@ -135,27 +139,25 @@ static void set_baudrate(void *_uart, int baud_rate)
 	}
 
 	/* Baud divisor */
-	baud_rate = uart->hwInfo.fclk / (16 * baud_rate);
+	uint32_t newBaud = uart->hwInfo.fclk / (16 * baud_rate);
 
-	if (baud_rate > UINT16_MAX) {
+	if ((newBaud > UINT16_MAX) || (newBaud == 0)) {
 		return;
 	}
 
-	reg = uarthw_read(uart->hwctx, REG_LCR);
-
-	/* Set baud rate */
-	uarthw_write(uart->hwctx, REG_LCR, reg | LCR_DLAB);
-	uarthw_write(uart->hwctx, REG_LSB, (uint8_t)((unsigned)baud_rate));
-	uarthw_write(uart->hwctx, REG_MSB, (uint8_t)((unsigned)baud_rate >> 8));
-	uarthw_write(uart->hwctx, REG_LCR, reg & ~LCR_DLAB);
+	mutexLock(uart->lcrMutex);
+	atomic_store(&uart->baudChange, (uint16_t)newBaud);
+	condSignal(uart->intcond);
+	condWait(uart->lcrCond, uart->lcrMutex, 0);
+	mutexUnlock(uart->lcrMutex);
 }
 
 
 static void set_cflag(void *_uart, tcflag_t *cflag)
 {
 	uart_t *uart = (uart_t *)_uart;
-	uint8_t lcr = uarthw_read(uart->hwctx, REG_LCR);
-
+	mutexLock(uart->lcrMutex);
+	uint8_t lcr = atomic_load(&uart->lastestLcr);
 	lcr &= ~((3 << 0) | (1 << 2) | (1 << 3) | (1 << 4));
 
 	/* Character length */
@@ -173,7 +175,15 @@ static void set_cflag(void *_uart, tcflag_t *cflag)
 	/* Stop bits */
 	lcr |= ((*cflag & CSTOPB) != 0) << 2;
 
-	uarthw_write(uart->hwctx, REG_LCR, lcr);
+
+	uint8_t oldLcr = atomic_exchange(&uart->lastestLcr, lcr);
+	/* If old value is the same as new, handler thread won't know that change was requested and won't signal lcrCond */
+	if (oldLcr != lcr) {
+		condSignal(uart->intcond);
+		condWait(uart->lcrCond, uart->lcrMutex, 0);
+	}
+
+	mutexUnlock(uart->lcrMutex);
 }
 
 
@@ -280,10 +290,41 @@ static bool uart_handleTx(uart_t *uart)
 }
 
 
+/*
+ * Handle requests to change baud rate and transmission format.
+ * Due to peculiarities of 16550 UART changes to LCR need to be done when no other thread (incl. ISR)
+ * tries to access RHR, THR or IMR.
+ * For performance in typical use case (very rare changes) atomic variables are used to communicate changes
+ * so that no syscalls need to be performed.
+ */
+static void uart_handleLcr(uart_t *uart, uint8_t *currentLcr)
+{
+	if ((atomic_load(&uart->baudChange) == 0) && (*currentLcr == atomic_load(&uart->lastestLcr))) {
+		/* No change requested */
+		return;
+	}
+
+	/* We must take this mutex to ensure all threads that requested changes are now waiting on lcrCond */
+	mutexLock(uart->lcrMutex);
+	*currentLcr = atomic_load(&uart->lastestLcr);
+	uint16_t baudChange = atomic_exchange(&uart->baudChange, 0);
+	if (baudChange != 0) {
+		uarthw_write(uart->hwctx, REG_LCR, *currentLcr | LCR_DLAB);
+		uarthw_write(uart->hwctx, REG_LSB, baudChange & 0xff);
+		uarthw_write(uart->hwctx, REG_MSB, (baudChange >> 8) & 0xff);
+	}
+
+	uarthw_write(uart->hwctx, REG_LCR, *currentLcr);
+	condBroadcast(uart->lcrCond);
+	mutexUnlock(uart->lcrMutex);
+}
+
+
 static void uart_intthr(void *arg)
 {
 	uart_t *uart = (uart_t *)arg;
 	uint8_t target_imr = IMR_DR | IMR_LS;
+	uint8_t currentLcr = uarthw_read(uart->hwctx, REG_LCR);
 
 	mutexLock(uart->mutex);
 	for (;;) {
@@ -292,6 +333,7 @@ static void uart_intthr(void *arg)
 		condWait(uart->intcond, uart->mutex, 0);
 		/* For the following part the interrupt needs to be masked */
 		uarthw_write(uart->hwctx, REG_IMR, 0);
+		uart_handleLcr(uart, &currentLcr);
 
 		if (!lf_fifo_empty(&uart->rxSwFifo) || (uart_readUpdateLineStatus(uart) & LSR_DR) != 0) {
 			int wake = 0, wakeHelper = 0;
@@ -535,10 +577,28 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed, int8
 		return err;
 	}
 
+	err = condCreate(&uart->lcrCond);
+	if (err < 0) {
+		resourceDestroy(uart->mutex);
+		resourceDestroy(uart->intcond);
+		libtty_destroy(&uart->tty);
+		return err;
+	}
+
+	err = mutexCreate(&uart->lcrMutex);
+	if (err < 0) {
+		resourceDestroy(uart->lcrCond);
+		resourceDestroy(uart->mutex);
+		resourceDestroy(uart->intcond);
+		libtty_destroy(&uart->tty);
+		return err;
+	}
+
 	/* Set speed (MOD) */
 	uarthw_write(uart->hwctx, REG_LCR, LCR_DLAB);
 	uarthw_write(uart->hwctx, REG_LSB, divisor);
 	uarthw_write(uart->hwctx, REG_MSB, divisor >> 8);
+	atomic_store(&uart->baudChange, 0);
 
 	/* Set data format, leave DLAB on because some 16750 implementations require it to enable extended FIFO settings */
 	uarthw_write(uart->hwctx, REG_LCR, LCR_DLAB | LCR_D8N1);
@@ -556,6 +616,7 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed, int8
 
 	/* Set LCR to its final value */
 	uarthw_write(uart->hwctx, REG_LCR, LCR_D8N1);
+	atomic_store(&uart->lastestLcr, LCR_D8N1);
 
 	/* Enable hardware interrupts */
 	uarthw_write(uart->hwctx, REG_MCR, MCR_OUT2);
@@ -566,6 +627,8 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed, int8
 	err = interrupt(uarthw_irq(uart->hwctx), uart_interrupt, uart, uart->intcond, &uart->inth);
 	if (err < 0) {
 		uarthw_write(uart->hwctx, REG_MCR, 0);
+		resourceDestroy(uart->lcrMutex);
+		resourceDestroy(uart->lcrCond);
 		resourceDestroy(uart->mutex);
 		resourceDestroy(uart->intcond);
 		libtty_destroy(&uart->tty);
@@ -576,6 +639,8 @@ static int _uart_init(uart_t *uart, unsigned int uartn, unsigned int speed, int8
 	if (err < 0) {
 		resourceDestroy(uart->inth);
 		uarthw_write(uart->hwctx, REG_MCR, 0);
+		resourceDestroy(uart->lcrMutex);
+		resourceDestroy(uart->lcrCond);
 		resourceDestroy(uart->mutex);
 		resourceDestroy(uart->intcond);
 		libtty_destroy(&uart->tty);


### PR DESCRIPTION
## Description
This PR fixes a possible data race when setting the UART's baud rate.

Previous implementation of `set_baudrate` directly manipulated `LCR_DLAB` to enable writing of baud rate divider. However, doing so changes the function of `RBR`, `THR` and `IER` registers. Said registers are accessed within ISR and `uart_intthr`, while `set_baudrate` callback runs from `poolthr`. The changing of these registers was not synchronized in any way with other threads, which could lead to unintended consequences (setting incorrect baud rate, RX/TX data loss, deadlock waiting for interrupt).

In this implementation `libtty` callbacks store requested changes in memory as atomic variables, signal `uart_intthr` then wait on a conditional for the change to be performed. Changes to `LCR` are done within `uart_intthr` while UART interrupts are masked - this ensures no invalid states can occur. Changes in data format (also controlled by `LCR`) are handled similarly to changes in baud rate.

Thanks to the use of atomic variables no syscalls are necessary within `uart_intthr` unless a change is requested. The loop within `uart_intthr` iterates frequently (every ~8 bytes by default) - so for performance it is crucial to reduce the number of syscalls to minimum. We assume changes to baud rate will occur very infrequently, so in that case using mutexes and conditionals is acceptable.

Multiple threads can request changes at once - this is not an intended use case, but the driver must handle such situations without deadlocks or other bugs. When `uart_intthr` detects that changes have been requested it takes `lcrMutex` to ensure that all threads requesting changes are either waiting on the `lcrMutex` (haven't changed atomic variables yet) or on `lcrCond` (have changed variables and will be woken up by `condBroadcast`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

YT: RTOS-1412

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu, aarch64a53-zynqmp-som

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
