### PR TITLE
stm32l4-multi/pwm_n6: auto detect faster rx bit lengths

### DIFF
--- a/multi/stm32l4-multi/pwm_n6.c
+++ b/multi/stm32l4-multi/pwm_n6.c
@@ -328,6 +328,49 @@ static int dshot_decodeRxData(uint16_t bitlen, const uint16_t *counts, size_t nC
 		return -EILSEQ;
 	}
 
+	/* find minimum and maximum pulse widths */
+	uint32_t minDiff = 0xffffffffUL;
+	uint32_t maxDiff = 0;
+	for (size_t i = 1; i < nCounts; i++) {
+		if (counts[i] <= counts[i - 1]) {
+			continue;
+		}
+
+		uint32_t diff = counts[i] - counts[i - 1];
+
+		/* filter out unreasonable diffs */
+		if (diff > (bitlen / 2) && diff < (bitlen * 6)) {
+			if (diff < minDiff) {
+				minDiff = diff;
+			}
+			if (diff > maxDiff) {
+				maxDiff = diff;
+			}
+		}
+	}
+
+	/* adjust bitlen based on observed timings */
+	if (minDiff < maxDiff) {
+		/*
+		 * 3 scenarios:
+		 * - min = 1 bit, max = 3 bits (ratio = 3.0)
+		 * - min = 1 bit, max = 2 bits (ratio = 2.0)
+		 * - min = 2 bits, max = 3 bits (ratio = 1.5)
+		 * for first and second scenario, min gives us the bit length
+		 * for the third scenario min is two bit lengths
+		 */
+		if ((maxDiff * 100) > (minDiff * 175)) {
+			bitlen = minDiff; /* (min=1, max=3) or (min=1, max=2) */
+		}
+		else {
+			bitlen = minDiff / 2; /* (min=2, max=3) */
+		}
+	}
+
+	if (bitlen == 0) {
+		return -EILSEQ;
+	}
+
 	uint32_t val = 1; /* Signal always starts in high state, so starting value is 1 */
 	size_t totalBits = 0;
 	for (size_t i = 1; i <= nCounts; i++) {


### PR DESCRIPTION
TASK: PP-626

<!--- Provide a general summary of your changes in the Title above -->

## Description
AM32 ESCs were empirically found to transmit telemetry faster than they should. This change implements a basic attempt at automatically detecting these shorter bit lengths at runtime.
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
